### PR TITLE
test: disable logs on test run

### DIFF
--- a/cmd/terramate/cli/cli_run_test.go
+++ b/cmd/terramate/cli/cli_run_test.go
@@ -413,7 +413,7 @@ func TestRunOrderNotChangedStackIgnored(t *testing.T) {
 		"--changed",
 		cat,
 		mainTfFileName,
-	), runExpected{Stdout: wantRun, IgnoreStderr: true})
+	), runExpected{Stdout: wantRun})
 
 	wantRun = mainTfContents
 
@@ -423,7 +423,7 @@ func TestRunOrderNotChangedStackIgnored(t *testing.T) {
 		"--changed",
 		cat,
 		mainTfFileName,
-	), runExpected{Stdout: wantRun, IgnoreStderr: true})
+	), runExpected{Stdout: wantRun})
 
 	cli = newCLI(t, stack2.Path())
 	assertRunResult(t, cli.run(
@@ -431,7 +431,7 @@ func TestRunOrderNotChangedStackIgnored(t *testing.T) {
 		"--changed",
 		cat,
 		mainTfFileName,
-	), runExpected{Stdout: "", IgnoreStderr: true})
+	), runExpected{Stdout: ""})
 }
 
 func TestRunOrderAllChangedStacksExecuted(t *testing.T) {
@@ -481,5 +481,5 @@ func TestRunOrderAllChangedStacksExecuted(t *testing.T) {
 		"--changed",
 		cat,
 		mainTfFileName,
-	), runExpected{Stdout: wantRun, IgnoreStderr: true})
+	), runExpected{Stdout: wantRun})
 }

--- a/cmd/terramate/cli/cli_runner_test.go
+++ b/cmd/terramate/cli/cli_runner_test.go
@@ -71,7 +71,7 @@ func (ts tscli) run(args ...string) runResult {
 		allargs = append(allargs, "--chdir", ts.chdir)
 	}
 	if len(args) > 0 {
-		// Avoid failing test when calling just terramate with no params
+		// Avoid failing test when calling just terramate with no args
 		allargs = append(allargs, "--log-level", "fatal")
 	}
 	allargs = append(allargs, args...)

--- a/cmd/terramate/cli/cli_runner_test.go
+++ b/cmd/terramate/cli/cli_runner_test.go
@@ -68,7 +68,7 @@ func (ts tscli) run(args ...string) runResult {
 
 	allargs := []string{}
 	if ts.chdir != "" {
-		allargs = append(allargs, "--chdir", ts.chdir)
+		allargs = append(allargs, "--chdir", ts.chdir, "--log-level", "fatal")
 	}
 
 	allargs = append(allargs, args...)

--- a/cmd/terramate/cli/cli_runner_test.go
+++ b/cmd/terramate/cli/cli_runner_test.go
@@ -68,9 +68,12 @@ func (ts tscli) run(args ...string) runResult {
 
 	allargs := []string{}
 	if ts.chdir != "" {
-		allargs = append(allargs, "--chdir", ts.chdir, "--log-level", "fatal")
+		allargs = append(allargs, "--chdir", ts.chdir)
 	}
-
+	if len(args) > 0 {
+		// Avoid failing test when calling just terramate with no params
+		allargs = append(allargs, "--log-level", "fatal")
+	}
 	allargs = append(allargs, args...)
 
 	cmd := exec.Command(terramateTestBin, allargs...)

--- a/cmd/terramate/cli/cli_test.go
+++ b/cmd/terramate/cli/cli_test.go
@@ -161,7 +161,7 @@ func TestListAndRunChangedStack(t *testing.T) {
 		"--changed",
 		cat,
 		mainTfFileName,
-	), runExpected{Stdout: wantRun, IgnoreStderr: true})
+	), runExpected{Stdout: wantRun})
 }
 
 func TestListAndRunChangedStackInAbsolutePath(t *testing.T) {


### PR DESCRIPTION
We can allow it to be configured if we ever test log output, but for now AFAIK we don't use log output on tests for validation, so we can just disable it to avoid tests failing or having to ignore stderr on a bunch of tests.