### PR TITLE
fix: tests broken missing stacks on init

### DIFF
--- a/cmd/terramate/cli/cli_list_test.go
+++ b/cmd/terramate/cli/cli_list_test.go
@@ -136,7 +136,7 @@ func TestListDetectChangesInSubDirOfStack(t *testing.T) {
 	subfile := subdir.CreateFile("something.sh", "# nothing")
 
 	cli := newCLI(t, s.RootDir())
-	assertRun(t, cli.run("init", stack.Path()))
+	assertRun(t, cli.run("stacks", "init", stack.Path()))
 
 	git := s.Git()
 	git.Add(".")
@@ -169,7 +169,7 @@ terramate {
 `)
 
 	cli := newCLI(t, s.RootDir())
-	assertRun(t, cli.run("init", stack.Path()))
+	assertRun(t, cli.run("stacks", "init", stack.Path()))
 
 	git := s.Git()
 	git.Add(".")


### PR DESCRIPTION
Missing fix on tests for "stacks init" instead of just "init"