### PR TITLE
fix: dont fail stack list if terramate block is absent

### DIFF
--- a/metadata_test.go
+++ b/metadata_test.go
@@ -36,6 +36,8 @@ func TestLoadMetadata(t *testing.T) {
 		wantErr error
 	}
 
+	const invalidHCL = "block {"
+
 	tcases := []testcase{
 		{
 			name:   "no stacks",
@@ -113,17 +115,17 @@ func TestLoadMetadata(t *testing.T) {
 		{
 			name: "single invalid stack",
 			layout: []string{
-				fmt.Sprintf("f:invalid-stack/%s:data=notvalidhcl", config.Filename),
+				fmt.Sprintf("f:invalid-stack/%s:data=%s", config.Filename, invalidHCL),
 			},
-			wantErr: hcl.ErrNoTerramateBlock,
+			wantErr: hcl.ErrHCLSyntax,
 		},
 		{
 			name: "valid stack with invalid stack",
 			layout: []string{
 				"s:stack-valid-1",
-				fmt.Sprintf("f:invalid-stack/%s:data=notvalidhcl", config.Filename),
+				fmt.Sprintf("f:invalid-stack/%s:data=%s", config.Filename, invalidHCL),
 			},
-			wantErr: hcl.ErrNoTerramateBlock,
+			wantErr: hcl.ErrHCLSyntax,
 		},
 	}
 

--- a/stack/loader.go
+++ b/stack/loader.go
@@ -15,6 +15,7 @@
 package stack
 
 import (
+	"errors"
 	"fmt"
 	"io/fs"
 	"os"
@@ -88,6 +89,12 @@ func (l Loader) TryLoad(dir string) (stack S, found bool, err error) {
 	}
 	fname := filepath.Join(dir, config.Filename)
 	cfg, err := hcl.ParseFile(fname)
+
+	if errors.Is(err, hcl.ErrNoTerramateBlock) {
+		// Config blocks may have only globals, no terramate
+		return S{}, false, nil
+	}
+
 	if err != nil {
 		return S{}, false, err
 	}


### PR DESCRIPTION
This causes some issues as discussed here: https://mineirosio.slack.com/archives/C02GFAAAKPT/p1640026231072900

Also is breaking global config testing since we can have a terramate HCL file with just globals inside (no terramate block) and that should work.