### PR TITLE
feat: make terramate blocks optional on stacks

### DIFF
--- a/cmd/terramate/cli/cli_list_test.go
+++ b/cmd/terramate/cli/cli_list_test.go
@@ -18,6 +18,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/mineiros-io/terramate/hcl"
 	"github.com/mineiros-io/terramate/test"
 	"github.com/mineiros-io/terramate/test/sandbox"
 )
@@ -103,6 +104,17 @@ z/a
 			assertRunResult(t, cli.run("list"), tc.want)
 		})
 	}
+}
+
+func TestListStackWithNoTerramateBlock(t *testing.T) {
+	s := sandbox.New(t)
+	s.BuildTree([]string{"s:stack"})
+	stack := s.StackEntry("stack")
+	stack.WriteConfig(hcl.Config{
+		Stack: &hcl.Stack{},
+	})
+	cli := newCLI(t, s.RootDir())
+	assertRunResult(t, cli.run("list"), runResult{Stdout: "stack\n"})
 }
 
 func TestListNoSuchFile(t *testing.T) {

--- a/config/config.go
+++ b/config/config.go
@@ -15,7 +15,6 @@
 package config
 
 import (
-	"errors"
 	"os"
 	"path/filepath"
 
@@ -62,13 +61,10 @@ func TryLoadRootConfig(dir string) (cfg hcl.Config, found bool, err error) {
 
 	cfg, err = hcl.ParseFile(path)
 	if err != nil {
-		if errors.Is(err, hcl.ErrNoTerramateBlock) {
-			return hcl.Config{}, false, nil
-		}
 		return hcl.Config{}, false, err
 	}
 
-	if cfg.Terramate.RootConfig != nil {
+	if cfg.Terramate != nil && cfg.Terramate.RootConfig != nil {
 		return cfg, true, nil
 	}
 	return hcl.Config{}, false, nil

--- a/generate.go
+++ b/generate.go
@@ -15,7 +15,6 @@
 package terramate
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -160,14 +159,11 @@ func generateStackConfig(root string, configdir string, evalctx *tfhcl.EvalConte
 
 	parsedConfig, err := hcl.Parse(configfile, config)
 	if err != nil {
-		if errors.Is(err, hcl.ErrNoTerramateBlock) {
-			return generateStackConfig(root, filepath.Dir(configdir), evalctx)
-		}
 		return nil, fmt.Errorf("parsing config: %w", err)
 	}
 
 	parsed := parsedConfig.Terramate
-	if parsed.Backend == nil {
+	if parsed == nil || parsed.Backend == nil {
 		return generateStackConfig(root, filepath.Dir(configdir), evalctx)
 	}
 

--- a/hcl/hcl_test.go
+++ b/hcl/hcl_test.go
@@ -204,7 +204,7 @@ terramate {}`,
 		{
 			name: "empty config",
 			want: want{
-				err: hcl.ErrNoTerramateBlock,
+				config: hcl.Config{},
 			},
 		},
 		{

--- a/stack/loader.go
+++ b/stack/loader.go
@@ -15,7 +15,6 @@
 package stack
 
 import (
-	"errors"
 	"fmt"
 	"io/fs"
 	"os"
@@ -90,11 +89,6 @@ func (l Loader) TryLoad(dir string) (stack S, found bool, err error) {
 	}
 	fname := filepath.Join(dir, config.Filename)
 	cfg, err := hcl.ParseFile(fname)
-
-	if errors.Is(err, hcl.ErrNoTerramateBlock) {
-		// Config blocks may have only globals, no terramate
-		return S{}, false, nil
-	}
 
 	if err != nil {
 		return S{}, false, err


### PR DESCRIPTION
Now terramate{} is no longer required on stacks for them to be detected as stacks, only "stack{}".