### PR TITLE
feat: add load of export_as_locals

### DIFF
--- a/export_as_locals.go
+++ b/export_as_locals.go
@@ -27,6 +27,8 @@ import (
 	"github.com/zclconf/go-cty/cty"
 )
 
+const ErrExportAsLocalsRedefined errutil.Error = "export_as_locals attribute redefined"
+
 // ExportAsLocals represents a export_as_locals block.
 type ExportAsLocals struct {
 	attributes map[string]cty.Value
@@ -83,10 +85,14 @@ func loadStackExportAsLocals(rootdir string, cfgdir string) (unEvalExportAsLocal
 
 	for _, block := range blocks {
 		for name, attr := range block.Body.Attributes {
-			// TODO(katcipis): test behavior
-			//if globals.has(name) {
-			//return nil, fmt.Errorf("%w: global %q already defined in configuration %q", ErrGlobalRedefined, name, cfgpath)
-			//}
+			if exportLocals.has(name) {
+				return unEvalExportAsLocals{}, fmt.Errorf(
+					"%w: export_as_locals %q already defined in configuration %q",
+					ErrExportAsLocalsRedefined,
+					name,
+					cfgpath,
+				)
+			}
 			exportLocals.expressions[name] = attr.Expr
 		}
 	}

--- a/export_as_locals.go
+++ b/export_as_locals.go
@@ -43,5 +43,9 @@ func LoadStackExportAsLocals(rootdir string, sm StackMetadata, g *Globals) (Expo
 }
 
 func (e ExportAsLocals) Attributes() map[string]cty.Value {
-	return nil
+	attrcopy := map[string]cty.Value{}
+	for k, v := range e.attributes {
+		attrcopy[k] = v
+	}
+	return attrcopy
 }

--- a/export_as_locals.go
+++ b/export_as_locals.go
@@ -87,7 +87,7 @@ func loadStackExportAsLocals(rootdir string, cfgdir string) (unEvalExportAsLocal
 			//if globals.has(name) {
 			//return nil, fmt.Errorf("%w: global %q already defined in configuration %q", ErrGlobalRedefined, name, cfgpath)
 			//}
-			exportLocals.add(name, attr.Expr)
+			exportLocals.expressions[name] = attr.Expr
 		}
 	}
 
@@ -112,13 +112,9 @@ type unEvalExportAsLocals struct {
 func (r unEvalExportAsLocals) merge(other unEvalExportAsLocals) {
 	for k, v := range other.expressions {
 		if !r.has(k) {
-			r.add(k, v)
+			r.expressions[k] = v
 		}
 	}
-}
-
-func (r unEvalExportAsLocals) add(name string, expr hclsyntax.Expression) {
-	r.expressions[name] = expr
 }
 
 func (r unEvalExportAsLocals) has(name string) bool {

--- a/export_as_locals.go
+++ b/export_as_locals.go
@@ -1,0 +1,47 @@
+// Copyright 2021 Mineiros GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package terramate
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/zclconf/go-cty/cty"
+)
+
+// ExportAsLocals represents a export_as_locals block.
+type ExportAsLocals struct {
+	attributes map[string]cty.Value
+}
+
+// LoadStackGlobals loads from the file system all globals defined for
+// a given stack. It will navigate the file system from the stack dir until
+// it reaches rootdir, loading globals and merging them appropriately.
+//
+// More specific globals (closer or at the stack) have precedence over
+// less specific globals (closer or at the root dir).
+//
+// Metadata for the stack is used on the evaluation of globals, defined on stackmeta.
+// The rootdir MUST be an absolute path.
+func LoadStackExportAsLocals(rootdir string, sm StackMetadata, g *Globals) (ExportAsLocals, error) {
+	if !filepath.IsAbs(rootdir) {
+		return ExportAsLocals{}, fmt.Errorf("%q is not absolute path", rootdir)
+	}
+	return ExportAsLocals{}, nil
+}
+
+func (e ExportAsLocals) Attributes() map[string]cty.Value {
+	return nil
+}

--- a/export_as_locals.go
+++ b/export_as_locals.go
@@ -132,10 +132,9 @@ func (r unEvalExportAsLocals) eval(meta StackMetadata, globals *Globals) (Export
 	// like: /some/path/relative/project/root
 	evalctx := eval.NewContext("." + meta.Path)
 
-	// TODO(katcipis): test behavior
-	//if err := meta.SetOnEvalCtx(evalctx); err != nil {
-	//return nil, fmt.Errorf("evaluating export_as_locals: setting terramate metadata namespace: %v", err)
-	//}
+	if err := meta.SetOnEvalCtx(evalctx); err != nil {
+		return ExportAsLocals{}, fmt.Errorf("evaluating export_as_locals: setting terramate metadata namespace: %v", err)
+	}
 
 	if err := globals.SetOnEvalCtx(evalctx); err != nil {
 		return ExportAsLocals{}, fmt.Errorf("evaluating export_as_locals: setting terramate globals namespace: %v", err)

--- a/export_as_locals.go
+++ b/export_as_locals.go
@@ -29,7 +29,8 @@ import (
 
 const ErrExportAsLocalsRedefined errutil.Error = "export_as_locals attribute redefined"
 
-// ExportAsLocals represents a export_as_locals block.
+// ExportAsLocals represents information obtained by parsing and evaluating
+// export_as_locals blocks.
 type ExportAsLocals struct {
 	attributes map[string]cty.Value
 }

--- a/export_as_locals_test.go
+++ b/export_as_locals_test.go
@@ -1,0 +1,186 @@
+// Copyright 2021 Mineiros GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package terramate_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/madlambda/spells/assert"
+	"github.com/mineiros-io/terramate"
+	"github.com/mineiros-io/terramate/config"
+	"github.com/mineiros-io/terramate/test"
+	"github.com/mineiros-io/terramate/test/hclwrite"
+	"github.com/mineiros-io/terramate/test/sandbox"
+)
+
+func TestExportAsLocals(t *testing.T) {
+	type (
+		block struct {
+			path string
+			add  *hclwrite.Block
+		}
+		testcase struct {
+			name    string
+			layout  []string
+			blocks  []block
+			want    map[string]*hclwrite.Block
+			wantErr bool
+		}
+	)
+
+	// Usually in Go names are cammel case, but on this case
+	// we want it to be as close to original HCL as possible (DSL).
+	export_as_locals := func(builders ...hclwrite.BlockBuilder) *hclwrite.Block {
+		return hclwrite.NewBuilder("globals", builders...)
+	}
+	globals := func(builders ...hclwrite.BlockBuilder) *hclwrite.Block {
+		return hclwrite.NewBuilder("globals", builders...)
+	}
+	expr := hclwrite.Expression
+	str := hclwrite.String
+	number := hclwrite.NumberInt
+	boolean := hclwrite.Boolean
+
+	tcases := []testcase{
+		{
+			name:   "no stacks no exported locals",
+			layout: []string{},
+		},
+		{
+			name:   "single stacks no no exported locals",
+			layout: []string{"s:stack"},
+		},
+		{
+			name: "two stacks no exported locals",
+			layout: []string{
+				"s:stacks/stack-1",
+				"s:stacks/stack-2",
+			},
+		},
+		{
+			name:   "single stack with its own exported locals using own globals",
+			layout: []string{"s:stack"},
+			blocks: []block{
+				{
+					path: "/stack",
+					add: globals(
+						str("some_string", "string"),
+						number("some_number", 777),
+						boolean("some_bool", true),
+					),
+				},
+				{
+					path: "/stack",
+					add: export_as_locals(
+						expr("string_local", "global.some_string"),
+						expr("number_local", "global.some_number"),
+						expr("bool_local", "global.some_bool"),
+					),
+				},
+			},
+			want: map[string]*hclwrite.Block{
+				"/stack": export_as_locals(
+					str("string_local", "string"),
+					number("number_local", 777),
+					boolean("bool_local", true),
+				),
+			},
+		},
+	}
+
+	for _, tcase := range tcases {
+		t.Run(tcase.name, func(t *testing.T) {
+			t.Skip()
+
+			s := sandbox.New(t)
+			s.BuildTree(tcase.layout)
+
+			for _, block := range tcase.blocks {
+				path := filepath.Join(s.RootDir(), block.path)
+				test.AppendFile(t, path, config.Filename, block.add.String())
+			}
+
+			wantExportAsLocals := tcase.want
+
+			metadata := s.LoadMetadata()
+			for _, stackMetadata := range metadata.Stacks {
+
+				globals := s.LoadStackGlobals(stackMetadata)
+				got, err := terramate.LoadStackExportAsLocals(
+					s.RootDir(),
+					stackMetadata,
+					globals,
+				)
+
+				if tcase.wantErr {
+					assert.Error(t, err)
+					continue
+				}
+
+				assert.NoError(t, err)
+
+				want, ok := wantExportAsLocals[stackMetadata.Path]
+				if !ok {
+					want = export_as_locals()
+				}
+				delete(wantExportAsLocals, stackMetadata.Path)
+
+				if want.HasExpressions() {
+					t.Errorf("wanted export_as_locals definition:\n%s\n", want)
+					t.Fatal("can't contain expressions, loaded export_as_locals are evaluated (values only)")
+				}
+
+				gotAttrs := got.Attributes()
+				wantAttrs := want.AttributesValues()
+
+				if len(gotAttrs) != len(wantAttrs) {
+					t.Errorf("got %d global attributes; wanted %d", len(gotAttrs), len(wantAttrs))
+				}
+
+				for name, wantVal := range wantAttrs {
+					gotVal, ok := gotAttrs[name]
+					if !ok {
+						t.Errorf("wanted global.%s is missing", name)
+						continue
+					}
+					if !gotVal.RawEquals(wantVal) {
+						t.Errorf("got global.%s=%v; want %v", name, gotVal, wantVal)
+					}
+				}
+			}
+
+			if len(wantExportAsLocals) > 0 {
+				t.Fatalf("wanted stack export as locals: %v that was not found on stacks: %v", wantExportAsLocals, metadata.Stacks)
+			}
+		})
+	}
+}
+
+func TestLoadStackExportAsLocalsErrorOnRelativeDir(t *testing.T) {
+	s := sandbox.New(t)
+	s.BuildTree([]string{"s:stack"})
+
+	rel, err := filepath.Rel(test.Getwd(t), s.RootDir())
+	assert.NoError(t, err)
+
+	meta := s.LoadMetadata()
+	assert.EqualInts(t, 1, len(meta.Stacks))
+
+	stackMetadata := meta.Stacks[0]
+	globals := s.LoadStackGlobals(stackMetadata)
+	exportLocals, err := terramate.LoadStackExportAsLocals(rel, stackMetadata, globals)
+	assert.Error(t, err, "got %v instead of error", exportLocals)
+}

--- a/export_as_locals_test.go
+++ b/export_as_locals_test.go
@@ -44,7 +44,7 @@ func TestExportAsLocals(t *testing.T) {
 	// Usually in Go names are cammel case, but on this case
 	// we want it to be as close to original HCL as possible (DSL).
 	export_as_locals := func(builders ...hclwrite.BlockBuilder) *hclwrite.Block {
-		return hclwrite.NewBuilder("globals", builders...)
+		return hclwrite.NewBuilder("export_as_locals", builders...)
 	}
 	globals := func(builders ...hclwrite.BlockBuilder) *hclwrite.Block {
 		return hclwrite.NewBuilder("globals", builders...)
@@ -147,17 +147,17 @@ func TestExportAsLocals(t *testing.T) {
 				wantAttrs := want.AttributesValues()
 
 				if len(gotAttrs) != len(wantAttrs) {
-					t.Errorf("got %d global attributes; wanted %d", len(gotAttrs), len(wantAttrs))
+					t.Errorf("got %d export_as_locals attributes; wanted %d", len(gotAttrs), len(wantAttrs))
 				}
 
 				for name, wantVal := range wantAttrs {
 					gotVal, ok := gotAttrs[name]
 					if !ok {
-						t.Errorf("wanted global.%s is missing", name)
+						t.Errorf("wanted %s is missing", name)
 						continue
 					}
 					if !gotVal.RawEquals(wantVal) {
-						t.Errorf("got global.%s=%v; want %v", name, gotVal, wantVal)
+						t.Errorf("got export_as_locals %s=%v; want %v", name, gotVal, wantVal)
 					}
 				}
 			}

--- a/export_as_locals_test.go
+++ b/export_as_locals_test.go
@@ -187,6 +187,51 @@ func TestExportAsLocals(t *testing.T) {
 				),
 			},
 		},
+		{
+			name: "multiple stacks with specific exported locals and globals from parent dirs",
+			layout: []string{
+				"s:stacks/stack-1",
+				"s:stacks/stack-2",
+			},
+			blocks: []block{
+				{
+					path: "/",
+					add: globals(
+						str("str", "string"),
+					),
+				},
+				{
+					path: "/stacks",
+					add: globals(
+						number("num", 666),
+					),
+				},
+				{
+					path: "/stacks/stack-1",
+					add: export_as_locals(
+						expr("str_local", "global.str"),
+						expr("name_local", "terramate.name"),
+					),
+				},
+				{
+					path: "/stacks/stack-2",
+					add: export_as_locals(
+						expr("num_local", "global.num"),
+						expr("path_local", "terramate.path"),
+					),
+				},
+			},
+			want: map[string]*hclwrite.Block{
+				"/stacks/stack-1": export_as_locals(
+					str("name_local", "stack-1"),
+					str("str_local", "string"),
+				),
+				"/stacks/stack-2": export_as_locals(
+					str("path_local", "/stacks/stack-2"),
+					number("num_local", 666),
+				),
+			},
+		},
 	}
 
 	for _, tcase := range tcases {

--- a/export_as_locals_test.go
+++ b/export_as_locals_test.go
@@ -99,6 +99,66 @@ func TestExportAsLocals(t *testing.T) {
 			},
 		},
 		{
+			name:   "single stack exporting metadata using functions",
+			layout: []string{"s:stack"},
+			blocks: []block{
+				{
+					path: "/stack",
+					add: export_as_locals(
+						expr("funny_path", `replace(terramate.path, "/", "@")`),
+					),
+				},
+			},
+			want: map[string]*hclwrite.Block{
+				"/stack": export_as_locals(
+					str("funny_path", "@stack"),
+				),
+			},
+		},
+		{
+			name: "multiple stack with exported locals being overridden",
+			layout: []string{
+				"s:stacks/stack-1",
+				"s:stacks/stack-2",
+			},
+			blocks: []block{
+				{
+					path: "/",
+					add: globals(
+						str("attr1", "value1"),
+						str("attr2", "value2"),
+						str("attr3", "value3"),
+					),
+				},
+				{
+					path: "/",
+					add: export_as_locals(
+						expr("string", "global.attr1"),
+					),
+				},
+				{
+					path: "/stacks",
+					add: export_as_locals(
+						expr("string", "global.attr2"),
+					),
+				},
+				{
+					path: "/stacks/stack-1",
+					add: export_as_locals(
+						expr("string", "global.attr3"),
+					),
+				},
+			},
+			want: map[string]*hclwrite.Block{
+				"/stacks/stack-1": export_as_locals(
+					str("string", "value3"),
+				),
+				"/stacks/stack-2": export_as_locals(
+					str("string", "value2"),
+				),
+			},
+		},
+		{
 			name:   "single stack with exported locals and globals from parent dirs",
 			layout: []string{"s:stacks/stack"},
 			blocks: []block{

--- a/export_as_locals_test.go
+++ b/export_as_locals_test.go
@@ -112,6 +112,7 @@ func TestExportAsLocals(t *testing.T) {
 					path: "/",
 					add: export_as_locals(
 						expr("num_local", "global.num"),
+						expr("path_local", "terramate.path"),
 					),
 				},
 				{
@@ -124,11 +125,14 @@ func TestExportAsLocals(t *testing.T) {
 					path: "/stacks",
 					add: export_as_locals(
 						expr("str_local", "global.str"),
+						expr("name_local", "terramate.name"),
 					),
 				},
 			},
 			want: map[string]*hclwrite.Block{
 				"/stacks/stack": export_as_locals(
+					str("name_local", "stack"),
+					str("path_local", "/stacks/stack"),
 					str("str_local", "string"),
 					number("num_local", 666),
 				),

--- a/export_as_locals_test.go
+++ b/export_as_locals_test.go
@@ -138,6 +138,55 @@ func TestExportAsLocals(t *testing.T) {
 				),
 			},
 		},
+		{
+			name: "multiple stacks with exported locals and globals from parent dirs",
+			layout: []string{
+				"s:stacks/stack-1",
+				"s:stacks/stack-2",
+			},
+			blocks: []block{
+				{
+					path: "/",
+					add: globals(
+						str("str", "string"),
+					),
+				},
+				{
+					path: "/",
+					add: export_as_locals(
+						expr("num_local", "global.num"),
+						expr("path_local", "terramate.path"),
+					),
+				},
+				{
+					path: "/stacks",
+					add: globals(
+						number("num", 666),
+					),
+				},
+				{
+					path: "/stacks",
+					add: export_as_locals(
+						expr("str_local", "global.str"),
+						expr("name_local", "terramate.name"),
+					),
+				},
+			},
+			want: map[string]*hclwrite.Block{
+				"/stacks/stack-1": export_as_locals(
+					str("name_local", "stack-1"),
+					str("path_local", "/stacks/stack-1"),
+					str("str_local", "string"),
+					number("num_local", 666),
+				),
+				"/stacks/stack-2": export_as_locals(
+					str("name_local", "stack-2"),
+					str("path_local", "/stacks/stack-2"),
+					str("str_local", "string"),
+					number("num_local", 666),
+				),
+			},
+		},
 	}
 
 	for _, tcase := range tcases {

--- a/globals.go
+++ b/globals.go
@@ -27,7 +27,7 @@ import (
 	"github.com/zclconf/go-cty/cty"
 )
 
-// Globals represents a globals block.
+// Globals represents information obtained by parsing and evaluating globals blocks.
 type Globals struct {
 	attributes map[string]cty.Value
 }

--- a/globals.go
+++ b/globals.go
@@ -58,9 +58,6 @@ func LoadStackGlobals(rootdir string, meta StackMetadata) (*Globals, error) {
 // Attributes returns all the global attributes, the key in the map
 // is the attribute name with its corresponding value mapped
 func (g *Globals) Attributes() map[string]cty.Value {
-	// FIXME(katcipis): this method is exported only for testing purposes.
-	// Would be nice to find a way to test globals only through their observable behavior
-	// Maybe using SetOnEvalCtx ?
 	attrcopy := map[string]cty.Value{}
 	for k, v := range g.attributes {
 		attrcopy[k] = v
@@ -77,10 +74,6 @@ func (g *Globals) String() string {
 // on the given evaluation context.
 func (g *Globals) SetOnEvalCtx(evalctx *eval.Context) error {
 	return evalctx.SetNamespace("global", g.Attributes())
-}
-
-func (g *Globals) set(name string, val cty.Value) {
-	g.attributes[name] = val
 }
 
 type rawGlobals struct {
@@ -133,7 +126,7 @@ func (r *rawGlobals) eval(meta StackMetadata) (*Globals, error) {
 				continue
 			}
 
-			globals.set(name, val)
+			globals.attributes[name] = val
 			amountEvaluated += 1
 			delete(pendingExprs, name)
 		}

--- a/globals.go
+++ b/globals.go
@@ -58,7 +58,14 @@ func LoadStackGlobals(rootdir string, meta StackMetadata) (*Globals, error) {
 // Attributes returns all the global attributes, the key in the map
 // is the attribute name with its corresponding value mapped
 func (g *Globals) Attributes() map[string]cty.Value {
-	return g.attributes
+	// FIXME(katcipis): this method is exported only for testing purposes.
+	// Would be nice to find a way to test globals only through their observable behavior
+	// Maybe using SetOnEvalCtx ?
+	attrcopy := map[string]cty.Value{}
+	for k, v := range g.attributes {
+		attrcopy[k] = v
+	}
+	return attrcopy
 }
 
 // String provides a string representation of the globals

--- a/globals_test.go
+++ b/globals_test.go
@@ -498,7 +498,6 @@ func TestLoadGlobals(t *testing.T) {
 
 			metadata := s.LoadMetadata()
 			for _, stackMetadata := range metadata.Stacks {
-				// TODO(katcipis): check got again
 				got, err := terramate.LoadStackGlobals(s.RootDir(), stackMetadata)
 
 				if tcase.wantErr {

--- a/hcl/hcl.go
+++ b/hcl/hcl.go
@@ -322,6 +322,15 @@ func ParseFile(path string) (Config, error) {
 
 // ParseGlobalsBlocks parses globals blocks, ignoring any other blocks
 func ParseGlobalsBlocks(path string) ([]*hclsyntax.Block, error) {
+	return parseBlocksOfType(path, "globals")
+}
+
+// ParseExportAsLocalsBlocks parses export_as_locals blocks, ignoring other blocks
+func ParseExportAsLocalsBlocks(path string) ([]*hclsyntax.Block, error) {
+	return parseBlocksOfType(path, "export_as_locals")
+}
+
+func parseBlocksOfType(path string, blocktype string) ([]*hclsyntax.Block, error) {
 	_, err := os.Stat(path)
 	if err != nil {
 		return nil, err
@@ -332,13 +341,12 @@ func ParseGlobalsBlocks(path string) ([]*hclsyntax.Block, error) {
 	if diags.HasErrors() {
 		return nil, errutil.Chain(
 			ErrHCLSyntax,
-			fmt.Errorf("parsing globals: %w", diags),
+			fmt.Errorf("parsing blocks of type %q: %w", blocktype, diags),
 		)
 	}
 
 	body, _ := f.Body.(*hclsyntax.Body)
-
-	return filterBlocksByType("globals", body.Blocks), nil
+	return filterBlocksByType(blocktype, body.Blocks), nil
 }
 
 func findStringAttr(block *hclsyntax.Block, attr string) (string, bool, error) {
@@ -541,7 +549,7 @@ func filterBlocksByType(blocktype string, blocks []*hclsyntax.Block) []*hclsynta
 
 func blockIsAllowed(name string) bool {
 	switch name {
-	case "terramate", "stack", "backend", "globals":
+	case "terramate", "stack", "backend", "globals", "export_as_locals":
 		return true
 	default:
 		return false

--- a/test/sandbox/sandbox.go
+++ b/test/sandbox/sandbox.go
@@ -200,6 +200,15 @@ func (s S) LoadMetadata() terramate.Metadata {
 	return meta
 }
 
+// Loads globals for stack on the sandbox
+func (s S) LoadStackGlobals(sm terramate.StackMetadata) *terramate.Globals {
+	s.t.Helper()
+
+	g, err := terramate.LoadStackGlobals(s.RootDir(), sm)
+	assert.NoError(s.t, err)
+	return g
+}
+
 // RootDir returns the root directory of the test env. All dirs/files created
 // through the test env will be included inside this dir.
 //


### PR DESCRIPTION
Includes the core logic but no code generation, which will be done in a different PR. It is very similar to globals, but evaluation is simpler, so there is no attempt to extract duplication here yet, maybe in a future PR.

The spec: https://github.com/mineiros-io/terramate/blob/main/docs/locals-generation.md