### PR TITLE
fix: evaluate only globals already known

### DIFF
--- a/hcl/eval/eval.go
+++ b/hcl/eval/eval.go
@@ -44,6 +44,10 @@ func NewContext(basedir string) *Context {
 	}
 }
 
+func (c *Context) GetHCLContext() *hhcl.EvalContext {
+	return c.hclctx
+}
+
 // SetNamespace will set the given values inside the given namespace on the
 // evaluation context.
 func (c *Context) SetNamespace(name string, vals map[string]cty.Value) error {


### PR DESCRIPTION
- detect unknown namespaces
- detect unknown variables in global namespace
- fix evaluation order
- detect global variables that could not be evaluated (cycles)
- set new context in each loop execution