### PR TITLE
test: add some tests on globals eval with try()

### DIFF
--- a/globals_test.go
+++ b/globals_test.go
@@ -1,4 +1,3 @@
-// Copyright 2021 Mineiros GmbH
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -50,8 +49,8 @@ func TestLoadGlobals(t *testing.T) {
 		return hclwrite.BuildBlock("globals", builders...)
 	}
 	expr := hclwrite.Expression
-	eval := func(name, expr string) hclwrite.BlockBuilder {
-		return hclwrite.Eval(t, name, expr)
+	attr := func(name, expr string) hclwrite.BlockBuilder {
+		return hclwrite.AttributeValue(t, name, expr)
 	}
 	str := hclwrite.String
 	number := hclwrite.NumberInt
@@ -451,7 +450,7 @@ func TestLoadGlobals(t *testing.T) {
 				{
 					path: "/stack",
 					add: globals(
-						eval("team", `{ members = ["aaa"] }`),
+						attr("team", `{ members = ["aaa"] }`),
 						expr("members", "global.team.members"),
 						expr("members_try", `try(global.team.members, [])`),
 					),
@@ -459,9 +458,9 @@ func TestLoadGlobals(t *testing.T) {
 			},
 			want: map[string]*hclwrite.Block{
 				"/stack": globals(
-					eval("team", `{ members = ["aaa"] }`),
-					eval("members", `["aaa"]`),
-					eval("members_try", `["aaa"]`),
+					attr("team", `{ members = ["aaa"] }`),
+					attr("members", `["aaa"]`),
+					attr("members_try", `["aaa"]`),
 				),
 			},
 		},
@@ -472,15 +471,15 @@ func TestLoadGlobals(t *testing.T) {
 				{
 					path: "/stack",
 					add: globals(
-						eval("team", `{ members = ["aaa"] }`),
+						attr("team", `{ members = ["aaa"] }`),
 						expr("members_try", `try(global.team.mistake, [])`),
 					),
 				},
 			},
 			want: map[string]*hclwrite.Block{
 				"/stack": globals(
-					eval("team", `{ members = ["aaa"] }`),
-					eval("members_try", "[]"),
+					attr("team", `{ members = ["aaa"] }`),
+					attr("members_try", "[]"),
 				),
 			},
 		},
@@ -498,15 +497,15 @@ func TestLoadGlobals(t *testing.T) {
 				{
 					path: "/stack",
 					add: globals(
-						eval("team", `{ def = { name = "awesome" } }`),
+						attr("team", `{ def = { name = "awesome" } }`),
 					),
 				},
 			},
 			want: map[string]*hclwrite.Block{
 				"/stack": globals(
-					eval("team", `{ def = { name = "awesome" } }`),
-					eval("team_def", `{ name = "awesome" }`),
-					eval("team_def_try", `{ name = "awesome" }`),
+					attr("team", `{ def = { name = "awesome" } }`),
+					attr("team_def", `{ name = "awesome" }`),
+					attr("team_def_try", `{ name = "awesome" }`),
 				),
 			},
 		},

--- a/globals_test.go
+++ b/globals_test.go
@@ -466,6 +466,32 @@ func TestLoadGlobals(t *testing.T) {
 			},
 		},
 		{
+			name:   "global reference with try on root config and value defined on stack",
+			layout: []string{"s:stack"},
+			globals: []globalsBlock{
+				{
+					path: "/",
+					add: globals(
+						expr("team_def", "global.team.def"),
+						expr("team_def_try", `try(global.team.def, {})`),
+					),
+				},
+				{
+					path: "/stack",
+					add: globals(
+						eval("team", `{ def = { name = "awesome" } }`),
+					),
+				},
+			},
+			want: map[string]*hclwrite.Block{
+				"/stack": globals(
+					eval("team", `{ def = { name = "awesome" } }`),
+					eval("team_def", `{ name = "awesome" }`),
+					eval("team_def_try", `{ name = "awesome" }`),
+				),
+			},
+		},
+		{
 			name:   "global undefined reference on root",
 			layout: []string{"s:stack"},
 			globals: []globalsBlock{

--- a/globals_test.go
+++ b/globals_test.go
@@ -466,6 +466,25 @@ func TestLoadGlobals(t *testing.T) {
 			},
 		},
 		{
+			name:   "global reference with failed try on stack",
+			layout: []string{"s:stack"},
+			globals: []globalsBlock{
+				{
+					path: "/stack",
+					add: globals(
+						eval("team", `{ members = ["aaa"] }`),
+						expr("members_try", `try(global.team.mistake, [])`),
+					),
+				},
+			},
+			want: map[string]*hclwrite.Block{
+				"/stack": globals(
+					eval("team", `{ members = ["aaa"] }`),
+					eval("members_try", "[]"),
+				),
+			},
+		},
+		{
 			name:   "global reference with try on root config and value defined on stack",
 			layout: []string{"s:stack"},
 			globals: []globalsBlock{

--- a/globals_test.go
+++ b/globals_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Mineiros GmbH
+// Copyright 2021 Mineiros GmbH
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/globals_test.go
+++ b/globals_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/mineiros-io/terramate/test"
 	"github.com/mineiros-io/terramate/test/hclwrite"
 	"github.com/mineiros-io/terramate/test/sandbox"
+	"github.com/zclconf/go-cty-debug/ctydebug"
 )
 
 // TODO(katcipis): add tests related to tf functions that depend on filesystem
@@ -592,8 +593,11 @@ func TestLoadGlobals(t *testing.T) {
 						t.Errorf("wanted global.%s is missing", name)
 						continue
 					}
-					if !gotVal.RawEquals(wantVal) {
-						t.Errorf("got global.%s=%v; want %v", name, gotVal.GoString(), wantVal.GoString())
+					if diff := ctydebug.DiffValues(wantVal, gotVal); diff != "" {
+						t.Errorf("global.%s doesn't match expectation", name)
+						t.Errorf("want: %s", ctydebug.ValueString(wantVal))
+						t.Errorf("got: %s", ctydebug.ValueString(gotVal))
+						t.Errorf("diff:\n%s", diff)
 					}
 				}
 			}

--- a/globals_test.go
+++ b/globals_test.go
@@ -1,3 +1,5 @@
+// Copyright 2022 Mineiros GmbH
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/globals_test.go
+++ b/globals_test.go
@@ -1,4 +1,3 @@
-//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/posener/complete v1.2.3
 	github.com/willabides/kongplete v0.2.0
 	github.com/zclconf/go-cty v1.8.3
+	github.com/zclconf/go-cty-debug v0.0.0-20191215020915-b22d67c1ba0b
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -447,6 +447,7 @@ github.com/zclconf/go-cty v1.2.0/go.mod h1:hOPWgoHbaTUnI5k4D2ld+GRpFJSCe6bCM7m1q
 github.com/zclconf/go-cty v1.8.0/go.mod h1:vVKLxnk3puL4qRAv72AO+W99LUD4da90g3uUAzyuvAk=
 github.com/zclconf/go-cty v1.8.3 h1:48gwZXrdSADU2UW9eZKHprxAI7APZGW9XmExpJpSjT0=
 github.com/zclconf/go-cty v1.8.3/go.mod h1:vVKLxnk3puL4qRAv72AO+W99LUD4da90g3uUAzyuvAk=
+github.com/zclconf/go-cty-debug v0.0.0-20191215020915-b22d67c1ba0b h1:FosyBZYxY34Wul7O/MSKey3txpPYyCqVO5ZyceuQJEI=
 github.com/zclconf/go-cty-debug v0.0.0-20191215020915-b22d67c1ba0b/go.mod h1:ZRKQfBXbGkpdV6QMzT3rU1kSTAnfu1dO8dPKjYprgj8=
 github.com/zclconf/go-cty-yaml v1.0.2 h1:dNyg4QLTrv2IfJpm7Wtxi55ed5gLGOlPrZ6kMd51hY0=
 github.com/zclconf/go-cty-yaml v1.0.2/go.mod h1:IP3Ylp0wQpYm50IHK8OZWKMu6sPJIUgKa8XhiVHura0=

--- a/test/hclwrite/hclwrite.go
+++ b/test/hclwrite/hclwrite.go
@@ -151,7 +151,7 @@ func Labels(labels ...string) BlockBuilder {
 	})
 }
 
-// Eval accepts an expr as parameter, similar to Expression,
+// AttributeValue accepts an expr as the attribute value, similar to Expression,
 // but will evaluate the expr and store the resulting value so
 // it will be available as an attribute value instead of as an
 // expression. If evaluation fails the test caller will fail.
@@ -159,10 +159,10 @@ func Labels(labels ...string) BlockBuilder {
 // The evaluation is quite limited, only suitable for evaluating
 // objects/lists/etc, but won't work with any references to
 // namespaces of function calls (context for evaluation is always empty).
-func Eval(t *testing.T, key string, expr string) BlockBuilder {
+func AttributeValue(t *testing.T, name string, expr string) BlockBuilder {
 	t.Helper()
 
-	rawbody := key + " = " + expr
+	rawbody := name + " = " + expr
 	parser := hclparse.NewParser()
 	res, diags := parser.ParseHCL([]byte(rawbody), "")
 	if diags.HasErrors() {
@@ -170,7 +170,7 @@ func Eval(t *testing.T, key string, expr string) BlockBuilder {
 	}
 	body := res.Body.(*hclsyntax.Body)
 
-	val, diags := body.Attributes[key].Expr.Value(nil)
+	val, diags := body.Attributes[name].Expr.Value(nil)
 	if diags.HasErrors() {
 		t.Fatalf("hclwrite.Eval: cant eval %s: %v", rawbody, diags)
 	}
@@ -178,8 +178,8 @@ func Eval(t *testing.T, key string, expr string) BlockBuilder {
 	return BlockBuilderFunc(func(g *Block) {
 		// hacky way to get original string representation of composite types
 		// but also have proper cty values that can be compared.
-		g.ctyvalues[key] = val
-		g.values[key] = expr
+		g.ctyvalues[name] = val
+		g.values[name] = expr
 	})
 }
 
@@ -188,27 +188,27 @@ func Eval(t *testing.T, key string, expr string) BlockBuilder {
 // affect the attribute values of the block.
 //
 // The given expression will be added on the generated output verbatim.
-func Expression(key string, expr string) BlockBuilder {
+func Expression(name string, expr string) BlockBuilder {
 	return BlockBuilderFunc(func(g *Block) {
-		g.AddExpr(key, expr)
+		g.AddExpr(name, expr)
 	})
 }
 
-func String(key string, val string) BlockBuilder {
+func String(name string, val string) BlockBuilder {
 	return BlockBuilderFunc(func(g *Block) {
-		g.AddString(key, val)
+		g.AddString(name, val)
 	})
 }
 
-func Boolean(key string, val bool) BlockBuilder {
+func Boolean(name string, val bool) BlockBuilder {
 	return BlockBuilderFunc(func(g *Block) {
-		g.AddBoolean(key, val)
+		g.AddBoolean(name, val)
 	})
 }
 
-func NumberInt(key string, val int64) BlockBuilder {
+func NumberInt(name string, val int64) BlockBuilder {
 	return BlockBuilderFunc(func(g *Block) {
-		g.AddNumberInt(key, val)
+		g.AddNumberInt(name, val)
 	})
 }
 

--- a/test/hclwrite/hclwrite.go
+++ b/test/hclwrite/hclwrite.go
@@ -151,13 +151,14 @@ func Labels(labels ...string) BlockBuilder {
 	})
 }
 
-// Eval accepts an expr as parameter, similar to Expression
+// Eval accepts an expr as parameter, similar to Expression,
 // but will evaluate the expr and store the resulting value so
 // it will be available as an attribute value instead of as an
 // expression. If evaluation fails the test caller will fail.
+//
 // The evaluation is quite limited, only suitable for evaluating
-// objects/lists/etc, but won't work with any references (context
-// for evaluation is assumed as always empty).
+// objects/lists/etc, but won't work with any references to
+// namespaces of function calls (context for evaluation is always empty).
 func Eval(t *testing.T, key string, expr string) BlockBuilder {
 	t.Helper()
 
@@ -182,6 +183,11 @@ func Eval(t *testing.T, key string, expr string) BlockBuilder {
 	})
 }
 
+// Expression adds the attribute with the given name with the
+// given expression, the expression won't be evaluated and this won't
+// affect the attribute values of the block.
+//
+// The given expression will be added on the generated output verbatim.
 func Expression(key string, expr string) BlockBuilder {
 	return BlockBuilderFunc(func(g *Block) {
 		g.AddExpr(key, expr)

--- a/test/hclwrite/hclwrite_test.go
+++ b/test/hclwrite/hclwrite_test.go
@@ -201,6 +201,8 @@ func TestHCLWrite(t *testing.T) {
 			want := hclwrite.Format(tcase.want)
 			got := tcase.hcl.String()
 
+			assertIsValidHCL(t, got)
+
 			if diff := cmp.Diff(got, want); diff != "" {
 				t.Errorf("got:\n%s", got)
 				t.Errorf("want:\n%s", want)
@@ -232,6 +234,17 @@ func TestHCLWriteAddingAttributeValue(t *testing.T) {
 
 	if diff := ctydebug.DiffValues(want, got); diff != "" {
 		t.Fatal(diff)
+	}
+}
+
+func assertIsValidHCL(t *testing.T, code string) {
+	t.Helper()
+
+	parser := hclparse.NewParser()
+	_, diags := parser.ParseHCL([]byte(code), "")
+	if diags.HasErrors() {
+		t.Errorf("invalid HCL: %v", diags)
+		t.Fatalf("code:\n%s", code)
 	}
 }
 

--- a/test/hclwrite/hclwrite_test.go
+++ b/test/hclwrite/hclwrite_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/madlambda/spells/assert"
 	"github.com/mineiros-io/terramate/test/hclwrite"
+	"github.com/zclconf/go-cty-debug/ctydebug"
 	"github.com/zclconf/go-cty/cty"
 )
 
@@ -230,8 +231,8 @@ func TestHCLWriteEvalReturnAttributeValue(t *testing.T) {
 
 	got := gotAttrsValues["team"]
 
-	if !got.RawEquals(want) {
-		t.Errorf("got %v != %v", got, want)
+	if diff := ctydebug.DiffValues(want, got); diff != "" {
+		t.Fatal(diff)
 	}
 }
 

--- a/test/hclwrite/hclwrite_test.go
+++ b/test/hclwrite/hclwrite_test.go
@@ -76,7 +76,7 @@ func TestHCLWrite(t *testing.T) {
 			`,
 		},
 		{
-			name: "block with evaluated complex data structures",
+			name: "block with complex attributes",
 			hcl: block("test",
 				attr("team", `{ members = ["aaa"] }`),
 				attr("nesting", `{ first = { second = { "hi": 666 } } }`),

--- a/test/hclwrite/hclwrite_test.go
+++ b/test/hclwrite/hclwrite_test.go
@@ -40,8 +40,8 @@ func TestHCLWrite(t *testing.T) {
 	hcl := hclwrite.NewHCL
 	labels := hclwrite.Labels
 	expr := hclwrite.Expression
-	eval := func(name, expr string) hclwrite.BlockBuilder {
-		return hclwrite.Eval(t, name, expr)
+	attr := func(name, expr string) hclwrite.BlockBuilder {
+		return hclwrite.AttributeValue(t, name, expr)
 	}
 	str := hclwrite.String
 	number := hclwrite.NumberInt
@@ -78,9 +78,9 @@ func TestHCLWrite(t *testing.T) {
 		{
 			name: "block with evaluated complex data structures",
 			hcl: block("test",
-				eval("team", `{ members = ["aaa"] }`),
-				eval("nesting", `{ first = { second = { "hi": 666 } } }`),
-				eval("list", `[1, 2, 3]`),
+				attr("team", `{ members = ["aaa"] }`),
+				attr("nesting", `{ first = { second = { "hi": 666 } } }`),
+				attr("list", `[1, 2, 3]`),
 			),
 			want: `
 			  test {
@@ -215,13 +215,13 @@ func TestHCLWriteEvalReturnAttributeValue(t *testing.T) {
 	block := func(name string, builders ...hclwrite.BlockBuilder) *hclwrite.Block {
 		return hclwrite.BuildBlock(name, builders...)
 	}
-	eval := func(name, expr string) hclwrite.BlockBuilder {
-		return hclwrite.Eval(t, name, expr)
+	attr := func(name, expr string) hclwrite.BlockBuilder {
+		return hclwrite.AttributeValue(t, name, expr)
 	}
 	const objectExpression = `{ members = ["aaa"] }`
 
 	testblock := block("test",
-		eval("team", objectExpression),
+		attr("team", objectExpression),
 	)
 
 	want := evaluateValExpr(t, objectExpression)

--- a/test/hclwrite/hclwrite_test.go
+++ b/test/hclwrite/hclwrite_test.go
@@ -78,12 +78,14 @@ func TestHCLWrite(t *testing.T) {
 			name: "block with evaluated complex data structures",
 			hcl: block("test",
 				eval("team", `{ members = ["aaa"] }`),
+				eval("nesting", `{ first = { second = { "hi": 666 } } }`),
 				eval("list", `[1, 2, 3]`),
 			),
 			want: `
 			  test {
-			    list = [1, 2, 3]
-			    team = { members = ["aaa"] }
+			    list    = [1, 2, 3]
+			    nesting = { first = { second = { "hi": 666 } } }
+			    team    = { members = ["aaa"] }
 			  }
 			`,
 		},

--- a/test/hclwrite/hclwrite_test.go
+++ b/test/hclwrite/hclwrite_test.go
@@ -211,7 +211,7 @@ func TestHCLWrite(t *testing.T) {
 	}
 }
 
-func TestHCLWriteEvalReturnAttributeValue(t *testing.T) {
+func TestHCLWriteAddingAttributeValue(t *testing.T) {
 	block := func(name string, builders ...hclwrite.BlockBuilder) *hclwrite.Block {
 		return hclwrite.BuildBlock(name, builders...)
 	}
@@ -223,7 +223,6 @@ func TestHCLWriteEvalReturnAttributeValue(t *testing.T) {
 	testblock := block("test",
 		attr("team", objectExpression),
 	)
-
 	want := evaluateValExpr(t, objectExpression)
 	gotAttrsValues := testblock.AttributesValues()
 


### PR DESCRIPTION
Adding some tests to cover the fix for try() usage, it was failing before but after I merged the fix it started to work, so it seems to cover the fix reasonably well.