### PR TITLE
fix: avoid calling log.Fatal on core logic

### DIFF
--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -206,9 +206,7 @@ func newCLI(
 
 	cwd, err := os.Getwd()
 	if err != nil {
-		log.Fatal().
-			Err(err).
-			Msg("Getwd() failed")
+		return nil, fmt.Errorf("Getwd() failed: %v", err)
 	}
 
 	if parsedArgs.Chdir != "" {
@@ -218,18 +216,12 @@ func newCLI(
 			Msg("Changing working directory")
 		err = os.Chdir(parsedArgs.Chdir)
 		if err != nil {
-			logger.Fatal().
-				Str("cwd", cwd).
-				Str("dir", parsedArgs.Chdir).
-				Err(err).
-				Msg("Changing working directory failed")
+			return nil, fmt.Errorf("Changing workind dir failed: %v", err)
 		}
 
 		cwd, err = os.Getwd()
 		if err != nil {
-			log.Fatal().
-				Err(err).
-				Msg("Getwd() failed")
+			return nil, fmt.Errorf("Getwd() failed: %v", err)
 		}
 	}
 

--- a/cmd/terramate/cli/cli_test.go
+++ b/cmd/terramate/cli/cli_test.go
@@ -392,7 +392,7 @@ func (ts tscli) run(args ...string) runResult {
 
 	allargs := []string{}
 	if ts.chdir != "" {
-		allargs = append(allargs, "--chdir", ts.chdir)
+		allargs = append(allargs, "--chdir", ts.chdir, "--log-level", "fatal")
 	}
 
 	allargs = append(allargs, args...)

--- a/manager.go
+++ b/manager.go
@@ -25,8 +25,6 @@ import (
 	"github.com/mineiros-io/terramate/git"
 	"github.com/mineiros-io/terramate/hcl"
 	"github.com/mineiros-io/terramate/stack"
-
-	"github.com/rs/zerolog/log"
 )
 
 type (
@@ -201,9 +199,7 @@ func listChangedFiles(dir string, gitBaseRef string) ([]string, error) {
 	}
 
 	if len(untracked) > 0 {
-		log.Fatal().
-			Strs("files", untracked).
-			Msg("repository has untracked files")
+		return nil, fmt.Errorf("repository has untracked files: %v", untracked)
 	}
 
 	uncommitted, err := g.ListUncommitted()
@@ -212,9 +208,7 @@ func listChangedFiles(dir string, gitBaseRef string) ([]string, error) {
 	}
 
 	if len(uncommitted) > 0 {
-		log.Fatal().
-			Strs("files", uncommitted).
-			Msg("repository has uncommitted files")
+		return nil, fmt.Errorf("repository has uncommitted files: %v", uncommitted)
 	}
 
 	baseRef, err := g.RevParse(gitBaseRef)


### PR DESCRIPTION
The [PR](https://github.com/mineiros-io/terramate/pull/138) introduces log.Fatal calls inside the core logic (manager, cli), that will abort the tests suddenly making the output of the tests to disappear (the test program is exited abruptly). From [zerolog docs](https://pkg.go.dev/github.com/rs/zerolog#Logger.Fatal):

"Fatal starts a new message with fatal level. The os.Exit(1) function is called by the Msg method, which terminates the program immediately."

One reason to not use Fatal/os.Exit on the middle of some logic is what happened right now, makes it harder to test (the test caller will just exit), but it also can be problematic if there are deferred calls on the stack that will cleanup things if something went wrong.

To ensure that you will execute deferred calls + being able to test you need to return an error or panic, panic will execute all defers + will show properly with stack info on the test when it fails + it can be recovered from on a test for inspection.
There seems to be some other change in behavior, but now the tests fails with error messages in a more graceful manner (they are not aborted mid execution).

Since the tests are not ready to handle new data on stderr I also set the level to "fatal" for the tests for now, we can re-assess later.