### PR TITLE
feat: terramate stacks globals

### DIFF
--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -83,6 +83,11 @@ type cliSpec struct {
 		} `cmd:"" help:"show the topological ordering of the stacks"`
 	} `cmd:"" help:"plan execution."`
 
+	Stacks struct {
+		Globals struct {
+		} `cmd:"" help:"list globals for all stacks."`
+	} `cmd:"" help:"stack related commands."`
+
 	Generate struct{} `cmd:"" help:"Generate terraform code for stacks."`
 	Metadata struct{} `cmd:"" help:"shows metadata available on the project"`
 
@@ -224,7 +229,7 @@ func newCLI(
 	}
 
 	if parsedArgs.Changed && !prj.isRepo {
-		return nil, fmt.Errorf("flag --changed provided but no git repository found.")
+		return nil, fmt.Errorf("flag --changed provided but no git repository found")
 	}
 
 	return &cli{
@@ -270,6 +275,8 @@ func (c *cli) run() error {
 		return c.generateGraph()
 	case "plan run-order":
 		return c.printRunOrder()
+	case "stacks globals":
+		return c.printStacksGlobals()
 	case "run":
 		if len(c.parsedArgs.Run.Command) == 0 {
 			return errors.New("no command specified")
@@ -446,6 +453,10 @@ func (c *cli) printRunOrder() error {
 		c.log("%s", s)
 	}
 
+	return nil
+}
+
+func (c *cli) printStacksGlobals() error {
 	return nil
 }
 

--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -457,6 +457,25 @@ func (c *cli) printRunOrder() error {
 }
 
 func (c *cli) printStacksGlobals() error {
+	metadata, err := terramate.LoadMetadata(c.root())
+	if err != nil {
+		return err
+	}
+
+	for _, stackMetadata := range metadata.Stacks {
+		globals, err := terramate.LoadStackGlobals(c.root(), stackMetadata)
+		if err != nil {
+			return err
+		}
+		globalsStrRepr := globals.String()
+		if globalsStrRepr == "" {
+			continue
+		}
+		c.log("\nstack %q:", stackMetadata.Path)
+		for _, global := range strings.Split(globalsStrRepr, "\n") {
+			c.log("\t%s", global)
+		}
+	}
 	return nil
 }
 

--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -472,8 +472,8 @@ func (c *cli) printStacksGlobals() error {
 			continue
 		}
 		c.log("\nstack %q:", stackMetadata.Path)
-		for _, global := range strings.Split(globalsStrRepr, "\n") {
-			c.log("\t%s", global)
+		for _, line := range strings.Split(globalsStrRepr, "\n") {
+			c.log("\t%s", line)
 		}
 	}
 	return nil

--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -459,18 +459,24 @@ func (c *cli) printRunOrder() error {
 func (c *cli) printStacksGlobals() error {
 	metadata, err := terramate.LoadMetadata(c.root())
 	if err != nil {
-		return err
+		return fmt.Errorf("listing stacks globals: loading stacks metadata: %v", err)
 	}
 
 	for _, stackMetadata := range metadata.Stacks {
 		globals, err := terramate.LoadStackGlobals(c.root(), stackMetadata)
 		if err != nil {
-			return err
+			return fmt.Errorf(
+				"listing stacks globals: loading stack %q globals: %v",
+				stackMetadata.Path,
+				err,
+			)
 		}
+
 		globalsStrRepr := globals.String()
 		if globalsStrRepr == "" {
 			continue
 		}
+
 		c.log("\nstack %q:", stackMetadata.Path)
 		for _, line := range strings.Split(globalsStrRepr, "\n") {
 			c.log("\t%s", line)

--- a/cmd/terramate/cli/stacks_globals_test.go
+++ b/cmd/terramate/cli/stacks_globals_test.go
@@ -31,11 +31,10 @@ func TestStacksGlobals(t *testing.T) {
 			add  *hclwrite.Block
 		}
 		testcase struct {
-			name       string
-			layout     []string
-			workingDir string
-			globals    []globalsBlock
-			want       runResult
+			name    string
+			layout  []string
+			globals []globalsBlock
+			want    runResult
 		}
 	)
 

--- a/cmd/terramate/cli/stacks_globals_test.go
+++ b/cmd/terramate/cli/stacks_globals_test.go
@@ -77,9 +77,9 @@ func TestStacksGlobals(t *testing.T) {
 			want: runResult{
 				Stdout: `
 stack "/stack":
-	global.bool   = true
-	global.number = 777
-	global.str    = "string"
+	bool   = true
+	number = 777
+	str    = "string"
 `,
 			},
 		},

--- a/cmd/terramate/cli/stacks_globals_test.go
+++ b/cmd/terramate/cli/stacks_globals_test.go
@@ -83,6 +83,51 @@ stack "/stack":
 `,
 			},
 		},
+		{
+			name: "two stacks only one has globals",
+			layout: []string{
+				"s:stacks/stack-1",
+				"s:stacks/stack-2",
+			},
+			globals: []globalsBlock{
+				{
+					path: "/stacks/stack-1",
+					add: globals(
+						str("str", "string"),
+					),
+				},
+			},
+			want: runResult{
+				Stdout: `
+stack "/stacks/stack-1":
+	str = "string"
+`,
+			},
+		},
+		{
+			name: "two stacks with same globals",
+			layout: []string{
+				"s:stacks/stack-1",
+				"s:stacks/stack-2",
+			},
+			globals: []globalsBlock{
+				{
+					path: "/stacks",
+					add: globals(
+						str("str", "string"),
+					),
+				},
+			},
+			want: runResult{
+				Stdout: `
+stack "/stacks/stack-1":
+	str = "string"
+
+stack "/stacks/stack-2":
+	str = "string"
+`,
+			},
+		},
 	}
 
 	for _, tcase := range tcases {

--- a/cmd/terramate/cli/stacks_globals_test.go
+++ b/cmd/terramate/cli/stacks_globals_test.go
@@ -25,13 +25,12 @@ func TestStacksGlobals(t *testing.T) {
 		}
 	)
 
-	//globals := func(builders ...hclwrite.BlockBuilder) *hclwrite.Block {
-	//return hclwrite.NewBuilder("globals", builders...)
-	//}
-	//expr := hclwrite.Expression
-	//str := hclwrite.String
-	//number := hclwrite.NumberInt
-	//boolean := hclwrite.Boolean
+	globals := func(builders ...hclwrite.BlockBuilder) *hclwrite.Block {
+		return hclwrite.NewBuilder("globals", builders...)
+	}
+	str := hclwrite.String
+	number := hclwrite.NumberInt
+	boolean := hclwrite.Boolean
 
 	tcases := []testcase{
 		{
@@ -47,6 +46,27 @@ func TestStacksGlobals(t *testing.T) {
 			layout: []string{
 				"s:stacks/stack-1",
 				"s:stacks/stack-2",
+			},
+		},
+		{
+			name:   "single stack with a global",
+			layout: []string{"s:stack"},
+			globals: []globalsBlock{
+				{
+					path: "/stack",
+					add: globals(
+						str("str", "string"),
+						number("number", 777),
+						boolean("bool", true),
+					),
+				},
+			},
+			want: runResult{
+				Stdout: `stack "/stack":
+	global.str="string"
+	global.number=777
+	global.bool=true
+`,
 			},
 		},
 	}

--- a/cmd/terramate/cli/stacks_globals_test.go
+++ b/cmd/terramate/cli/stacks_globals_test.go
@@ -1,3 +1,17 @@
+// Copyright 2021 Mineiros GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package cli_test
 
 import (
@@ -62,25 +76,28 @@ func TestStacksGlobals(t *testing.T) {
 				},
 			},
 			want: runResult{
-				Stdout: `stack "/stack":
-	global.str="string"
-	global.number=777
-	global.bool=true
+				Stdout: `
+stack "/stack":
+	global.str    = "string"
+	global.number = 777
+	global.bool   = true
 `,
 			},
 		},
 	}
 
 	for _, tcase := range tcases {
-		s := sandbox.New(t)
-		s.BuildTree(tcase.layout)
+		t.Run(tcase.name, func(t *testing.T) {
+			s := sandbox.New(t)
+			s.BuildTree(tcase.layout)
 
-		for _, globalBlock := range tcase.globals {
-			path := filepath.Join(s.RootDir(), globalBlock.path)
-			test.AppendFile(t, path, config.Filename, globalBlock.add.String())
-		}
+			for _, globalBlock := range tcase.globals {
+				path := filepath.Join(s.RootDir(), globalBlock.path)
+				test.AppendFile(t, path, config.Filename, globalBlock.add.String())
+			}
 
-		ts := newCLI(t, s.RootDir())
-		assertRunResult(t, ts.run("stacks", "globals"), tcase.want)
+			ts := newCLI(t, s.RootDir())
+			assertRunResult(t, ts.run("stacks", "globals"), tcase.want)
+		})
 	}
 }

--- a/cmd/terramate/cli/stacks_globals_test.go
+++ b/cmd/terramate/cli/stacks_globals_test.go
@@ -78,9 +78,9 @@ func TestStacksGlobals(t *testing.T) {
 			want: runResult{
 				Stdout: `
 stack "/stack":
-	global.str    = "string"
-	global.number = 777
 	global.bool   = true
+	global.number = 777
+	global.str    = "string"
 `,
 			},
 		},

--- a/generate/generate.go
+++ b/generate/generate.go
@@ -65,6 +65,8 @@ func Do(root string) error {
 		return fmt.Errorf("project's root %q is not a directory", root)
 	}
 
+	// FIXME(katcipis): we are listing stacks twice here
+	// terramate.LoadMetadata already lists stacks, so we can improve this for sure.
 	stackEntries, err := terramate.ListStacks(root)
 	if err != nil {
 		return fmt.Errorf("listing stack: %w", err)

--- a/globals.go
+++ b/globals.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/madlambda/spells/errutil"
@@ -59,6 +60,18 @@ func LoadStackGlobals(rootdir string, meta StackMetadata) (*Globals, error) {
 // is the attribute name with its corresponding value mapped
 func (g *Globals) Attributes() map[string]cty.Value {
 	return g.attributes
+}
+
+// String provides a string representation of the globals
+func (g *Globals) String() string {
+	if len(g.Attributes()) == 0 {
+		return ""
+	}
+	attrs := strings.Split(hcl.FormatAttributes(g.Attributes()), "\n")
+	for i, attr := range attrs {
+		attrs[i] = "global." + attr
+	}
+	return strings.Join(attrs, "\n")
 }
 
 // SetOnEvalCtx will add the proper namespace for evaluation of globals

--- a/globals.go
+++ b/globals.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/madlambda/spells/errutil"
@@ -64,14 +63,7 @@ func (g *Globals) Attributes() map[string]cty.Value {
 
 // String provides a string representation of the globals
 func (g *Globals) String() string {
-	if len(g.Attributes()) == 0 {
-		return ""
-	}
-	attrs := strings.Split(hcl.FormatAttributes(g.Attributes()), "\n")
-	for i, attr := range attrs {
-		attrs[i] = "global." + attr
-	}
-	return strings.Join(attrs, "\n")
+	return hcl.FormatAttributes(g.Attributes())
 }
 
 // SetOnEvalCtx will add the proper namespace for evaluation of globals

--- a/hcl/formatter.go
+++ b/hcl/formatter.go
@@ -15,6 +15,7 @@
 package hcl
 
 import (
+	"sort"
 	"strings"
 
 	"github.com/hashicorp/hcl/v2/hclwrite"
@@ -23,12 +24,25 @@ import (
 
 // FormatAttributes will format a given attribute map to a string.
 // Name of the attributes are the keys and the corresponding value is mapped.
+// The formatted output will always be lexicographically sorted by the attribute name,
+// so calling this function with the same map multiple times produces the same result.
 func FormatAttributes(attrs map[string]cty.Value) string {
+	if len(attrs) == 0 {
+		return ""
+	}
+
 	f := hclwrite.NewEmptyFile()
 	body := f.Body()
+	sortedAttrNames := make([]string, 0, len(attrs))
 
-	for name, value := range attrs {
-		body.SetAttributeValue(name, value)
+	for name := range attrs {
+		sortedAttrNames = append(sortedAttrNames, name)
+	}
+
+	sort.Strings(sortedAttrNames)
+
+	for _, name := range sortedAttrNames {
+		body.SetAttributeValue(name, attrs[name])
 	}
 
 	return strings.Trim(string(f.Bytes()), "\n")

--- a/hcl/formatter.go
+++ b/hcl/formatter.go
@@ -1,0 +1,35 @@
+// Copyright 2021 Mineiros GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hcl
+
+import (
+	"strings"
+
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/zclconf/go-cty/cty"
+)
+
+// FormatAttributes will format a given attribute map to a string.
+// Name of the attributes are the keys and the corresponding value is mapped.
+func FormatAttributes(attrs map[string]cty.Value) string {
+	f := hclwrite.NewEmptyFile()
+	body := f.Body()
+
+	for name, value := range attrs {
+		body.SetAttributeValue(name, value)
+	}
+
+	return strings.Trim(string(f.Bytes()), "\n")
+}

--- a/hcl/formatter_test.go
+++ b/hcl/formatter_test.go
@@ -1,0 +1,65 @@
+// Copyright 2021 Mineiros GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hcl_test
+
+import (
+	"testing"
+
+	"github.com/madlambda/spells/assert"
+	"github.com/mineiros-io/terramate/hcl"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func TestFormatAttributes(t *testing.T) {
+	type testcase struct {
+		name       string
+		attributes map[string]cty.Value
+		want       string
+	}
+
+	tcases := []testcase{
+		{
+			name:       "format empty attributes",
+			attributes: map[string]cty.Value{},
+		},
+		{
+			name:       "format nil attributes",
+			attributes: nil,
+		},
+		{
+			name: "format single str attribute",
+			attributes: map[string]cty.Value{
+				"str": cty.StringVal("value"),
+			},
+			want: "str = \"value\"",
+		},
+		{
+			name: "format multiple attributes",
+			attributes: map[string]cty.Value{
+				"str":  cty.StringVal("value"),
+				"num":  cty.NumberIntVal(666),
+				"bool": cty.BoolVal(true),
+			},
+			want: "str  = \"value\"\nnum  = 666\nbool = true",
+		},
+	}
+
+	for _, tcase := range tcases {
+		t.Run(tcase.name, func(t *testing.T) {
+			got := hcl.FormatAttributes(tcase.attributes)
+			assert.EqualStrings(t, tcase.want, got)
+		})
+	}
+}

--- a/hcl/formatter_test.go
+++ b/hcl/formatter_test.go
@@ -54,6 +54,19 @@ func TestFormatAttributes(t *testing.T) {
 			},
 			want: "bool = true\nnum  = 666\nstr  = \"value\"",
 		},
+		{
+			name: "format map attribute",
+			attributes: map[string]cty.Value{
+				"map": cty.MapVal(map[string]cty.Value{
+					"key1": cty.StringVal("value1"),
+					"key2": cty.StringVal("value2"),
+				}),
+			},
+			want: `map = {
+  key1 = "value1"
+  key2 = "value2"
+}`,
+		},
 	}
 
 	for _, tcase := range tcases {

--- a/hcl/formatter_test.go
+++ b/hcl/formatter_test.go
@@ -52,7 +52,7 @@ func TestFormatAttributes(t *testing.T) {
 				"num":  cty.NumberIntVal(666),
 				"bool": cty.BoolVal(true),
 			},
-			want: "str  = \"value\"\nnum  = 666\nbool = true",
+			want: "bool = true\nnum  = 666\nstr  = \"value\"",
 		},
 	}
 

--- a/hcl/formatter_test.go
+++ b/hcl/formatter_test.go
@@ -67,6 +67,19 @@ func TestFormatAttributes(t *testing.T) {
   key2 = "value2"
 }`,
 		},
+		{
+			name: "format object attribute",
+			attributes: map[string]cty.Value{
+				"obj": cty.ObjectVal(map[string]cty.Value{
+					"key1": cty.StringVal("value1"),
+					"key2": cty.StringVal("value2"),
+				}),
+			},
+			want: `obj = {
+  key1 = "value1"
+  key2 = "value2"
+}`,
+		},
 	}
 
 	for _, tcase := range tcases {


### PR DESCRIPTION
Implement the command:

```
terramate stacks globals
```

That will list all globals defined per stack. A quick example:

```sh
#!/bin/bash

set -o errexit
set -o nounset

basedir=$(mktemp -d)

cd "${basedir}"

cat > terramate.tm.hcl <<- EOM
terramate {
  config {
  }
}
EOM

mkdir -p stacks/stack-1
mkdir -p stacks/stack-2

terramate init stacks/stack-1
terramate init stacks/stack-2

echo "terramate list"
echo

terramate list

echo

cat > stacks/terramate.tm.hcl <<- EOM
globals {
  testing = "test value"
  object = {
    name = "hello"
    data = "world"
  }
}
EOM

echo "terramate stacks globals"

terramate stacks globals

echo
```