### PR TITLE
Continue adding logging

### DIFF
--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -55,11 +55,6 @@ const (
 	defaultBranchBaseRef = "HEAD^"
 )
 
-const (
-	defaultLogLevel = "none"
-	defaultLogFmt   = "text"
-)
-
 type cliSpec struct {
 	Version       struct{} `cmd:"" help:"Terramate version."`
 	Chdir         string   `short:"C" optional:"true" help:"sets working directory."`
@@ -441,7 +436,7 @@ func (c *cli) listStacks(mgr *terramate.Manager, isChanged bool) ([]terramate.En
 	if isChanged {
 		log.Trace().
 			Str("action", "listStacks()").
-			Str("stack", c.wd()).
+			Str("workingDir", c.wd()).
 			Msg("`Changed` flag was set. List changed stacks.")
 		return mgr.ListChanged()
 	}
@@ -454,12 +449,12 @@ func (c *cli) printStacks() {
 		Logger()
 
 	logger.Trace().
-		Str("stack", c.wd()).
+		Str("workingDir", c.wd()).
 		Msg("Create a new stack manager.")
 	mgr := terramate.NewManager(c.root(), c.prj.baseRef)
 
 	logger.Trace().
-		Str("stack", c.wd()).
+		Str("workingDir", c.wd()).
 		Msg("Get stack list.")
 	entries, err := c.listStacks(mgr, c.parsedArgs.Changed)
 	if err != nil {
@@ -468,7 +463,7 @@ func (c *cli) printStacks() {
 	}
 
 	logger.Trace().
-		Str("stack", c.wd()).
+		Str("workingDir", c.wd()).
 		Msg("Print stacks.")
 	for _, entry := range entries {
 		stack := entry.Stack
@@ -494,7 +489,7 @@ func (c *cli) generateGraph() {
 
 	logger := log.With().
 		Str("action", "generateGraph()").
-		Str("stack", c.wd()).
+		Str("workingDir", c.wd()).
 		Logger()
 
 	logger.Trace().
@@ -627,7 +622,7 @@ func generateDot(
 func (c *cli) printRunOrder() {
 	logger := log.With().
 		Str("action", "printRunOrder()").
-		Str("stack", c.wd()).
+		Str("workingDir", c.wd()).
 		Logger()
 
 	logger.Trace().
@@ -713,7 +708,7 @@ func (c *cli) printMetadata() {
 		Logger()
 
 	logger.Trace().
-		Str("stack", c.wd()).
+		Str("workingDir", c.wd()).
 		Msg("Load metadata.")
 	metadata, err := terramate.LoadMetadata(c.root())
 	if err != nil {
@@ -722,7 +717,7 @@ func (c *cli) printMetadata() {
 	}
 
 	logger.Trace().
-		Str("stack", c.wd()).
+		Str("workingDir", c.wd()).
 		Msg("Log metadata.")
 	c.log("Available metadata:")
 
@@ -739,7 +734,7 @@ func (c *cli) printMetadata() {
 func (c *cli) runOnStacks() {
 	logger := log.With().
 		Str("action", "runOnStacks()").
-		Str("stack", c.wd()).
+		Str("workingDir", c.wd()).
 		Logger()
 
 	logger.Trace().
@@ -883,7 +878,7 @@ func (c *cli) checkDefaultRemote(g *git.Git) error {
 func (c *cli) checkLocalDefaultIsUpdated(g *git.Git) error {
 	logger := log.With().
 		Str("action", "checkLocalDefaultIsUpdated()").
-		Str("stack", c.wd()).
+		Str("workingDir", c.wd()).
 		Logger()
 
 	logger.Trace().
@@ -940,7 +935,7 @@ func (c *cli) friendlyFmtDir(dir string) (string, bool) {
 func (c *cli) filterStacksByWorkingDir(stacks []terramate.Entry) []terramate.Entry {
 	logger := log.With().
 		Str("action", "filterStacksByWorkingDir()").
-		Str("stack", c.wd()).
+		Str("workingDir", c.wd()).
 		Logger()
 
 	logger.Trace().
@@ -986,7 +981,7 @@ func lookupProject(wd string) (prj project, found bool, err error) {
 
 	logger := log.With().
 		Str("action", "lookupProject()").
-		Str("stack", wd).
+		Str("workingDir", wd).
 		Logger()
 
 	logger.Trace().
@@ -1059,7 +1054,7 @@ func lookupProject(wd string) (prj project, found bool, err error) {
 func (p *project) setDefaults(parsedArgs *cliSpec) error {
 	logger := log.With().
 		Str("action", "setDefaults()").
-		Str("stack", p.wd).
+		Str("workingDir", p.wd).
 		Logger()
 
 	if p.rootcfg.Terramate == nil {

--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -55,6 +55,14 @@ const (
 	defaultBranchBaseRef = "HEAD^"
 )
 
+<<<<<<< HEAD
+=======
+const (
+	defaultLogLevel = "none"
+	defaultLogFmt   = "text"
+)
+
+>>>>>>> fix: change default logging fmt to text
 type cliSpec struct {
 	Version       struct{} `cmd:"" help:"Terramate version."`
 	Chdir         string   `short:"C" optional:"true" help:"sets working directory."`

--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -55,14 +55,11 @@ const (
 	defaultBranchBaseRef = "HEAD^"
 )
 
-<<<<<<< HEAD
-=======
 const (
 	defaultLogLevel = "none"
 	defaultLogFmt   = "text"
 )
 
->>>>>>> fix: change default logging fmt to text
 type cliSpec struct {
 	Version       struct{} `cmd:"" help:"Terramate version."`
 	Chdir         string   `short:"C" optional:"true" help:"sets working directory."`
@@ -216,15 +213,17 @@ func newCLI(
 			Msg("Getwd() failed")
 	}
 
+	logger = logger.With().
+		Str("workingDir", wd).
+		Logger()
+
 	if parsedArgs.Chdir != "" {
 		logger.Debug().
-			Str("wd", wd).
 			Str("dir", parsedArgs.Chdir).
 			Msg("Changing working directory")
 		err = os.Chdir(parsedArgs.Chdir)
 		if err != nil {
 			logger.Fatal().
-				Str("wd", wd).
 				Str("dir", parsedArgs.Chdir).
 				Err(err).
 				Msg("Changing working directory failed")
@@ -246,13 +245,11 @@ func newCLI(
 	}
 
 	logger.Trace().
-		Str("wd", wd).
 		Msg("Running in directory")
 
 	prj, foundRoot, err := lookupProject(wd)
 	if err != nil {
 		logger.Fatal().
-			Str("wd", wd).
 			Err(err).
 			Msg("failed to lookup project root")
 	}
@@ -295,7 +292,7 @@ func (c *cli) run() {
 
 	logger := log.With().
 		Str("action", "run()").
-		Str("stack", c.wd()).
+		Str("workingDir", c.wd()).
 		Logger()
 
 	if c.parsedArgs.Changed {
@@ -338,37 +335,31 @@ func (c *cli) run() {
 	case "plan graph":
 		log.Trace().
 			Str("actionContext", "cli()").
-			Str("stack", c.wd()).
 			Msg("Handle `plan graph`.")
 		c.generateGraph()
 	case "plan run-order":
 		log.Trace().
 			Str("actionContext", "cli()").
-			Str("stack", c.wd()).
 			Msg("Print run-order.")
 		c.printRunOrder()
 	case "stacks init":
 		log.Trace().
 			Str("actionContext", "cli()").
-			Str("stack", c.wd()).
 			Msg("Handle stacks init command.")
 		c.initStack([]string{c.wd()})
 	case "stacks list":
 		log.Trace().
 			Str("actionContext", "cli()").
-			Str("stack", c.wd()).
 			Msg("Print list of stacks.")
 		c.printStacks()
 	case "stacks init <paths>":
 		log.Trace().
 			Str("actionContext", "cli()").
-			Str("stack", c.wd()).
 			Msg("Handle stacks init <paths> command.")
 		c.initStack(c.parsedArgs.Stacks.Init.StackDirs)
 	case "stacks globals":
 		log.Trace().
 			Str("actionContext", "cli()").
-			Str("stack", c.wd()).
 			Msg("Handle stacks global command.")
 		c.printStacksGlobals()
 	case "run":

--- a/cmd/terramate/cli/cli_run_test.go
+++ b/cmd/terramate/cli/cli_run_test.go
@@ -413,7 +413,7 @@ func TestRunOrderNotChangedStackIgnored(t *testing.T) {
 		"--changed",
 		cat,
 		mainTfFileName,
-	), runExpected{Stdout: wantRun, IgnoreStderr: true})
+	), runExpected{Stdout: wantRun})
 
 	wantRun = mainTfContents
 
@@ -423,7 +423,7 @@ func TestRunOrderNotChangedStackIgnored(t *testing.T) {
 		"--changed",
 		cat,
 		mainTfFileName,
-	), runExpected{Stdout: wantRun, IgnoreStderr: true})
+	), runExpected{Stdout: wantRun})
 
 	cli = newCLI(t, stack2.Path())
 	assertRunResult(t, cli.run(
@@ -431,7 +431,7 @@ func TestRunOrderNotChangedStackIgnored(t *testing.T) {
 		"--changed",
 		cat,
 		mainTfFileName,
-	), runExpected{Stdout: "", IgnoreStderr: true})
+	), runExpected{Stdout: ""})
 }
 
 func TestRunOrderAllChangedStacksExecuted(t *testing.T) {
@@ -481,5 +481,5 @@ func TestRunOrderAllChangedStacksExecuted(t *testing.T) {
 		"--changed",
 		cat,
 		mainTfFileName,
-	), runExpected{Stdout: wantRun, IgnoreStderr: true})
+	), runExpected{Stdout: wantRun})
 }

--- a/cmd/terramate/cli/cli_runner_test.go
+++ b/cmd/terramate/cli/cli_runner_test.go
@@ -91,7 +91,7 @@ func (ts tscli) run(args ...string) runResult {
 func assertRun(t *testing.T, got runResult) {
 	t.Helper()
 
-	assertRunResult(t, got, runExpected{IgnoreStdout: true, IgnoreStderr: true})
+	assertRunResult(t, got, runExpected{})
 }
 
 func assertRunResult(t *testing.T, got runResult, want runExpected) {
@@ -115,7 +115,9 @@ func assertRunResult(t *testing.T, got runResult, want runExpected) {
 				)
 			}
 		} else {
-			assert.EqualStrings(t, wantStdout, stdout, "stdout mismatch")
+			if want.Stdout != "" {
+				assert.EqualStrings(t, wantStdout, stdout, "stdout mismatch")
+			}
 		}
 	}
 
@@ -131,7 +133,9 @@ func assertRunResult(t *testing.T, got runResult, want runExpected) {
 				)
 			}
 		} else {
-			assert.EqualStrings(t, want.Stderr, got.Stderr, "stderr mismatch")
+			if want.Stderr != "" {
+				assert.EqualStrings(t, want.Stderr, got.Stderr, "stderr mismatch")
+			}
 		}
 	}
 

--- a/cmd/terramate/cli/cli_test.go
+++ b/cmd/terramate/cli/cli_test.go
@@ -161,7 +161,7 @@ func TestListAndRunChangedStack(t *testing.T) {
 		"--changed",
 		cat,
 		mainTfFileName,
-	), runExpected{Stdout: wantRun, IgnoreStderr: true})
+	), runExpected{Stdout: wantRun})
 }
 
 func TestListAndRunChangedStackInAbsolutePath(t *testing.T) {
@@ -247,10 +247,7 @@ func TestDefaultBaseRefInMain(t *testing.T) {
 	git.Push("main")
 
 	// main uses HEAD^1 as default baseRef.
-	want := runExpected{
-		Stdout:       stack.RelPath() + "\n",
-		IgnoreStderr: true,
-	}
+	want := runExpected{Stdout: stack.RelPath() + "\n"}
 	assertRunResult(t, cli.run("stacks", "list", "--changed"), want)
 }
 
@@ -270,9 +267,7 @@ func TestBaseRefFlagPrecedenceOverDefault(t *testing.T) {
 
 	assertRunResult(t, cli.run("stacks", "list", "--changed",
 		"--git-change-base", "origin/main"),
-		runExpected{
-			IgnoreStderr: true,
-		},
+		runExpected{},
 	)
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -34,7 +34,7 @@ const (
 func Exists(path string) bool {
 	logger := log.With().
 		Str("action", "Exists()").
-		Str("stack", path).
+		Str("path", path).
 		Logger()
 
 	logger.Trace().
@@ -64,7 +64,7 @@ func Exists(path string) bool {
 func TryLoadRootConfig(dir string) (cfg hcl.Config, found bool, err error) {
 	logger := log.With().
 		Str("action", "TryLoadRootConfig()").
-		Str("stack", dir).
+		Str("path", dir).
 		Str("configFile", dir+Filename).
 		Logger()
 

--- a/dag/dag.go
+++ b/dag/dag.go
@@ -70,7 +70,8 @@ func (d *DAG) AddNode(id ID, value interface{}, before, after []ID) error {
 		}
 
 		logger.Trace().
-			Str("id", fmt.Sprintf("from `%s` to `%s`", bid, id)).
+			Str("from", bid).
+			Str("to", id).
 			Msg("Add edge.")
 		d.addEdge(bid, id)
 	}
@@ -92,7 +93,8 @@ func (d *DAG) addEdges(from ID, toids []ID) {
 	for _, to := range toids {
 		log.Trace().
 			Str("action", "addEdges()").
-			Str("id", fmt.Sprintf("from `%s` to `%s`", from, to)).
+			Str("from", from).
+			Str("to", to).
 			Msg("Add edges.")
 		d.addEdge(from, to)
 	}
@@ -107,7 +109,8 @@ func (d *DAG) addEdge(from, to ID) {
 	if !IDList(fromEdges).contains(to) {
 		log.Trace().
 			Str("action", "addEdge()").
-			Str("id", fmt.Sprintf("from `%s` to `%s`", from, to)).
+			Str("from", from).
+			Str("to", to).
 			Msg("Append edge.")
 		fromEdges = append(fromEdges, to)
 	}

--- a/dag/dag.go
+++ b/dag/dag.go
@@ -70,8 +70,8 @@ func (d *DAG) AddNode(id ID, value interface{}, before, after []ID) error {
 		}
 
 		logger.Trace().
-			Str("from", bid).
-			Str("to", id).
+			Str("from", string(bid)).
+			Str("to", string(id)).
 			Msg("Add edge.")
 		d.addEdge(bid, id)
 	}
@@ -93,8 +93,8 @@ func (d *DAG) addEdges(from ID, toids []ID) {
 	for _, to := range toids {
 		log.Trace().
 			Str("action", "addEdges()").
-			Str("from", from).
-			Str("to", to).
+			Str("from", string(from)).
+			Str("to", string(to)).
 			Msg("Add edges.")
 		d.addEdge(from, to)
 	}
@@ -109,8 +109,8 @@ func (d *DAG) addEdge(from, to ID) {
 	if !IDList(fromEdges).contains(to) {
 		log.Trace().
 			Str("action", "addEdge()").
-			Str("from", from).
-			Str("to", to).
+			Str("from", string(from)).
+			Str("to", string(to)).
 			Msg("Append edge.")
 		fromEdges = append(fromEdges, to)
 	}

--- a/exported_locals.go
+++ b/exported_locals.go
@@ -88,17 +88,18 @@ func loadStackExportedLocalExprs(rootdir string, cfgdir string) (exportedLocalEx
 		Msg("Get config file path.")
 	cfgpath := filepath.Join(rootdir, cfgdir, config.Filename)
 
-	logger.Debug().
+	logger = logger.With().
 		Str("configFile", cfgpath).
+		Logger()
+
+	logger.Debug().
 		Msg("Parse export as locals blocks.")
 	blocks, err := hcl.ParseExportAsLocalsBlocks(cfgpath)
 
 	logger.Trace().
-		Str("configFile", cfgpath).
 		Msg("Check if file exists.")
 	if os.IsNotExist(err) {
 		logger.Trace().
-			Str("configFile", cfgpath).
 			Msg("Get parent directory.")
 		parentcfg, ok := parentDir(cfgdir)
 		if !ok {
@@ -112,16 +113,13 @@ func loadStackExportedLocalExprs(rootdir string, cfgdir string) (exportedLocalEx
 	}
 
 	logger.Trace().
-		Str("configFile", cfgpath).
 		Msg("Get new exported local exprs.")
 	exportLocals := newExportedLocalExprs()
 
 	logger.Trace().
-		Str("configFile", cfgpath).
 		Msg("Range over blocks.")
 	for _, block := range blocks {
 		logger.Trace().
-			Str("configFile", cfgpath).
 			Msg("Range over block attributes.")
 		for name, attr := range block.Body.Attributes {
 			if exportLocals.has(name) {
@@ -137,7 +135,6 @@ func loadStackExportedLocalExprs(rootdir string, cfgdir string) (exportedLocalEx
 	}
 
 	logger.Trace().
-		Str("configFile", cfgpath).
 		Msg("Get parent config.")
 	parentcfg, ok := parentDir(cfgdir)
 	if !ok {
@@ -145,7 +142,6 @@ func loadStackExportedLocalExprs(rootdir string, cfgdir string) (exportedLocalEx
 	}
 
 	logger.Debug().
-		Str("configFile", parentcfg).
 		Msg("Get parent export locals.")
 	parentExportLocals, err := loadStackExportedLocalExprs(rootdir, parentcfg)
 	if err != nil {
@@ -153,7 +149,6 @@ func loadStackExportedLocalExprs(rootdir string, cfgdir string) (exportedLocalEx
 	}
 
 	logger.Trace().
-		Str("configFile", parentcfg).
 		Msg("Merge export locals with parent export locals.")
 	exportLocals.merge(parentExportLocals)
 	return exportLocals, nil

--- a/exported_locals.go
+++ b/exported_locals.go
@@ -24,6 +24,7 @@ import (
 	"github.com/mineiros-io/terramate/config"
 	"github.com/mineiros-io/terramate/hcl"
 	"github.com/mineiros-io/terramate/hcl/eval"
+	"github.com/rs/zerolog/log"
 	"github.com/zclconf/go-cty/cty"
 )
 
@@ -47,10 +48,21 @@ type ExportedLocalValues struct {
 //
 // The rootdir MUST be an absolute path.
 func LoadStackExportedLocals(rootdir string, sm StackMetadata, g *Globals) (ExportedLocalValues, error) {
+	logger := log.With().
+		Str("action", "LoadStackExportedLocals()").
+		Str("stack", sm.Path).
+		Logger()
+
+	logger.Trace().
+		Str("path", rootdir).
+		Msg("Get absolute file path of rootdir.")
 	if !filepath.IsAbs(rootdir) {
 		return ExportedLocalValues{}, fmt.Errorf("%q must be an absolute path", rootdir)
 	}
 
+	logger.Trace().
+		Str("path", rootdir).
+		Msg("Load stack exported locals exprs.")
 	localVars, err := loadStackExportedLocalExprs(rootdir, sm.Path)
 	if err != nil {
 		return ExportedLocalValues{}, err
@@ -67,10 +79,27 @@ func (e ExportedLocalValues) Attributes() map[string]cty.Value {
 }
 
 func loadStackExportedLocalExprs(rootdir string, cfgdir string) (exportedLocalExprs, error) {
+	logger := log.With().
+		Str("action", "loadStackExportedLocalExprs()").
+		Str("path", rootdir).
+		Logger()
+
+	logger.Trace().
+		Msg("Get config file path.")
 	cfgpath := filepath.Join(rootdir, cfgdir, config.Filename)
+
+	logger.Debug().
+		Str("configFile", cfgpath).
+		Msg("Parse export as locals blocks.")
 	blocks, err := hcl.ParseExportAsLocalsBlocks(cfgpath)
 
+	logger.Trace().
+		Str("configFile", cfgpath).
+		Msg("Check if file exists.")
 	if os.IsNotExist(err) {
+		logger.Trace().
+			Str("configFile", cfgpath).
+			Msg("Get parent directory.")
 		parentcfg, ok := parentDir(cfgdir)
 		if !ok {
 			return newExportedLocalExprs(), nil
@@ -82,9 +111,18 @@ func loadStackExportedLocalExprs(rootdir string, cfgdir string) (exportedLocalEx
 		return exportedLocalExprs{}, err
 	}
 
+	logger.Trace().
+		Str("configFile", cfgpath).
+		Msg("Get new exported local exprs.")
 	exportLocals := newExportedLocalExprs()
 
+	logger.Trace().
+		Str("configFile", cfgpath).
+		Msg("Range over blocks.")
 	for _, block := range blocks {
+		logger.Trace().
+			Str("configFile", cfgpath).
+			Msg("Range over block attributes.")
 		for name, attr := range block.Body.Attributes {
 			if exportLocals.has(name) {
 				return exportedLocalExprs{}, fmt.Errorf(
@@ -98,16 +136,25 @@ func loadStackExportedLocalExprs(rootdir string, cfgdir string) (exportedLocalEx
 		}
 	}
 
+	logger.Trace().
+		Str("configFile", cfgpath).
+		Msg("Get parent config.")
 	parentcfg, ok := parentDir(cfgdir)
 	if !ok {
 		return exportLocals, nil
 	}
 
+	logger.Debug().
+		Str("configFile", parentcfg).
+		Msg("Get parent export locals.")
 	parentExportLocals, err := loadStackExportedLocalExprs(rootdir, parentcfg)
 	if err != nil {
 		return exportedLocalExprs{}, err
 	}
 
+	logger.Trace().
+		Str("configFile", parentcfg).
+		Msg("Merge export locals with parent export locals.")
 	exportLocals.merge(parentExportLocals)
 	return exportLocals, nil
 }
@@ -133,12 +180,24 @@ func (r exportedLocalExprs) eval(meta StackMetadata, globals *Globals) (Exported
 	// FIXME(katcipis): get abs path for stack.
 	// This is relative only to root since meta.Path will look
 	// like: /some/path/relative/project/root
+
+	logger := log.With().
+		Str("action", "eval()").
+		Str("stack", meta.Path).
+		Logger()
+
+	logger.Trace().
+		Msg("Create new context.")
 	evalctx := eval.NewContext("." + meta.Path)
 
+	logger.Trace().
+		Msg("Add proper namespace for stack metadata evaluation.")
 	if err := meta.SetOnEvalCtx(evalctx); err != nil {
 		return ExportedLocalValues{}, fmt.Errorf("evaluating export_as_locals: setting terramate metadata namespace: %v", err)
 	}
 
+	logger.Trace().
+		Msg("Add proper namespace for globals evaluation.")
 	if err := globals.SetOnEvalCtx(evalctx); err != nil {
 		return ExportedLocalValues{}, fmt.Errorf("evaluating export_as_locals: setting terramate globals namespace: %v", err)
 	}
@@ -146,6 +205,8 @@ func (r exportedLocalExprs) eval(meta StackMetadata, globals *Globals) (Exported
 	var errs []error
 	exportAsLocals := newExportedLocalValues()
 
+	logger.Trace().
+		Msg("Range over exported locals expressions.")
 	for name, expr := range r.expressions {
 		val, err := evalctx.Eval(expr)
 		if err != nil {
@@ -156,6 +217,8 @@ func (r exportedLocalExprs) eval(meta StackMetadata, globals *Globals) (Exported
 	}
 
 	// TODO(katcipis): error reporting can be improved here.
+	logger.Trace().
+		Msg("Reduce errors to single error.")
 	err := errutil.Reduce(func(err1 error, err2 error) error {
 		return fmt.Errorf("%v,%v", err1, err2)
 	}, errs...)

--- a/generate/generate.go
+++ b/generate/generate.go
@@ -96,7 +96,7 @@ func Do(root string) error {
 		// Not the most optimized way (re-parsing), we can improve later
 
 		logger.Trace().
-			Msg("Get stack path.")
+			Msg("Get stack absolute path.")
 		stackpath := project.AbsPath(root, stackMetadata.Path)
 
 		logger.Debug().
@@ -179,7 +179,7 @@ func generateStackLocals(
 	}
 
 	logger.Trace().
-		Str("configFile", genfile).
+		Str("genfile", genfile).
 		Msg("Load stack exported locals.")
 	stackLocals, err := terramate.LoadStackExportedLocals(rootdir, metadata, globals)
 	if err != nil {
@@ -187,7 +187,7 @@ func generateStackLocals(
 	}
 
 	logger.Trace().
-		Str("configFile", genfile).
+		Str("genfile", genfile).
 		Msg("Get stack attributes.")
 	localsAttrs := stackLocals.Attributes()
 	if len(localsAttrs) == 0 {
@@ -240,7 +240,7 @@ func generateStackBackendConfig(root string, stackpath string, evalctx *eval.Con
 	}
 
 	logger.Debug().
-		Str("configFile", genfile).
+		Str("genfile", genfile).
 		Msg("Load stack backend config.")
 	tfcode, err := loadStackBackendConfig(root, stackpath, evalctx)
 	if err != nil {
@@ -410,7 +410,7 @@ func checkFileCanBeOverwritten(path string) error {
 	}
 
 	logger.Trace().
-		Msg("Convert data to string.")
+		Msg("Check if code has terramate header.")
 	code := string(data)
 	if !strings.HasPrefix(code, codeHeader) {
 		return fmt.Errorf("%w: at %q", ErrManualCodeExists, path)

--- a/git/git.go
+++ b/git/git.go
@@ -116,6 +116,7 @@ func NewConfig(username, email string) Config {
 func NewConfigWithPath(username, email, programPath string) Config {
 	log.Debug().
 		Str("action", "NewConfigWithPath()").
+		Str("path", programPath).
 		Msg("Make new config.")
 	config := NewConfig(username, email)
 	config.ProgramPath = programPath
@@ -131,7 +132,7 @@ func NewWrapper(user, email string) (*Git, error) {
 func WithConfig(cfg Config) (*Git, error) {
 	logger := log.With().
 		Str("action", "WithConfig()").
-		Str("stack", cfg.WorkingDir).
+		Str("workingDir", cfg.WorkingDir).
 		Logger()
 
 	logger.Trace().
@@ -163,7 +164,7 @@ func WithConfig(cfg Config) (*Git, error) {
 func (git *Git) applyDefaults() error {
 	logger := log.With().
 		Str("action", "applyDefaults()").
-		Str("stack", git.config.WorkingDir).
+		Str("workingDir", git.config.WorkingDir).
 		Logger()
 
 	cfg := &git.config
@@ -216,7 +217,7 @@ func (git *Git) validate() error {
 
 	logger := log.With().
 		Str("action", "validate()").
-		Str("stack", git.config.WorkingDir).
+		Str("workingDir", git.config.WorkingDir).
 		Logger()
 
 	logger.Trace().
@@ -239,7 +240,7 @@ func (git *Git) validate() error {
 func (git *Git) Version() (string, error) {
 	logger := log.With().
 		Str("action", "Version()").
-		Str("stack", git.config.WorkingDir).
+		Str("workingDir", git.config.WorkingDir).
 		Logger()
 
 	logger.Debug().
@@ -266,7 +267,7 @@ func (git *Git) Version() (string, error) {
 func (git *Git) Init(dir string, bare bool) error {
 	logger := log.With().
 		Str("action", "Init()").
-		Str("stack", git.config.WorkingDir).
+		Str("workingDir", git.config.WorkingDir).
 		Logger()
 
 	if !git.config.AllowPorcelain {
@@ -333,7 +334,7 @@ func (git *Git) Remotes() ([]Remote, error) {
 
 	logger := log.With().
 		Str("action", "Remotes()").
-		Str("stack", git.config.WorkingDir).
+		Str("workingDir", git.config.WorkingDir).
 		Logger()
 
 	logger.Trace().
@@ -392,7 +393,7 @@ func (git *Git) Remotes() ([]Remote, error) {
 func (git *Git) LogSummary(revs ...string) ([]LogLine, error) {
 	logger := log.With().
 		Str("action", "LogSummary()").
-		Str("stack", git.config.WorkingDir).
+		Str("workingDir", git.config.WorkingDir).
 		Logger()
 
 	if len(revs) == 0 {
@@ -450,7 +451,7 @@ func (git *Git) Add(files ...string) error {
 
 	log.Debug().
 		Str("action", "Add()").
-		Str("stack", git.config.WorkingDir).
+		Str("workingDir", git.config.WorkingDir).
 		Msg("Add file to current staged index.")
 	_, err := git.exec("add", files...)
 	return err
@@ -462,7 +463,7 @@ func (git *Git) Add(files ...string) error {
 func (git *Git) Commit(msg string, args ...string) error {
 	logger := log.With().
 		Str("action", "Commit()").
-		Str("stack", git.config.WorkingDir).
+		Str("workingDir", git.config.WorkingDir).
 		Logger()
 
 	if !git.config.AllowPorcelain {
@@ -502,7 +503,7 @@ func (git *Git) RevParse(rev string) (string, error) {
 func (git *Git) FetchRemoteRev(remote, ref string) (Ref, error) {
 	logger := log.With().
 		Str("action", "FetchRemoteRev()").
-		Str("stack", git.config.WorkingDir).
+		Str("workingDir", git.config.WorkingDir).
 		Logger()
 
 	logger.Debug().
@@ -553,7 +554,7 @@ func (git *Git) Status() (string, error) {
 func (git *Git) DiffTree(from, to string, relative, nameOnly, recurse bool) (string, error) {
 	logger := log.With().
 		Str("action", "DiffTree()").
-		Str("stack", git.config.WorkingDir).
+		Str("workingDir", git.config.WorkingDir).
 		Logger()
 
 	args := []string{from, to}
@@ -585,7 +586,7 @@ func (git *Git) DiffTree(from, to string, relative, nameOnly, recurse bool) (str
 func (git *Git) DiffNames(from, to string) ([]string, error) {
 	log.Trace().
 		Str("action", "DiffNames()").
-		Str("stack", git.config.WorkingDir).
+		Str("workingDir", git.config.WorkingDir).
 		Str("reference", fmt.Sprintf("from `%s` to `%s`", from, to)).
 		Msg("Get tree differences.")
 	diff, err := git.DiffTree(from, to, true, true, true)
@@ -600,7 +601,7 @@ func (git *Git) DiffNames(from, to string) ([]string, error) {
 func (git *Git) NewBranch(name string) error {
 	log.Trace().
 		Str("action", "NewBranch()").
-		Str("stack", git.config.WorkingDir).
+		Str("workingDir", git.config.WorkingDir).
 		Str("reference", name).
 		Msg("Get commit ID.")
 	_, err := git.RevParse(name)
@@ -610,7 +611,7 @@ func (git *Git) NewBranch(name string) error {
 
 	log.Debug().
 		Str("action", "NewBranch()").
-		Str("stack", git.config.WorkingDir).
+		Str("workingDir", git.config.WorkingDir).
 		Str("reference", name).
 		Msg("Create new branch.")
 	_, err = git.exec("update-ref", "refs/heads/"+name, "HEAD")
@@ -621,7 +622,7 @@ func (git *Git) NewBranch(name string) error {
 func (git *Git) DeleteBranch(name string) error {
 	log.Trace().
 		Str("action", "DeleteBranch()").
-		Str("stack", git.config.WorkingDir).
+		Str("workingDir", git.config.WorkingDir).
 		Str("reference", name).
 		Msg("Get commit ID.")
 	_, err := git.RevParse(name)
@@ -631,7 +632,7 @@ func (git *Git) DeleteBranch(name string) error {
 
 	log.Debug().
 		Str("action", "DeleteBranch()").
-		Str("stack", git.config.WorkingDir).
+		Str("workingDir", git.config.WorkingDir).
 		Str("reference", name).
 		Msg("Delete branch.")
 	_, err = git.exec("update-ref", "-d", "refs/heads/"+name)
@@ -650,7 +651,7 @@ func (git *Git) Checkout(rev string, create bool) error {
 	if create {
 		log.Trace().
 			Str("action", "Checkout()").
-			Str("stack", git.config.WorkingDir).
+			Str("workingDir", git.config.WorkingDir).
 			Str("reference", rev).
 			Msg("Create new branch.")
 		err := git.NewBranch(rev)
@@ -661,7 +662,7 @@ func (git *Git) Checkout(rev string, create bool) error {
 
 	log.Debug().
 		Str("action", "Checkout()").
-		Str("stack", git.config.WorkingDir).
+		Str("workingDir", git.config.WorkingDir).
 		Str("reference", rev).
 		Msg("Checkout.")
 	_, err := git.exec("checkout", rev)
@@ -678,7 +679,7 @@ func (git *Git) Merge(branch string) error {
 
 	log.Debug().
 		Str("action", "Merge()").
-		Str("stack", git.config.WorkingDir).
+		Str("workingDir", git.config.WorkingDir).
 		Str("reference", branch).
 		Msg("Merge.")
 	_, err := git.exec("merge", "--no-ff", branch)
@@ -693,7 +694,7 @@ func (git *Git) Push(remote, branch string) error {
 
 	log.Debug().
 		Str("action", "Push()").
-		Str("stack", git.config.WorkingDir).
+		Str("workingDir", git.config.WorkingDir).
 		Str("reference", fmt.Sprintf("from `%s` to `%s`", branch, remote)).
 		Msg("Git push.")
 	_, err := git.exec("push", remote, branch)
@@ -708,7 +709,7 @@ func (git *Git) Pull(remote, branch string) error {
 
 	log.Debug().
 		Str("action", "Pull()").
-		Str("stack", git.config.WorkingDir).
+		Str("workingDir", git.config.WorkingDir).
 		Str("reference", fmt.Sprintf("from `%s` to `%s`", remote, branch)).
 		Msg("Git pull.")
 	_, err := git.exec("pull", remote, branch)
@@ -725,7 +726,7 @@ func (git *Git) FFMerge(branch string) error {
 
 	log.Debug().
 		Str("action", "FFMerge()").
-		Str("stack", git.config.WorkingDir).
+		Str("workingDir", git.config.WorkingDir).
 		Str("reference", branch).
 		Msg("Fast forward merge branch.")
 	_, err := git.exec("merge", "--ff", branch)
@@ -745,7 +746,7 @@ func (git *Git) ListUntracked(dirs ...string) ([]string, error) {
 
 	log.Debug().
 		Str("action", "ListUntracked()").
-		Str("stack", git.config.WorkingDir).
+		Str("workingDir", git.config.WorkingDir).
 		Msg("List untracked files.")
 	out, err := git.exec("ls-files", args...)
 	if err != nil {
@@ -769,7 +770,7 @@ func (git *Git) ListUncommitted(dirs ...string) ([]string, error) {
 
 	log.Debug().
 		Str("action", "ListUncommitted()").
-		Str("stack", git.config.WorkingDir).
+		Str("workingDir", git.config.WorkingDir).
 		Msg("List uncommitted files.")
 	out, err := git.exec("ls-files", args...)
 	if err != nil {
@@ -808,7 +809,7 @@ func (git *Git) CurrentBranch() (string, error) {
 func (git *Git) exec(command string, args ...string) (string, error) {
 	logger := log.With().
 		Str("action", "exec()").
-		Str("stack", git.config.WorkingDir).
+		Str("workingDir", git.config.WorkingDir).
 		Logger()
 
 	logger.Trace().

--- a/globals.go
+++ b/globals.go
@@ -25,6 +25,7 @@ import (
 	"github.com/mineiros-io/terramate/config"
 	"github.com/mineiros-io/terramate/hcl"
 	"github.com/mineiros-io/terramate/hcl/eval"
+	"github.com/rs/zerolog/log"
 	"github.com/zclconf/go-cty/cty"
 )
 
@@ -45,10 +46,17 @@ const ErrGlobalRedefined errutil.Error = "global redefined"
 // Metadata for the stack is used on the evaluation of globals, defined on stackmeta.
 // The rootdir MUST be an absolute path.
 func LoadStackGlobals(rootdir string, meta StackMetadata) (*Globals, error) {
+	logger := log.With().
+		Str("action", "LoadStackGlobals()").
+		Str("stack", meta.Path).
+		Logger()
+
 	if !filepath.IsAbs(rootdir) {
 		return nil, fmt.Errorf("%q is not absolute path", rootdir)
 	}
 
+	logger.Debug().
+		Msg("Load stack globals.")
 	unEvalGlobals, err := loadStackGlobals(rootdir, meta.Path)
 	if err != nil {
 		return nil, err
@@ -102,14 +110,26 @@ func (r *rawGlobals) eval(meta StackMetadata) (*Globals, error) {
 	// FIXME(katcipis): get abs path for stack.
 	// This is relative only to root since meta.Path will look
 	// like: /some/path/relative/project/root
+	logger := log.With().
+		Str("action", "eval()").
+		Str("stack", meta.Path).
+		Logger()
+
+	logger.Trace().
+		Msg("Create new evaluation context.")
 	evalctx := eval.NewContext("." + meta.Path)
 
+	logger.Trace().
+		Msg("Add proper name space for stack metadata evaluation.")
 	if err := meta.SetOnEvalCtx(evalctx); err != nil {
 		return nil, err
 	}
 
 	globals := newGlobals()
 	// error messages improve if globals is empty instead of undefined
+
+	logger.Trace().
+		Msg("Add proper name space for globals evaluation.")
 	if err := globals.SetOnEvalCtx(evalctx); err != nil {
 		return nil, fmt.Errorf("initializing global eval: %v", err)
 	}
@@ -122,10 +142,14 @@ func (r *rawGlobals) eval(meta StackMetadata) (*Globals, error) {
 	for len(pendingExprs) > 0 {
 		amountEvaluated := 0
 
+		logger.Trace().
+			Msg("Range pending expressions.")
 	pendingExpression:
 		for name, expr := range pendingExprs {
 			vars := hclsyntax.Variables(expr)
 
+			logger.Trace().
+				Msg("Range vars.")
 			for _, namespace := range vars {
 				if _, ok := hclctx.Variables[namespace.RootName()]; !ok {
 					return nil, fmt.Errorf("unknown variable namespace: %s - %s", namespace.RootName(), namespace.SourceRange())
@@ -149,6 +173,8 @@ func (r *rawGlobals) eval(meta StackMetadata) (*Globals, error) {
 				}
 			}
 
+			logger.Trace().
+				Msg("Evaluate expression.")
 			val, err := evalctx.Eval(expr)
 			if err != nil {
 				errs = append(errs, err)
@@ -157,8 +183,13 @@ func (r *rawGlobals) eval(meta StackMetadata) (*Globals, error) {
 
 			globals.attributes[name] = val
 			amountEvaluated += 1
+
+			logger.Trace().
+				Msg("Delete pending expression.")
 			delete(pendingExprs, name)
 
+			logger.Trace().
+				Msg("Try add proper namespace for globals evaluation context.")
 			if err := globals.SetOnEvalCtx(evalctx); err != nil {
 				return nil, fmt.Errorf("evaluating globals: %v", err)
 			}
@@ -176,6 +207,8 @@ func (r *rawGlobals) eval(meta StackMetadata) (*Globals, error) {
 		return nil, fmt.Errorf("could not resolve all globals")
 	}
 
+	logger.Trace().
+		Msg("Reduce multiple errors into one.")
 	err := errutil.Reduce(func(err1 error, err2 error) error {
 		return fmt.Errorf("%v,%v", err1, err2)
 	}, errs...)
@@ -194,9 +227,22 @@ func newRawGlobals() *rawGlobals {
 }
 
 func loadStackGlobals(rootdir string, cfgdir string) (*rawGlobals, error) {
+	logger := log.With().
+		Str("action", "loadStackGlobals()").
+		Logger()
+
+	logger.Trace().
+		Msg("Get config file path.")
 	cfgpath := filepath.Join(rootdir, cfgdir, config.Filename)
+
+	logger.Debug().
+		Str("configFile", cfgpath).
+		Msg("Parse globals blocks.")
 	blocks, err := hcl.ParseGlobalsBlocks(cfgpath)
 
+	logger.Trace().
+		Str("configFile", cfgpath).
+		Msg("Check if config file exists.")
 	if os.IsNotExist(err) {
 		parentcfg, ok := parentDir(cfgdir)
 		if !ok {
@@ -211,11 +257,20 @@ func loadStackGlobals(rootdir string, cfgdir string) (*rawGlobals, error) {
 
 	globals := newRawGlobals()
 
+	logger.Trace().
+		Str("configFile", cfgpath).
+		Msg("Range over blocks.")
 	for _, block := range blocks {
+		logger.Trace().
+			Str("configFile", cfgpath).
+			Msg("Range over block attributes.")
 		for name, attr := range block.Body.Attributes {
 			if globals.has(name) {
 				return nil, fmt.Errorf("%w: global %q already defined in configuration %q", ErrGlobalRedefined, name, cfgpath)
 			}
+			logger.Trace().
+				Str("configFile", cfgpath).
+				Msg("Add attribute to globals.")
 			globals.add(name, attr.Expr)
 		}
 	}

--- a/globals.go
+++ b/globals.go
@@ -235,13 +235,15 @@ func loadStackGlobals(rootdir string, cfgdir string) (*rawGlobals, error) {
 		Msg("Get config file path.")
 	cfgpath := filepath.Join(rootdir, cfgdir, config.Filename)
 
-	logger.Debug().
+	logger = logger.With().
 		Str("configFile", cfgpath).
+		Logger()
+
+	logger.Debug().
 		Msg("Parse globals blocks.")
 	blocks, err := hcl.ParseGlobalsBlocks(cfgpath)
 
 	logger.Trace().
-		Str("configFile", cfgpath).
 		Msg("Check if config file exists.")
 	if os.IsNotExist(err) {
 		parentcfg, ok := parentDir(cfgdir)
@@ -258,18 +260,15 @@ func loadStackGlobals(rootdir string, cfgdir string) (*rawGlobals, error) {
 	globals := newRawGlobals()
 
 	logger.Trace().
-		Str("configFile", cfgpath).
 		Msg("Range over blocks.")
 	for _, block := range blocks {
 		logger.Trace().
-			Str("configFile", cfgpath).
 			Msg("Range over block attributes.")
 		for name, attr := range block.Body.Attributes {
 			if globals.has(name) {
 				return nil, fmt.Errorf("%w: global %q already defined in configuration %q", ErrGlobalRedefined, name, cfgpath)
 			}
 			logger.Trace().
-				Str("configFile", cfgpath).
 				Msg("Add attribute to globals.")
 			globals.add(name, attr.Expr)
 		}

--- a/hcl/eval/eval.go
+++ b/hcl/eval/eval.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/rs/zerolog/log"
 	"github.com/zclconf/go-cty/cty"
 	"github.com/zclconf/go-cty/cty/gocty"
 
@@ -51,6 +52,12 @@ func (c *Context) GetHCLContext() *hhcl.EvalContext {
 // SetNamespace will set the given values inside the given namespace on the
 // evaluation context.
 func (c *Context) SetNamespace(name string, vals map[string]cty.Value) error {
+	logger := log.With().
+		Str("action", "SetNamespace()").
+		Logger()
+
+	logger.Trace().
+		Msg("Convert from map to object.")
 	obj, err := fromMapToObject(vals)
 	if err != nil {
 		return fmt.Errorf("setting namespace %q:%v", name, err)
@@ -69,10 +76,19 @@ func (c *Context) Eval(expr hclsyntax.Expression) (cty.Value, error) {
 }
 
 func fromMapToObject(m map[string]cty.Value) (cty.Value, error) {
+	logger := log.With().
+		Str("action", "fromMapToObject()").
+		Logger()
+
+	logger.Trace().
+		Msg("Range over map.")
 	ctyTypes := map[string]cty.Type{}
 	for key, value := range m {
 		ctyTypes[key] = value.Type()
 	}
+
+	logger.Trace().
+		Msg("Convert type and value to object.")
 	ctyObject := cty.Object(ctyTypes)
 	ctyVal, err := gocty.ToCtyValue(m, ctyObject)
 	if err != nil {

--- a/hcl/formatter.go
+++ b/hcl/formatter.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/rs/zerolog/log"
 	"github.com/zclconf/go-cty/cty"
 )
 
@@ -31,6 +32,12 @@ func FormatAttributes(attrs map[string]cty.Value) string {
 		return ""
 	}
 
+	logger := log.With().
+		Str("action", "FormatAttributes()").
+		Logger()
+
+	logger.Trace().
+		Msg("Create empty hcl file.")
 	f := hclwrite.NewEmptyFile()
 	body := f.Body()
 	sortedAttrNames := make([]string, 0, len(attrs))
@@ -39,8 +46,12 @@ func FormatAttributes(attrs map[string]cty.Value) string {
 		sortedAttrNames = append(sortedAttrNames, name)
 	}
 
+	logger.Trace().
+		Msg("Sort attributes.")
 	sort.Strings(sortedAttrNames)
 
+	logger.Trace().
+		Msg("Set attribute values.")
 	for _, name := range sortedAttrNames {
 		body.SetAttributeValue(name, attrs[name])
 	}

--- a/hcl/hcl.go
+++ b/hcl/hcl.go
@@ -281,7 +281,7 @@ func Parse(fname string, data []byte) (Config, error) {
 			switch name {
 			case "required_version":
 				logger.Trace().
-					Msg("Attribute name was 'required_version'.")
+					Msg("Parsing  attribute 'required_version'.")
 				if attrVal.Type() != cty.String {
 					return Config{}, errutil.Chain(
 						ErrMalformedTerramateConfig,
@@ -307,7 +307,7 @@ func Parse(fname string, data []byte) (Config, error) {
 			switch block.Type {
 			case "backend":
 				logger.Trace().
-					Msg("Block type was backend.")
+					Msg("Parsing backend block.")
 				if foundBackend {
 					return Config{}, errutil.Chain(
 						ErrMalformedTerramateConfig,
@@ -328,7 +328,7 @@ func Parse(fname string, data []byte) (Config, error) {
 
 			case "config":
 				logger.Trace().
-					Msg("Block type was config.")
+					Msg("Found config block.")
 				if foundConfig {
 					return Config{}, errutil.Chain(
 						ErrMalformedTerramateConfig,

--- a/hcl/printer.go
+++ b/hcl/printer.go
@@ -18,14 +18,24 @@ import (
 	"io"
 
 	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/rs/zerolog/log"
 	"github.com/zclconf/go-cty/cty"
 )
 
 func PrintConfig(w io.Writer, cfg Config) error {
+	logger := log.With().
+		Str("action", "PrintConfig()").
+		Str("stack", cfg.Stack.Name).
+		Logger()
+
+	logger.Trace().
+		Msg("Create empty hcl file.")
 	f := hclwrite.NewEmptyFile()
 	rootBody := f.Body()
 
 	if cfg.Terramate != nil {
+		logger.Trace().
+			Msg("Append terramate block.")
 		tm := cfg.Terramate
 		tmBlock := rootBody.AppendNewBlock("terramate", nil)
 		tmBody := tmBlock.Body()
@@ -37,6 +47,8 @@ func PrintConfig(w io.Writer, cfg Config) error {
 	}
 
 	if cfg.Stack != nil {
+		logger.Trace().
+			Msg("Append 'stack' block.")
 		stack := cfg.Stack
 		stackBlock := rootBody.AppendNewBlock("stack", nil)
 		stackBody := stackBlock.Body()
@@ -50,6 +62,8 @@ func PrintConfig(w io.Writer, cfg Config) error {
 		}
 	}
 
+	logger.Trace().
+		Msg("Write to output.")
 	_, err := w.Write(f.Bytes())
 	return err
 }

--- a/hcl/printer.go
+++ b/hcl/printer.go
@@ -62,7 +62,7 @@ func PrintConfig(w io.Writer, cfg Config) error {
 		}
 	}
 
-	logger.Trace().
+	logger.Debug().
 		Msg("Write to output.")
 	_, err := w.Write(f.Bytes())
 	return err

--- a/list.go
+++ b/list.go
@@ -20,13 +20,21 @@ import (
 	"path/filepath"
 
 	"github.com/mineiros-io/terramate/stack"
+	"github.com/rs/zerolog/log"
 )
 
 // ListStacks walks the project's root directory looking for terraform stacks.
 // It returns a lexicographic sorted list of stack directories.
 func ListStacks(root string) ([]Entry, error) {
+	logger := log.With().
+		Str("action", "ListStacks()").
+		Str("path", root).
+		Logger()
+
 	entries := []Entry{}
 
+	logger.Trace().
+		Msg("Walk path.")
 	err := filepath.Walk(
 		root,
 		func(path string, info fs.FileInfo, err error) error {
@@ -34,12 +42,18 @@ func ListStacks(root string) ([]Entry, error) {
 				return err
 			}
 
+			logger.Trace().
+				Str("stack", path).
+				Msg("Try load stack.")
 			stack, found, err := stack.TryLoad(root, path)
 			if err != nil {
 				return fmt.Errorf("listing stacks: %w", err)
 			}
 
 			if found {
+				logger.Debug().
+					Str("stack", stack.Dir).
+					Msg("Found stack.")
 				entries = append(entries, Entry{Stack: stack})
 			}
 

--- a/manager.go
+++ b/manager.go
@@ -26,7 +26,6 @@ import (
 	"github.com/mineiros-io/terramate/git"
 	"github.com/mineiros-io/terramate/hcl"
 	"github.com/mineiros-io/terramate/stack"
-
 	"github.com/rs/zerolog/log"
 )
 
@@ -68,20 +67,38 @@ func (m *Manager) List() ([]Entry, error) {
 // It's an error to call this method in a directory that's not
 // inside a repository or a repository with no commits in it.
 func (m *Manager) ListChanged() ([]Entry, error) {
+	logger := log.With().
+		Str("action", "ListChanged()").
+		Logger()
+
+	logger.Debug().
+		Msg("List changed files.")
 	files, err := listChangedFiles(m.root, m.gitBaseRef)
 	if err != nil {
 		return nil, err
 	}
 
 	stackSet := map[string]Entry{}
+
+	logger.Trace().
+		Msg("Range over files.")
 	for _, path := range files {
+		logger.Trace().
+			Msg("Get dir name.")
 		dirname := filepath.Dir(filepath.Join(m.root, path))
+
+		logger.Debug().
+			Str("path", dirname).
+			Msg("Try load changed.")
 		s, found, err := m.stackLoader.TryLoadChanged(m.root, dirname)
 		if err != nil {
 			return nil, fmt.Errorf("listing changed files: %w", err)
 		}
 
 		if !found {
+			logger.Debug().
+				Str("path", dirname).
+				Msg("Lookup parent stack.")
 			s, found, err = stack.LookupParent(m.root, dirname)
 			if err != nil {
 				return nil, fmt.Errorf("listing changed files: %w", err)
@@ -98,38 +115,73 @@ func (m *Manager) ListChanged() ([]Entry, error) {
 		}
 	}
 
+	logger.Debug().
+		Msg("Get list of all stacks.")
 	allstacks, err := m.List()
 	if err != nil {
 		return nil, fmt.Errorf("searching for stacks: %v", err)
 	}
 
+	logger.Trace().
+		Msg("Range over all stacks.")
 	for _, stackEntry := range allstacks {
 		stack := stackEntry.Stack
 		if _, ok := stackSet[stack.Dir]; ok {
 			continue
 		}
 
+		logger.Trace().
+			Str("stack", stack.Dir).
+			Msg("Get absolute path of stack.")
 		abspath := filepath.Join(m.root, stack.Dir)
+
+		logger.Debug().
+			Str("stack", abspath).
+			Msg("Apply function to stack.")
 		err := m.filesApply(abspath, func(file fs.DirEntry) error {
 			if path.Ext(file.Name()) != ".tf" {
 				return nil
 			}
 
+			logger.Trace().
+				Str("stack", stack.Dir).
+				Msg("Get absolute path of stack.")
 			abspath := filepath.Join(m.root, stack.Dir)
+
+			logger.Debug().
+				Str("stack", abspath).
+				Msg("Get tf file path.")
 			tfpath := filepath.Join(abspath, file.Name())
+
+			logger.Trace().
+				Str("stack", abspath).
+				Str("configFile", tfpath).
+				Msg("Parse modules.")
 			modules, err := hcl.ParseModules(tfpath)
 			if err != nil {
 				return fmt.Errorf("parsing modules at %q: %w",
 					file.Name(), err)
 			}
 
+			logger.Trace().
+				Str("stack", abspath).
+				Str("configFile", tfpath).
+				Msg("Range over modules.")
 			for _, mod := range modules {
+				logger.Trace().
+					Str("stack", abspath).
+					Str("configFile", tfpath).
+					Msg("Check if module changed.")
 				changed, why, err := m.moduleChanged(mod, abspath, make(map[string]bool))
 				if err != nil {
 					return fmt.Errorf("checking module %q: %w", mod.Source, err)
 				}
 
 				if changed {
+					logger.Debug().
+						Str("stack", abspath).
+						Str("configFile", tfpath).
+						Msg("Module changed.")
 					stackSet[stack.Dir] = Entry{
 						Stack:  stack,
 						Reason: fmt.Sprintf("stack changed because %q changed because %s", mod.Source, why),
@@ -145,26 +197,41 @@ func (m *Manager) ListChanged() ([]Entry, error) {
 		}
 	}
 
+	logger.Trace().
+		Msg("Make set of changed stacks.")
 	changedStacks := make([]Entry, 0, len(stackSet))
 	for _, stack := range stackSet {
 		changedStacks = append(changedStacks, stack)
 	}
 
+	logger.Trace().
+		Msg("Sort changed stacks.")
 	sort.Sort(EntrySlice(changedStacks))
 	return changedStacks, nil
 }
 
 func (m *Manager) filesApply(dir string, apply func(file fs.DirEntry) error) error {
+	logger := log.With().
+		Str("action", "filesApply()").
+		Str("path", dir).
+		Logger()
+
+	logger.Debug().
+		Msg("Read dir.")
 	files, err := os.ReadDir(dir)
 	if err != nil {
 		return fmt.Errorf("listing files of directory %q: %w", dir, err)
 	}
 
+	logger.Trace().
+		Msg("Range files in dir.")
 	for _, file := range files {
 		if file.IsDir() {
 			continue
 		}
 
+		logger.Debug().
+			Msg("Apply function to file.")
 		err := apply(file)
 		if err != nil {
 			return fmt.Errorf("applying operation to file %q: %w", file, err)
@@ -176,15 +243,26 @@ func (m *Manager) filesApply(dir string, apply func(file fs.DirEntry) error) err
 
 // listChangedFiles lists all changed files in the dir directory.
 func listChangedFiles(dir string, gitBaseRef string) ([]string, error) {
+	logger := log.With().
+		Str("action", "listChangedFiles()").
+		Str("path", dir).
+		Logger()
+
+	logger.Trace().
+		Msg("Get dir info.")
 	st, err := os.Stat(dir)
 	if err != nil {
 		return nil, fmt.Errorf("stat failed on %q: %w", dir, err)
 	}
 
+	logger.Trace().
+		Msg("Check if path is dir.")
 	if !st.IsDir() {
 		return nil, fmt.Errorf("is not a directory")
 	}
 
+	logger.Trace().
+		Msg("Create git wrapper with dir.")
 	g, err := git.WithConfig(git.Config{
 		WorkingDir: dir,
 	})
@@ -192,15 +270,21 @@ func listChangedFiles(dir string, gitBaseRef string) ([]string, error) {
 		return nil, err
 	}
 
+	logger.Trace().
+		Msg("Check if path is git repo.")
 	if !g.IsRepository() {
 		return nil, fmt.Errorf("the path \"%s\" is not a git repository", dir)
 	}
 
+	logger.Debug().
+		Msg("Get list of untracked files.")
 	untracked, err := g.ListUntracked()
 	if err != nil {
 		return nil, fmt.Errorf("listing untracked files: %v", err)
 	}
 
+	logger.Debug().
+		Msg("Get list of uncommitted files in dir.")
 	uncommitted, err := g.ListUncommitted()
 	if err != nil {
 		return nil, fmt.Errorf("listing uncommitted files: %v", err)
@@ -224,11 +308,15 @@ func listChangedFiles(dir string, gitBaseRef string) ([]string, error) {
 		return nil, errors.New("git status is not clean")
 	}
 
+	logger.Trace().
+		Msg("Get commit id of git base ref.")
 	baseRef, err := g.RevParse(gitBaseRef)
 	if err != nil {
 		return nil, fmt.Errorf("getting revision %q: %w", gitBaseRef, err)
 	}
 
+	logger.Trace().
+		Msg("Get commit id of HEAD.")
 	headRef, err := g.RevParse("HEAD")
 	if err != nil {
 		return nil, fmt.Errorf("getting HEAD revision: %w", err)
@@ -238,6 +326,8 @@ func listChangedFiles(dir string, gitBaseRef string) ([]string, error) {
 		return []string{}, nil
 	}
 
+	logger.Trace().
+		Msg("Find common commit ancestor of HEAd and base ref.")
 	mergeBaseRef, err := g.MergeBase("HEAD", baseRef)
 	if err != nil {
 		return nil, fmt.Errorf("getting merge-base HEAD main: %w", err)
@@ -258,10 +348,17 @@ func listChangedFiles(dir string, gitBaseRef string) ([]string, error) {
 func (m *Manager) moduleChanged(
 	mod hcl.Module, basedir string, visited map[string]bool,
 ) (changed bool, why string, err error) {
+	logger := log.With().
+		Str("action", "moduleChanged()").
+		Logger()
+
 	if _, ok := visited[mod.Source]; ok {
 		return false, "", nil
 	}
 
+	logger.Trace().
+		Str("path", basedir).
+		Msg("Check if module source is local directory.")
 	if !mod.IsLocal() {
 		// if the source is a remote path (URL, VCS path, S3 bucket, etc) then
 		// we assume it's not changed.
@@ -269,7 +366,14 @@ func (m *Manager) moduleChanged(
 		return false, "", nil
 	}
 
+	logger.Trace().
+		Str("path", basedir).
+		Msg("Get module path.")
 	modPath := filepath.Join(basedir, mod.Source)
+
+	logger.Trace().
+		Str("path", modPath).
+		Msg("Get module path info.")
 	st, err := os.Stat(modPath)
 
 	// TODO(i4k): resolve symlinks
@@ -278,6 +382,9 @@ func (m *Manager) moduleChanged(
 		return false, "", fmt.Errorf("\"source\" path %q is not a directory", modPath)
 	}
 
+	logger.Debug().
+		Str("path", modPath).
+		Msg("Get list of changed files.")
 	changedFiles, err := listChangedFiles(modPath, m.gitBaseRef)
 	if err != nil {
 		return false, "", fmt.Errorf("listing changes in the module %q: %w",
@@ -289,6 +396,10 @@ func (m *Manager) moduleChanged(
 	}
 
 	visited[mod.Source] = true
+
+	logger.Debug().
+		Str("path", modPath).
+		Msg("Apply function to files in path.")
 	err = m.filesApply(modPath, func(file fs.DirEntry) error {
 		if changed {
 			return nil
@@ -297,19 +408,32 @@ func (m *Manager) moduleChanged(
 			return nil
 		}
 
+		logger.Trace().
+			Str("path", modPath).
+			Msg("Parse modules.")
 		modules, err := hcl.ParseModules(filepath.Join(modPath, file.Name()))
 		if err != nil {
 			return fmt.Errorf("parsing module %q: %w", mod.Source, err)
 		}
 
+		logger.Trace().
+			Str("path", modPath).
+			Msg("Range over modules.")
 		for _, mod2 := range modules {
 			var reason string
+
+			logger.Trace().
+				Str("path", modPath).
+				Msg("Get if module is changed.")
 			changed, reason, err = m.moduleChanged(mod2, modPath, visited)
 			if err != nil {
 				return err
 			}
 
 			if changed {
+				logger.Trace().
+					Str("path", modPath).
+					Msg("Module was changed.")
 				why = fmt.Sprintf("%s%s changed because %s ", why, mod.Source,
 					reason)
 				return nil

--- a/metadata.go
+++ b/metadata.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 
 	"github.com/mineiros-io/terramate/hcl/eval"
+	"github.com/rs/zerolog/log"
 	"github.com/zclconf/go-cty/cty"
 )
 
@@ -37,11 +38,20 @@ type Metadata struct {
 
 // LoadMetadata loads the project metadata given the project basedir.
 func LoadMetadata(basedir string) (Metadata, error) {
+	logger := log.With().
+		Str("action", "LoadMetadata()").
+		Str("path", basedir).
+		Logger()
+
+	logger.Debug().
+		Msg("Get list of stacks in path.")
 	stackEntries, err := ListStacks(basedir)
 	if err != nil {
 		return Metadata{}, err
 	}
 
+	logger.Trace().
+		Msg("Make array of stack metadata entries.")
 	stacksMetadata := make([]StackMetadata, len(stackEntries))
 	for i, stackEntry := range stackEntries {
 		stacksMetadata[i] = StackMetadata{

--- a/project/project.go
+++ b/project/project.go
@@ -24,6 +24,7 @@ import (
 // RelPath returns the dir relative to project's root.
 func RelPath(root, dir string) string {
 	log.Trace().
+		Str("action", "RelPath()").
 		Str("dir", dir).
 		Str("root", root).
 		Msg("Trim path to get relative dir.")
@@ -45,7 +46,11 @@ func AbsPath(root, dir string) string {
 
 // FriendlyFmtDir formats the directory in a friendly way for tooling output.
 func FriendlyFmtDir(root, wd, dir string) (string, bool) {
-	log.Trace().
+	logger := log.With().
+		Str("action", "FriendlyFmtDir()").
+		Logger()
+
+	logger.Trace().
 		Str("prefix", wd).
 		Str("root", root).
 		Str("dir", dir).
@@ -56,10 +61,10 @@ func FriendlyFmtDir(root, wd, dir string) (string, bool) {
 		return "", false
 	}
 
-	log.Trace().
+	logger.Trace().
 		Str("dir", dir).
 		Str("prefix", trimPart).
-		Msg("trimming prefix")
+		Msg("Trim prefix.")
 	dir = strings.TrimPrefix(dir, trimPart)
 
 	if dir == "" {
@@ -68,9 +73,9 @@ func FriendlyFmtDir(root, wd, dir string) (string, bool) {
 		dir = dir[1:]
 	}
 
-	log.Trace().
+	logger.Trace().
 		Str("newdir", dir).
-		Msg("friendly dir")
+		Msg("Get friendly dir.")
 
 	return dir, true
 }

--- a/run.go
+++ b/run.go
@@ -19,7 +19,6 @@ import (
 	"path/filepath"
 
 	"github.com/mineiros-io/terramate/stack"
-
 	"github.com/rs/zerolog/log"
 )
 

--- a/stack/loader.go
+++ b/stack/loader.go
@@ -198,7 +198,7 @@ func (l Loader) LoadAll(root string, basedir string, dirs ...string) ([]S, error
 	absbase := filepath.Join(root, basedir)
 
 	logger.Trace().
-		Str("stack", root).
+		Str("path", root).
 		Msg("Range over directories.")
 	for _, d := range dirs {
 		if !filepath.IsAbs(d) {

--- a/version.go
+++ b/version.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	tfversion "github.com/hashicorp/go-version"
+	"github.com/rs/zerolog/log"
 )
 
 //go:embed VERSION
@@ -28,6 +29,12 @@ var version string
 var tfversionObj *tfversion.Version
 
 func init() {
+	logger := log.With().
+		Str("action", "init()").
+		Logger()
+
+	logger.Debug().
+		Msg("Get semver version.")
 	var err error
 	tfversionObj, err = tfversion.NewSemver(Version())
 	if err != nil {

--- a/version.go
+++ b/version.go
@@ -31,10 +31,11 @@ var tfversionObj *tfversion.Version
 func init() {
 	logger := log.With().
 		Str("action", "init()").
+		Str("version", Version()).
 		Logger()
 
 	logger.Debug().
-		Msg("Get semver version.")
+		Msg("Parsing version as semver.")
 	var err error
 	tfversionObj, err = tfversion.NewSemver(Version())
 	if err != nil {


### PR DESCRIPTION
Logging is done for any action or decision.

- Imperative statements are used for logging actions, simple statements for decisions
- Logging is done immediately before the action occurs
- Logging is done AFTER the decision has been made
	- Eg: In an if statement make log directly after entering saying what has happened
	- Simple statement - non-imperative. Eg: 'Changed' flag was set
- Not all fields are required
- Format is: 
	- level - trace, debug
	- time - Unix or RC3339
	- stack (optional) - Path of stack
	- action - Name of function where the action is found. With `()` to improve readibility
	- fileContext (optional) - Absolute path of file if reading a file
	- configFile (optional) - Config file associated with action
	- configDir (optional) - Config directory if relevant
	- workingDirectory (optional) - Working directory - especially used if stack not relevant
	- path (optional) - Path/directory if relevant
	- command (optional) - Command if relevant
	- reference (optional) - Reference if relevant
	- id (optional) - ID if relevant
	- attribute (optional)
	- message - Imperative/simple statement describing what is about to happen/has happened.. Period `.` at end to improve readibility.
- Things not to log:
	- return statements
	- errrors (are handled differently)
- Msg should not include variables - all msgf variables should be in a context field
Other relevant info should also be logged