### PR TITLE
feat: add stack description

### DIFF
--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -712,16 +712,16 @@ func (c *cli) printMetadata() {
 	logger.Trace().
 		Str("workingDir", c.wd()).
 		Msg("Load metadata.")
+
 	metadata, err := terramate.LoadMetadata(c.root())
 	if err != nil {
-		logger.Fatal().
-			Err(err).
-			Msg("loading metadata")
+		logger.Fatal().Err(err).Msg("loading metadata")
 	}
 
 	logger.Trace().
 		Str("workingDir", c.wd()).
 		Msg("Log metadata.")
+
 	c.log("Available metadata:")
 
 	for _, stack := range metadata.Stacks {
@@ -731,6 +731,7 @@ func (c *cli) printMetadata() {
 		c.log("\nstack %q:", stack.Path)
 		c.log("\tterramate.name=%q", stack.Name)
 		c.log("\tterramate.path=%q", stack.Path)
+		c.log("\tterramate.description=%q", stack.Description)
 	}
 }
 

--- a/docs/metadata.md
+++ b/docs/metadata.md
@@ -49,3 +49,18 @@ Given this stack layout (from the root of the project):
 
 * terramate.name for **stack-a** = stack-a
 * terramate.name for **stack-b** = stack-b
+
+
+## terramate.description (string) 
+
+The description of the stack, if it has any. The default value is an empty string
+if undefined.
+
+To define a description for a stack just add a **description**
+attribute to the **stack** block:
+
+```hcl
+stack {
+  description =  "some description"
+}
+```

--- a/globals_test.go
+++ b/globals_test.go
@@ -226,7 +226,7 @@ func TestLoadGlobals(t *testing.T) {
 			name: "stacks referencing metadata",
 			layout: []string{
 				"s:stacks/stack-1",
-				"s:stacks/stack-2",
+				"s:stacks/stack-2:description=someDescriptionStack2",
 			},
 			globals: []globalsBlock{
 				{
@@ -234,19 +234,27 @@ func TestLoadGlobals(t *testing.T) {
 					add: globals(
 						expr("stack_path", "terramate.path"),
 						expr("interpolated", `"prefix-${terramate.name}-suffix"`),
+						expr("stack_description", "terramate.description"),
 					),
 				},
 				{
 					path: "/stacks/stack-2",
-					add:  globals(expr("stack_path", "terramate.path")),
+					add: globals(
+						expr("stack_path", "terramate.path"),
+						expr("stack_description", "terramate.description"),
+					),
 				},
 			},
 			want: map[string]*hclwrite.Block{
 				"/stacks/stack-1": globals(
 					str("stack_path", "/stacks/stack-1"),
 					str("interpolated", "prefix-stack-1-suffix"),
+					str("stack_description", ""),
 				),
-				"/stacks/stack-2": globals(str("stack_path", "/stacks/stack-2")),
+				"/stacks/stack-2": globals(
+					str("stack_path", "/stacks/stack-2"),
+					str("stack_description", "someDescriptionStack2"),
+				),
 			},
 		},
 		{

--- a/hcl/hcl.go
+++ b/hcl/hcl.go
@@ -66,6 +66,9 @@ type Stack struct {
 	// Name of the stack
 	Name string
 
+	// Description of the stack
+	Description string
+
 	// After is a list of non-duplicated stack entries that must run after the
 	// current stack runs.
 	After []string
@@ -517,11 +520,11 @@ func parseStack(stack *Stack, stackblock *hclsyntax.Block) error {
 		Str("stack", stack.Name).
 		Logger()
 
-	logger.Debug().
-		Msg("Get stack attributes.")
+	logger.Debug().Msg("Get stack attributes.")
+
 	for name, value := range stackblock.Body.Attributes {
-		logger.Trace().
-			Msg("Get attribute value.")
+		logger.Trace().Msg("Get attribute value.")
+
 		attrVal, diags := value.Expr.Value(nil)
 		if diags.HasErrors() {
 			return errutil.Chain(
@@ -531,6 +534,7 @@ func parseStack(stack *Stack, stackblock *hclsyntax.Block) error {
 			)
 		}
 		switch name {
+
 		case "name":
 			logger.Trace().
 				Msg("Attribute name was 'name'.")
@@ -541,6 +545,7 @@ func parseStack(stack *Stack, stackblock *hclsyntax.Block) error {
 				)
 			}
 			stack.Name = attrVal.AsString()
+
 		case "after":
 			logger.Trace().
 				Msg("Attribute name was 'after'.")
@@ -556,6 +561,16 @@ func parseStack(stack *Stack, stackblock *hclsyntax.Block) error {
 			if err != nil {
 				return err
 			}
+
+		case "description":
+			logger.Trace().Msg("parsing stack description.")
+			if attrVal.Type() != cty.String {
+				return errutil.Chain(ErrMalformedTerramateConfig,
+					fmt.Errorf("field stack.\"description\" must be a \"string\" but given %q",
+						attrVal.Type().FriendlyName()),
+				)
+			}
+			stack.Description = attrVal.AsString()
 
 		default:
 			return errutil.Chain(ErrMalformedTerramateConfig,

--- a/hcl/hcl_test.go
+++ b/hcl/hcl_test.go
@@ -722,6 +722,35 @@ stack {
 			},
 		},
 		{
+			name: "stack with valid description",
+			input: ` stack {
+				description = "some cool description"
+			}`,
+			want: want{
+				config: hcl.Config{
+					Stack: &hcl.Stack{
+						Description: "some cool description",
+					},
+				},
+			},
+		},
+		{
+			name: "stack with multiline description",
+			input: ` stack {
+				description =  <<-EOD
+line1
+line2
+EOD
+			}`,
+			want: want{
+				config: hcl.Config{
+					Stack: &hcl.Stack{
+						Description: "line1\nline2",
+					},
+				},
+			},
+		},
+		{
 			name: "'before' and 'after'",
 			input: `
 terramate {

--- a/hcl/printer.go
+++ b/hcl/printer.go
@@ -60,6 +60,10 @@ func PrintConfig(w io.Writer, cfg Config) error {
 		if len(stack.Before) > 0 {
 			stackBody.SetAttributeValue("before", cty.SetVal(listToValue(stack.Before)))
 		}
+
+		if stack.Description != "" {
+			stackBody.SetAttributeValue("description", cty.StringVal(stack.Description))
+		}
 	}
 
 	logger.Debug().

--- a/metadata.go
+++ b/metadata.go
@@ -24,8 +24,9 @@ import (
 
 // StackMetadata has all metadata loaded per stack
 type StackMetadata struct {
-	Name string
-	Path string
+	Name        string
+	Path        string
+	Description string
 }
 
 // Metadata has all metadata loader per project
@@ -55,8 +56,9 @@ func LoadMetadata(basedir string) (Metadata, error) {
 	stacksMetadata := make([]StackMetadata, len(stackEntries))
 	for i, stackEntry := range stackEntries {
 		stacksMetadata[i] = StackMetadata{
-			Name: stackEntry.Stack.Name(),
-			Path: strings.TrimPrefix(stackEntry.Stack.Dir, basedir),
+			Name:        stackEntry.Stack.Name(),
+			Description: stackEntry.Stack.Description(),
+			Path:        strings.TrimPrefix(stackEntry.Stack.Dir, basedir),
 		}
 	}
 

--- a/metadata.go
+++ b/metadata.go
@@ -73,8 +73,9 @@ func LoadMetadata(basedir string) (Metadata, error) {
 func (m StackMetadata) SetOnEvalCtx(evalctx *eval.Context) error {
 	// Not 100% sure this eval related logic should be here.
 	vals := map[string]cty.Value{
-		"name": cty.StringVal(m.Name),
-		"path": cty.StringVal(m.Path),
+		"name":        cty.StringVal(m.Name),
+		"path":        cty.StringVal(m.Path),
+		"description": cty.StringVal(m.Description),
 	}
 	return evalctx.SetNamespace("terramate", vals)
 }

--- a/metadata_test.go
+++ b/metadata_test.go
@@ -113,6 +113,21 @@ func TestLoadMetadata(t *testing.T) {
 			},
 		},
 		{
+			name: "stacks with description",
+			layout: []string{
+				"s:stack:description=desc",
+			},
+			want: terramate.Metadata{
+				Stacks: []terramate.StackMetadata{
+					{
+						Name:        "stack",
+						Path:        "/stack",
+						Description: "desc",
+					},
+				},
+			},
+		},
+		{
 			name: "single invalid stack",
 			layout: []string{
 				fmt.Sprintf("f:invalid-stack/%s:data=%s", config.Filename, invalidHCL),
@@ -141,7 +156,7 @@ func TestLoadMetadata(t *testing.T) {
 			}
 
 			if diff := cmp.Diff(tcase.want, metadata, cmpopts.IgnoreUnexported(tcase.want)); diff != "" {
-				t.Fatalf("want %v != got %v.\ndiff:\n%s", tcase.want, metadata, diff)
+				t.Fatalf("want %+v != got %+v.\ndiff:\n%s", tcase.want, metadata, diff)
 			}
 		})
 	}

--- a/stack/stack.go
+++ b/stack/stack.go
@@ -36,6 +36,10 @@ func (s S) Name() string {
 	return filepath.Base(s.Dir)
 }
 
+func (s S) Description() string {
+	return s.block.Description
+}
+
 func (s S) After() []string  { return s.block.After }
 func (s S) Before() []string { return s.block.Before }
 

--- a/test/sandbox/sandbox.go
+++ b/test/sandbox/sandbox.go
@@ -147,6 +147,8 @@ func (s S) BuildTree(layout []string) {
 				tm.Stack.After = specList(t, name, value)
 			case "before":
 				tm.Stack.Before = specList(t, name, value)
+			case "description":
+				tm.Stack.Description = value
 			default:
 				t.Fatalf("attribute " + parts[0] + " not supported.")
 			}


### PR DESCRIPTION
Adds possibility of having a description for the stack:

```hcl
stack {
  description =  "some description"
}
```

The description shows when listing stack metadata + it can be used on globals or anywhere else that terramate.path and terramate.name can be used (let me know if it doesn't make sense). The default value for the description is empty, if none is defined.

To kick the tires:

```sh
#!/bin/bash

set -o errexit
set -o nounset

basedir=$(mktemp -d)

cd "${basedir}"

cat > terramate.tm.hcl <<- EOM
terramate {
  config {
  }
}
EOM

mkdir -p stack
terramate stacks init stack

echo
echo "listing metadata"
echo
terramate metadata

echo
echo "adding description to stack"

cat > stack/terramate.tm.hcl <<- EOM
stack {
  description = "the stack description"
}
EOM

echo
echo "listing metadata"
echo
terramate metadata
```

Should output:

```
listing metadata

Available metadata:

stack "/stack":
        terramate.name="stack"
        terramate.path="/stack"
        terramate.description=""

adding description to stack

listing metadata

Available metadata:

stack "/stack":
        terramate.name="stack"
        terramate.path="/stack"
        terramate.description="the stack description"
```