### PR TITLE
fix: ignore stdout/stderr in tests when not set

### DIFF
--- a/cmd/terramate/cli/cli_run_test.go
+++ b/cmd/terramate/cli/cli_run_test.go
@@ -413,7 +413,7 @@ func TestRunOrderNotChangedStackIgnored(t *testing.T) {
 		"--changed",
 		cat,
 		mainTfFileName,
-	), runExpected{Stdout: wantRun, IgnoreStderr: true})
+	), runExpected{Stdout: wantRun})
 
 	wantRun = mainTfContents
 
@@ -423,7 +423,7 @@ func TestRunOrderNotChangedStackIgnored(t *testing.T) {
 		"--changed",
 		cat,
 		mainTfFileName,
-	), runExpected{Stdout: wantRun, IgnoreStderr: true})
+	), runExpected{Stdout: wantRun})
 
 	cli = newCLI(t, stack2.Path())
 	assertRunResult(t, cli.run(
@@ -431,7 +431,7 @@ func TestRunOrderNotChangedStackIgnored(t *testing.T) {
 		"--changed",
 		cat,
 		mainTfFileName,
-	), runExpected{Stdout: "", IgnoreStderr: true})
+	), runExpected{Stdout: ""})
 }
 
 func TestRunOrderAllChangedStacksExecuted(t *testing.T) {
@@ -481,5 +481,5 @@ func TestRunOrderAllChangedStacksExecuted(t *testing.T) {
 		"--changed",
 		cat,
 		mainTfFileName,
-	), runExpected{Stdout: wantRun, IgnoreStderr: true})
+	), runExpected{Stdout: wantRun})
 }

--- a/cmd/terramate/cli/cli_runner_test.go
+++ b/cmd/terramate/cli/cli_runner_test.go
@@ -91,7 +91,7 @@ func (ts tscli) run(args ...string) runResult {
 func assertRun(t *testing.T, got runResult) {
 	t.Helper()
 
-	assertRunResult(t, got, runExpected{IgnoreStdout: true, IgnoreStderr: true})
+	assertRunResult(t, got, runExpected{})
 }
 
 func assertRunResult(t *testing.T, got runResult, want runExpected) {
@@ -115,7 +115,9 @@ func assertRunResult(t *testing.T, got runResult, want runExpected) {
 				)
 			}
 		} else {
-			assert.EqualStrings(t, wantStdout, stdout, "stdout mismatch")
+			if want.Stdout != "" {
+				assert.EqualStrings(t, wantStdout, stdout, "stdout mismatch")
+			}
 		}
 	}
 
@@ -131,7 +133,9 @@ func assertRunResult(t *testing.T, got runResult, want runExpected) {
 				)
 			}
 		} else {
-			assert.EqualStrings(t, want.Stderr, got.Stderr, "stderr mismatch")
+			if want.Stderr != "" {
+				assert.EqualStrings(t, want.Stderr, got.Stderr, "stderr mismatch")
+			}
 		}
 	}
 

--- a/cmd/terramate/cli/cli_test.go
+++ b/cmd/terramate/cli/cli_test.go
@@ -161,7 +161,7 @@ func TestListAndRunChangedStack(t *testing.T) {
 		"--changed",
 		cat,
 		mainTfFileName,
-	), runExpected{Stdout: wantRun, IgnoreStderr: true})
+	), runExpected{Stdout: wantRun})
 }
 
 func TestListAndRunChangedStackInAbsolutePath(t *testing.T) {
@@ -247,10 +247,7 @@ func TestDefaultBaseRefInMain(t *testing.T) {
 	git.Push("main")
 
 	// main uses HEAD^1 as default baseRef.
-	want := runExpected{
-		Stdout:       stack.RelPath() + "\n",
-		IgnoreStderr: true,
-	}
+	want := runExpected{Stdout: stack.RelPath() + "\n"}
 	assertRunResult(t, cli.run("stacks", "list", "--changed"), want)
 }
 
@@ -270,9 +267,7 @@ func TestBaseRefFlagPrecedenceOverDefault(t *testing.T) {
 
 	assertRunResult(t, cli.run("stacks", "list", "--changed",
 		"--git-change-base", "origin/main"),
-		runExpected{
-			IgnoreStderr: true,
-		},
+		runExpected{},
 	)
 }
 


### PR DESCRIPTION
this should fix all tests in #139 @kassianh 