### PR TITLE
test: add testcase to reproduce bug fixed on #149

### DIFF
--- a/cmd/terramate/cli/cli_stacks_list_test.go
+++ b/cmd/terramate/cli/cli_stacks_list_test.go
@@ -186,3 +186,37 @@ terramate {
 	}
 	assertRunResult(t, cli.run("stacks", "list", "--changed"), want)
 }
+
+func TestListTwiceBug(t *testing.T) {
+	const (
+		mainTfFileName = "main.tf"
+		mainTfContents = "# change is the eternal truth of the universe"
+
+		modname = "modA"
+	)
+
+	s := sandbox.New(t)
+
+	stack := s.CreateStack("stack")
+	mod1 := s.CreateModule(modname)
+	mod1MainTf := mod1.CreateFile(mainTfFileName, "# module A")
+
+	stack.CreateFile("main.tf", `
+module "mod1" {
+source = "%s"
+}`, stack.ModSource(mod1))
+
+	git := s.Git()
+	git.CommitAll("first commit")
+	git.Push("main")
+	git.CheckoutNew("change-stack")
+
+	mod1MainTf.Write("# something else")
+	stack.CreateFile("test.txt", "something else")
+	git.CommitAll("stack and module changed")
+
+	cli := newCLI(t, s.RootDir())
+
+	wantList := stack.RelPath() + "\n"
+	assertRunResult(t, cli.run("stacks", "list", "--changed"), runExpected{Stdout: wantList})
+}


### PR DESCRIPTION
When executed against d2c4d710045650072ab4a810bc6bf5b25881dbd0 it gives the output below:

```
[i4k@i4k-mineiros terramate]$ make test
go test -count=1 -race ./...
ok  	github.com/mineiros-io/terramate	1.771s
?   	github.com/mineiros-io/terramate/cmd/terramate	[no test files]
{"level":"debug","action":"init()","version":"0.0.8-dev","time":"2022-01-11T15:36:52Z","message":"Parsing version as semver."}
--- FAIL: TestListTwiceBug (0.05s)
    cli_stacks_list_test.go:223: wanted[stack
        ] but got[stack
        stack
        ].stdout mismatch
FAIL
FAIL	github.com/mineiros-io/terramate/cmd/terramate/cli	2.589s
?   	github.com/mineiros-io/terramate/config	[no test files]
ok  	github.com/mineiros-io/terramate/dag	0.029s
ok  	github.com/mineiros-io/terramate/generate	0.886s
ok  	github.com/mineiros-io/terramate/git	0.357s
ok  	github.com/mineiros-io/terramate/hcl	0.098s
?   	github.com/mineiros-io/terramate/hcl/eval	[no test files]
?   	github.com/mineiros-io/terramate/project	[no test files]
?   	github.com/mineiros-io/terramate/stack	[no test files]
ok  	github.com/mineiros-io/terramate/test	0.084s
ok  	github.com/mineiros-io/terramate/test/hclwrite	0.048s
ok  	github.com/mineiros-io/terramate/test/sandbox	0.060s
FAIL
make: *** [Makefile:54: test] Error 1
```