### PR TITLE
fix: stacks listed twice

### DIFF
--- a/manager.go
+++ b/manager.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/mineiros-io/terramate/git"
 	"github.com/mineiros-io/terramate/hcl"
+	"github.com/mineiros-io/terramate/project"
 	"github.com/mineiros-io/terramate/stack"
 	"github.com/rs/zerolog/log"
 )
@@ -87,6 +88,10 @@ func (m *Manager) ListChanged() ([]Entry, error) {
 			Msg("Get dir name.")
 		dirname := filepath.Dir(filepath.Join(m.root, path))
 
+		if _, ok := stackSet[project.RelPath(m.root, dirname)]; ok {
+			continue
+		}
+
 		logger.Debug().
 			Str("path", dirname).
 			Msg("Try load changed.")
@@ -109,7 +114,7 @@ func (m *Manager) ListChanged() ([]Entry, error) {
 			}
 		}
 
-		stackSet[dirname] = Entry{
+		stackSet[s.Dir] = Entry{
 			Stack:  s,
 			Reason: "stack has unmerged changes",
 		}


### PR DESCRIPTION
The root cause was stacks listed twice and the incorrect one was missing the changed flag, so the run-order put them in a map, randomly overwriting the entry, so in the end stacks could have a changed flag or not, so the run-order was broken.

It's a bit hard to reproduce because it only happens when a stack detected as changed also had a module that changed, so I'm going to provide a testcase later this week.