### PR TITLE
tests: remove logging on tests output

### DIFF
--- a/cmd/terramate/cli/loglevel_test.go
+++ b/cmd/terramate/cli/loglevel_test.go
@@ -1,0 +1,7 @@
+package cli_test
+
+import "github.com/rs/zerolog"
+
+func init() {
+	zerolog.SetGlobalLevel(zerolog.Disabled)
+}

--- a/cmd/terramate/cli/loglevel_test.go
+++ b/cmd/terramate/cli/loglevel_test.go
@@ -1,3 +1,17 @@
+// Copyright 2022 Mineiros GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package cli_test
 
 import "github.com/rs/zerolog"

--- a/dag/dag_test.go
+++ b/dag/dag_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/madlambda/spells/assert"
 	"github.com/madlambda/spells/errutil"
 	"github.com/mineiros-io/terramate/dag"
+	"github.com/rs/zerolog"
 )
 
 type node struct {
@@ -307,4 +308,8 @@ func assertOrder(t *testing.T, want, got []dag.ID) {
 	for i, w := range want {
 		assert.EqualStrings(t, string(w), string(got[i]), "id %d mismatch", i)
 	}
+}
+
+func init() {
+	zerolog.SetGlobalLevel(zerolog.Disabled)
 }

--- a/generate/generate_test.go
+++ b/generate/generate_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/mineiros-io/terramate/test"
 	"github.com/mineiros-io/terramate/test/hclwrite"
 	"github.com/mineiros-io/terramate/test/sandbox"
+	"github.com/rs/zerolog"
 )
 
 func TestGenerateFailsIfPathDoesntExist(t *testing.T) {
@@ -1359,4 +1360,8 @@ func findFiles(t *testing.T, rootdir string, filename string) []string {
 	assert.NoError(t, err)
 
 	return found
+}
+
+func init() {
+	zerolog.SetGlobalLevel(zerolog.Disabled)
 }

--- a/git/git_test.go
+++ b/git/git_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/mineiros-io/terramate/git"
 	"github.com/mineiros-io/terramate/test"
 	"github.com/mineiros-io/terramate/test/sandbox"
+	"github.com/rs/zerolog"
 )
 
 const CookedCommitID = "4e991b55e3d58b9c3137a791a9986ed9c5069697"
@@ -379,4 +380,8 @@ func assertEqualRemotes(t *testing.T, got []git.Remote, want []git.Remote) {
 			diff,
 		)
 	}
+}
+
+func init() {
+	zerolog.SetGlobalLevel(zerolog.Disabled)
 }

--- a/hcl/hcl_test.go
+++ b/hcl/hcl_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/madlambda/spells/assert"
 	"github.com/mineiros-io/terramate/hcl"
 	"github.com/mineiros-io/terramate/test"
+	"github.com/rs/zerolog"
 )
 
 type want struct {
@@ -755,4 +756,8 @@ func testParser(t *testing.T, tc testcase) {
 			test.AssertTerramateConfig(t, got, tc.want.config)
 		}
 	})
+}
+
+func init() {
+	zerolog.SetGlobalLevel(zerolog.Disabled)
 }

--- a/loglevel_test.go
+++ b/loglevel_test.go
@@ -1,3 +1,17 @@
+// Copyright 2022 Mineiros GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package terramate_test
 
 import "github.com/rs/zerolog"

--- a/loglevel_test.go
+++ b/loglevel_test.go
@@ -1,0 +1,7 @@
+package terramate_test
+
+import "github.com/rs/zerolog"
+
+func init() {
+	zerolog.SetGlobalLevel(zerolog.Disabled)
+}


### PR DESCRIPTION
For now it is disabled, someone can change it to debug if required but usually just the error message is enough to help (at least for me). The default is tracing, so there is so much output when a test fails that it is hard to check the error message itself.