### PR TITLE
fix: explicitly mark as changed stacks that changed due to module changes

### DIFF
--- a/manager.go
+++ b/manager.go
@@ -182,6 +182,8 @@ func (m *Manager) ListChanged() ([]Entry, error) {
 						Str("stack", abspath).
 						Str("configFile", tfpath).
 						Msg("Module changed.")
+
+					stack.SetChanged(true)
 					stackSet[stack.Dir] = Entry{
 						Stack:  stack,
 						Reason: fmt.Sprintf("stack changed because %q changed because %s", mod.Source, why),

--- a/stack/stack.go
+++ b/stack/stack.go
@@ -39,7 +39,8 @@ func (s S) Name() string {
 func (s S) After() []string  { return s.block.After }
 func (s S) Before() []string { return s.block.Before }
 
-func (s S) IsChanged() bool { return s.changed }
+func (s S) IsChanged() bool    { return s.changed }
+func (s *S) SetChanged(b bool) { s.changed = b }
 
 func (s S) String() string {
 	return s.Name()


### PR DESCRIPTION
This affects run-order of changed stacks due to module changes.