### PR TITLE
chore: add release automation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,5 +66,5 @@ jobs:
         uses: goreleaser/goreleaser-action@v2
         with:
           distribution: goreleaser
-          version: v2.8.0
+          version: 2.8.0
           args: release --snapshot --rm-dist

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,5 +66,5 @@ jobs:
         uses: goreleaser/goreleaser-action@v2
         with:
           distribution: goreleaser
-          version: 2.8.0
+          version: v1.2.5
           args: release --snapshot --rm-dist

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,3 +61,10 @@ jobs:
 
       - name: make build
         run: make build
+
+      - name: release dry run
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          distribution: goreleaser
+          version: v2.8.0
+          args: release --snapshot --rm-dist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,46 @@
+# Copyright 2022 Mineiros GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: release
+
+on:
+  push:
+    tags:
+      - '*'
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.17
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          distribution: goreleaser
+          version: v1.2.5
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ coverage.txt
 /cmd/terramate/terramate
 
 .vscode/
+
+dist/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,32 @@
+builds:
+  - main: ./cmd/terramate
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+      # - windows (when we add win support)
+      #
+archives:
+  - replacements:
+      darwin: Darwin
+      linux: Linux
+      #windows: Windows (when we add win support)
+      386: i386
+      amd64: x86_64
+
+checksum:
+  name_template: 'checksums.txt'
+
+snapshot:
+  name_template: "{{ incpatch .Version }}-next"
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - '^docs:'
+      - '^spec:'
+      - '^test:'
+      - '^refactor:'
+      - '^chore:'

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -42,5 +42,7 @@ changelog:
       - '^docs:'
       - '^spec:'
       - '^test:'
+      - '^tests:'
+      - '^testing:'
       - '^refactor:'
       - '^chore:'

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,3 +1,17 @@
+# Copyright 2022 Mineiros GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 builds:
   - main: ./cmd/terramate
     env:

--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,13 @@ install:
 clean:
 	rm -rf bin/*
 
+## creates a new release tag
+.PHONY: release/tag
+release/tag: VERSION?=v$(shell cat VERSION)
+release/tag:
+	git tag -a $(VERSION) -m "Release $(VERSION)"
+	git push origin $(VERSION)
+
 ## Display help for all targets
 .PHONY: help
 help:


### PR DESCRIPTION
Im going for this workflow:

* Create PR to change version from -dev to final one, like 0.0.9
* Reviewed/merged the PR
* Run locally on main: `make release/tag` it will automatically use the VERSION file (also used by the code itself)
* Release workflow is triggered by tag creation + goreleaser does it magic

It also generates the changelog automatically. For homebrew support it is a little more involved, maybe we can do it later, but at least for now we should get darwin binaries + linux/etc.

Not married with this particular workflow/no strong opinions, so feel free to suggest alternatives :-)