### PR TITLE
chore: improve error message on code generation

### DIFF
--- a/generate.go
+++ b/generate.go
@@ -71,7 +71,7 @@ func Generate(basedir string) error {
 		// Not the most optimized way (re-parsing), we can improve later
 		tfcode, err := generateStackConfig(basedir, stack.Dir)
 		if err != nil {
-			errs = append(errs, err)
+			errs = append(errs, fmt.Errorf("stack %q: %w", stack.Dir, err))
 			continue
 		}
 
@@ -84,7 +84,7 @@ func Generate(basedir string) error {
 	}
 
 	if err := errutil.Chain(errs...); err != nil {
-		return fmt.Errorf("Generate(%q): %w", basedir, err)
+		return fmt.Errorf("failed to generate code: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
Now the error looks like this:

```
terramate generate
2021/12/13 19:26:59 failed to generate code: stack "/tmp/lala/stack": parsing config: HCL syntax error: /tmp/lala/stack/terramate.tm.hcl:3,3-7: Argument or block definition required; An argument or block definition is required here. To set an argument, use the equals sign "=" to introduce the argument value.
```

It has stack info/less internal info.