### PR TITLE
testing: add subblocks/hcl to hclwrite

### DIFF
--- a/cmd/terramate/cli/stacks_globals_test.go
+++ b/cmd/terramate/cli/stacks_globals_test.go
@@ -39,7 +39,7 @@ func TestStacksGlobals(t *testing.T) {
 	)
 
 	globals := func(builders ...hclwrite.BlockBuilder) *hclwrite.Block {
-		return hclwrite.NewBuilder("globals", builders...)
+		return hclwrite.BuildBlock("globals", builders...)
 	}
 	str := hclwrite.String
 	number := hclwrite.NumberInt

--- a/globals_test.go
+++ b/globals_test.go
@@ -46,7 +46,7 @@ func TestLoadGlobals(t *testing.T) {
 	)
 
 	globals := func(builders ...hclwrite.BlockBuilder) *hclwrite.Block {
-		return hclwrite.NewBuilder("globals", builders...)
+		return hclwrite.BuildBlock("globals", builders...)
 	}
 	expr := hclwrite.Expression
 	str := hclwrite.String

--- a/test/hclwrite/hclwrite.go
+++ b/test/hclwrite/hclwrite.go
@@ -76,7 +76,7 @@ func (b *Block) HasExpressions() bool {
 }
 
 func (b *Block) String() string {
-	code := b.name + strings.Join(b.labels, ",") + "{\n"
+	code := b.name + strings.Join(b.labels, " ") + "{\n"
 	// Tried properly using hclwrite, it doesnt work well with expressions:
 	// - https://stackoverflow.com/questions/67945463/how-to-use-hcl-write-to-set-expressions-with
 	for _, name := range b.sortedExpressions() {
@@ -86,7 +86,7 @@ func (b *Block) String() string {
 		code += fmt.Sprintf("%s=%v\n", name, b.values[name])
 	}
 	code += "}"
-	return string(hclwrite.Format([]byte(code)))
+	return Format(code)
 }
 
 func NewBlock(name string) *Block {
@@ -100,7 +100,7 @@ func NewBlock(name string) *Block {
 
 type BlockBuilder func(*Block)
 
-func NewBuilder(name string, builders ...BlockBuilder) *Block {
+func BuildBlock(name string, builders ...BlockBuilder) *Block {
 	b := NewBlock(name)
 	for _, builder := range builders {
 		builder(b)

--- a/test/hclwrite/hclwrite.go
+++ b/test/hclwrite/hclwrite.go
@@ -105,7 +105,7 @@ func (b *Block) String() string {
 	return Format(code)
 }
 
-func (h *HCL) String() string {
+func (h HCL) String() string {
 	strs := make([]string, len(h.blocks))
 	for i, block := range h.blocks {
 		strs[i] = block.String()
@@ -122,8 +122,8 @@ func NewBlock(name string) *Block {
 	}
 }
 
-func NewHCL(blocks ...*Block) *HCL {
-	return &HCL{blocks: blocks}
+func NewHCL(blocks ...*Block) HCL {
+	return HCL{blocks: blocks}
 }
 
 type BlockBuilder interface {

--- a/test/hclwrite/hclwrite.go
+++ b/test/hclwrite/hclwrite.go
@@ -45,6 +45,10 @@ type Block struct {
 	values    map[string]interface{}
 }
 
+type HCL struct {
+	blocks []*Block
+}
+
 func (b *Block) AddLabel(name string) {
 	b.labels = append(b.labels, fmt.Sprintf("%q", name))
 }
@@ -101,6 +105,14 @@ func (b *Block) String() string {
 	return Format(code)
 }
 
+func (h *HCL) String() string {
+	strs := make([]string, len(h.blocks))
+	for i, block := range h.blocks {
+		strs[i] = block.String()
+	}
+	return strings.Join(strs, "\n")
+}
+
 func NewBlock(name string) *Block {
 	return &Block{
 		name:        name,
@@ -108,6 +120,10 @@ func NewBlock(name string) *Block {
 		ctyvalues:   map[string]cty.Value{},
 		values:      map[string]interface{}{},
 	}
+}
+
+func NewHCL(blocks ...*Block) *HCL {
+	return &HCL{blocks: blocks}
 }
 
 type BlockBuilder interface {

--- a/test/hclwrite/hclwrite_test.go
+++ b/test/hclwrite/hclwrite_test.go
@@ -1,0 +1,73 @@
+package hclwrite_test
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/mineiros-io/terramate/test/hclwrite"
+)
+
+func TestHCLWrite(t *testing.T) {
+	type testcase struct {
+		name  string
+		block *hclwrite.Block
+		want  string
+	}
+
+	block := func(name string, builders ...hclwrite.BlockBuilder) *hclwrite.Block {
+		return hclwrite.NewBuilder(name, builders...)
+	}
+	labels := hclwrite.Labels
+	expr := hclwrite.Expression
+	str := hclwrite.String
+	number := hclwrite.NumberInt
+	boolean := hclwrite.Boolean
+
+	tcases := []testcase{
+		{
+			name: "single block",
+			block: block("test",
+				str("str", "test"),
+				number("num", 666),
+				boolean("bool", true),
+				expr("expr_a", "local.name"),
+				expr("expr_b", "local.name"),
+			),
+			want: `
+			  test {
+			    expr_a = local.name
+			    expr_b = local.name
+			    bool   = true
+			    num    = 666
+			    str    = "test"
+			  }
+			`,
+		},
+		{
+			name: "single block with one label",
+			block: block("test",
+				labels("label"),
+				str("str", "labeltest"),
+			),
+			want: `
+			  test "label" {
+			    str    = "labeltest"
+			  }
+			`,
+		},
+	}
+
+	for _, tcase := range tcases {
+		t.Run(tcase.name, func(t *testing.T) {
+			want := hclwrite.Format(tcase.want)
+			got := tcase.block.String()
+
+			if diff := cmp.Diff(got, want); diff != "" {
+				t.Errorf("got:\n%s", got)
+				t.Errorf("want:\n%s", want)
+				t.Error("diff:")
+				t.Fatal(diff)
+			}
+		})
+	}
+}

--- a/test/hclwrite/hclwrite_test.go
+++ b/test/hclwrite/hclwrite_test.go
@@ -99,6 +99,29 @@ func TestHCLWrite(t *testing.T) {
 			  }
 			`,
 		},
+		{
+			name: "block nesting",
+			block: block("test",
+				str("str", "level1"),
+				block("nested",
+					str("str", "level2"),
+					block("yet_more_nesting",
+						str("str", "level3"),
+					),
+				),
+			),
+			want: `
+			  test {
+			    str = "level1"
+			    nested {
+			      str = "level2"
+			      yet_more_nesting {
+			        str = "level3"
+			      }
+			    }
+			  }
+			`,
+		},
 	}
 
 	for _, tcase := range tcases {

--- a/test/hclwrite/hclwrite_test.go
+++ b/test/hclwrite/hclwrite_test.go
@@ -122,6 +122,32 @@ func TestHCLWrite(t *testing.T) {
 			  }
 			`,
 		},
+		{
+			name: "block nesting with labels",
+			block: block("test",
+				labels("label"),
+				str("str", "level1"),
+				block("nested",
+					labels("label1", "label2"),
+					str("str", "level2"),
+					block("yet_more_nesting",
+						labels("label1", "label2", "label3"),
+						str("str", "level3"),
+					),
+				),
+			),
+			want: `
+			  test "label" {
+			    str = "level1"
+			    nested "label1" "label2" {
+			      str = "level2"
+			      yet_more_nesting "label1" "label2" "label3" {
+			        str = "level3"
+			      }
+			    }
+			  }
+			`,
+		},
 	}
 
 	for _, tcase := range tcases {

--- a/test/hclwrite/hclwrite_test.go
+++ b/test/hclwrite/hclwrite_test.go
@@ -1,3 +1,17 @@
+// Copyright 2021 Mineiros GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package hclwrite_test
 
 import (
@@ -15,7 +29,7 @@ func TestHCLWrite(t *testing.T) {
 	}
 
 	block := func(name string, builders ...hclwrite.BlockBuilder) *hclwrite.Block {
-		return hclwrite.NewBuilder(name, builders...)
+		return hclwrite.BuildBlock(name, builders...)
 	}
 	labels := hclwrite.Labels
 	expr := hclwrite.Expression
@@ -25,7 +39,15 @@ func TestHCLWrite(t *testing.T) {
 
 	tcases := []testcase{
 		{
-			name: "single block",
+			name:  "empty block",
+			block: block("test"),
+			want: `
+			  test {
+			  }
+			`,
+		},
+		{
+			name: "block with multiple attributes",
 			block: block("test",
 				str("str", "test"),
 				number("num", 666),
@@ -44,7 +66,7 @@ func TestHCLWrite(t *testing.T) {
 			`,
 		},
 		{
-			name: "single block with one label",
+			name: "block with one label",
 			block: block("test",
 				labels("label"),
 				str("str", "labeltest"),
@@ -52,6 +74,28 @@ func TestHCLWrite(t *testing.T) {
 			want: `
 			  test "label" {
 			    str    = "labeltest"
+			  }
+			`,
+		},
+		{
+			name: "empty block with one label",
+			block: block("test",
+				labels("label"),
+			),
+			want: `
+			  test "label" {
+			  }
+			`,
+		},
+		{
+			name: "block multiple labels",
+			block: block("test",
+				labels("label", "label2"),
+				str("str", "labelstest"),
+			),
+			want: `
+			  test "label" "label2" {
+			    str    = "labelstest"
 			  }
 			`,
 		},


### PR DESCRIPTION
This should make it possible to avoid the raw multiline strings for HCL stuff on testing, to make it look even nicer we can have something like:

```go
	terramate := func(builders ...hclwrite.BlockBuilder) *hclwrite.Block {
		return hclwrite.BuildBlock("terramate", builders...)
	}
```

And then code building terramate blocks would look like:

```go
terramate(
    str("required_version", "etc")
)
```

Not sure if this makes sense and I was kinda rushing to get something that would work, so review with care =P.