### PR TITLE
docs: add install improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,10 +50,17 @@ go install github.com/mineiros-io/terramate/cmd/terramate@<version>
 ```
 
 Where **<version>** is any terramate [version tag](https://github.com/mineiros-io/terramate/tags),
-or you can just install the **latest** using go install:
+or you can just install the **latest** release:
 
 ```
 go install github.com/mineiros-io/terramate/cmd/terramate@latest
+```
+
+To install the latest code on main:
+
+```
+export GOPROXY=direct
+go install github.com/mineiros-io/terramate/cmd/terramate@main
 ```
 
 Or if you have the project cloned locally just run:
@@ -63,7 +70,7 @@ make install
 ```
 
 We put great effort into keeping the main branch stable, so it should be safe
-to use **latest** to play around, but not recommended for long term automation
+to use **main** to play around, but not recommended for long term automation
 since you won't get the same build result each time you run the install command.
 
 


### PR DESCRIPTION
When installing things from @main it seems that Go proxy introduces some caching/staleness, we were not able to get the latest code until we disabled it (me and @mariux ). It didn't seem to be a caching issue, I cleaned the cache with `go clean` and also deleted all local versions of the packages, it was still downloading an old version of the package from the proxy server.