### PR TITLE
fix: terramate generate only works from project root dir

### DIFF
--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -372,7 +372,7 @@ func (c *cli) run() {
 	case "generate":
 		logger.Debug().
 			Msg("Handle `generate` command.")
-		err := generate.Do(c.root())
+		err := generate.Do(c.root(), c.wd())
 		if err != nil {
 			log.Fatal().
 				Err(err).

--- a/generate/generate.go
+++ b/generate/generate.go
@@ -49,14 +49,23 @@ const (
 	ErrManualCodeExists   errutil.Error = "manually defined code found"
 )
 
-// Do will walk all the directories starting from project's root
+// Do will walk all the stacks inside the given working dir
 // generating code for any stack it finds as it goes along.
+//
+// Code is generated based on configuration files spread around the entire
+// project until it reaches the given root. So even though a configuration
+// file may be outside the given working dir it may be used on code generation
+// if it is in a dir that is a parent of a stack found inside the working dir.
+//
+// The provided root must be the project's root directory as an absolute path.
+// The provided workding dir must be an absolute path that is a child of the
+// provided root (or the same as root, indicating that working dir is the project root).
 //
 // It will return an error if it finds any invalid Terramate configuration files
 // or if it can't generate the files properly for some reason.
-//
-// The provided root must be the project's root directory as an absolute path.
-func Do(root string) error {
+func Do(root string, workingDir string) error {
+
+	// TODO(katcipis): properly use workingDir
 
 	errs := forEachStack(root, func(
 		stackpath string,

--- a/generate/generate.go
+++ b/generate/generate.go
@@ -58,7 +58,7 @@ const (
 // if it is in a dir that is a parent of a stack found inside the working dir.
 //
 // The provided root must be the project's root directory as an absolute path.
-// The provided workding dir must be an absolute path that is a child of the
+// The provided working dir must be an absolute path that is a child of the
 // provided root (or the same as root, indicating that working dir is the project root).
 //
 // It will return an error if it finds any invalid Terramate configuration files

--- a/generate/generate_check_test.go
+++ b/generate/generate_check_test.go
@@ -15,12 +15,10 @@
 package generate_test
 
 import (
-	"path/filepath"
 	"testing"
 
 	"github.com/madlambda/spells/assert"
 	"github.com/mineiros-io/terramate/generate"
-	"github.com/mineiros-io/terramate/test"
 	"github.com/mineiros-io/terramate/test/sandbox"
 )
 
@@ -167,30 +165,6 @@ func TestCheckFailsWithInvalidConfig(t *testing.T) {
 		_, err = generate.Check(s.RootDir())
 		assert.Error(t, err, "should fail for configuration:\n%s", invalidConfig)
 	}
-}
-
-func TestCheckFailsIfPathDoesntExist(t *testing.T) {
-	_, err := generate.Check(test.NonExistingDir(t))
-	assert.Error(t, err)
-}
-
-func TestCheckFailsIfPathIsNotDir(t *testing.T) {
-	dir := t.TempDir()
-	filename := "test"
-
-	test.WriteFile(t, dir, filename, "whatever")
-	path := filepath.Join(dir, filename)
-
-	_, err := generate.Check(path)
-	assert.Error(t, err)
-}
-
-func TestCheckFailsIfPathIsRelative(t *testing.T) {
-	dir := t.TempDir()
-	relpath := test.RelPath(t, test.Getwd(t), dir)
-
-	_, err := generate.Check(relpath)
-	assert.Error(t, err)
 }
 
 func assertOutdatedEquals(t *testing.T, got []generate.Outdated, want []generate.Outdated) {

--- a/generate/generate_hcl_test.go
+++ b/generate/generate_hcl_test.go
@@ -26,6 +26,18 @@ func expr(name string, expr string) hclwrite.BlockBuilder {
 	return hclwrite.Expression(name, expr)
 }
 
+func str(name string, val string) hclwrite.BlockBuilder {
+	return hclwrite.String(name, val)
+}
+
+func number(name string, val int64) hclwrite.BlockBuilder {
+	return hclwrite.NumberInt(name, val)
+}
+
+func boolean(name string, val bool) hclwrite.BlockBuilder {
+	return hclwrite.Boolean(name, val)
+}
+
 func labels(labels ...string) hclwrite.BlockBuilder {
 	return hclwrite.Labels(labels...)
 }
@@ -38,8 +50,20 @@ func backend(builders ...hclwrite.BlockBuilder) *hclwrite.Block {
 	return hclwrite.BuildBlock("backend", builders...)
 }
 
+func globals(builders ...hclwrite.BlockBuilder) *hclwrite.Block {
+	return hclwrite.BuildBlock("globals", builders...)
+}
+
+func locals(builders ...hclwrite.BlockBuilder) *hclwrite.Block {
+	return hclwrite.BuildBlock("locals", builders...)
+}
+
 func terramate(builders ...hclwrite.BlockBuilder) *hclwrite.Block {
 	return hclwrite.BuildBlock("terramate", builders...)
+}
+
+func terraform(builders ...hclwrite.BlockBuilder) *hclwrite.Block {
+	return hclwrite.BuildBlock("terraform", builders...)
 }
 
 func exportAsLocals(builders ...hclwrite.BlockBuilder) *hclwrite.Block {

--- a/generate/generate_test.go
+++ b/generate/generate_test.go
@@ -1281,9 +1281,6 @@ func TestWontOverwriteManuallyDefinedBackendConfig(t *testing.T) {
 		manualContents = "some manual backend configs"
 	)
 
-	terramate := func(builders ...hclwrite.BlockBuilder) *hclwrite.Block {
-		return hclwrite.BuildBlock("terramate", builders...)
-	}
 	backend := func(label string) *hclwrite.Block {
 		b := hclwrite.BuildBlock("backend")
 		b.AddLabel(label)
@@ -1308,12 +1305,6 @@ func TestWontOverwriteManuallyDefinedBackendConfig(t *testing.T) {
 }
 
 func TestBackendConfigOverwriting(t *testing.T) {
-	terramate := func(builders ...hclwrite.BlockBuilder) *hclwrite.Block {
-		return hclwrite.BuildBlock("terramate", builders...)
-	}
-	terraform := func(builders ...hclwrite.BlockBuilder) *hclwrite.Block {
-		return hclwrite.BuildBlock("terraform", builders...)
-	}
 	backend := func(label string) *hclwrite.Block {
 		b := hclwrite.BuildBlock("backend")
 		b.AddLabel(label)
@@ -1347,11 +1338,6 @@ func TestWontOverwriteManuallyDefinedLocals(t *testing.T) {
 		manualLocals = "some manual stuff"
 	)
 
-	exportAsLocals := func(builders ...hclwrite.BlockBuilder) *hclwrite.Block {
-		return hclwrite.BuildBlock("export_as_locals", builders...)
-	}
-	expr := hclwrite.Expression
-
 	exportLocalsCfg := exportAsLocals(expr("a", "terramate.path"))
 
 	s := sandbox.New(t)
@@ -1370,15 +1356,6 @@ func TestWontOverwriteManuallyDefinedLocals(t *testing.T) {
 }
 
 func TestExportedLocalsOverwriting(t *testing.T) {
-	exportAsLocals := func(builders ...hclwrite.BlockBuilder) *hclwrite.Block {
-		return hclwrite.BuildBlock("export_as_locals", builders...)
-	}
-	locals := func(builders ...hclwrite.BlockBuilder) *hclwrite.Block {
-		return hclwrite.BuildBlock("locals", builders...)
-	}
-	expr := hclwrite.Expression
-	str := hclwrite.String
-
 	firstConfig := exportAsLocals(expr("a", "terramate.path"))
 	firstWant := locals(str("a", "/stack"))
 

--- a/stack/stack.go
+++ b/stack/stack.go
@@ -20,13 +20,14 @@ import (
 	"github.com/mineiros-io/terramate/hcl"
 )
 
+// S represents a stack
 type S struct {
-	name string
-	Dir  string
+	// Dir is the stack dir path relative to the project root
+	Dir string
 
+	name    string
 	changed bool
-
-	block *hcl.Stack
+	block   *hcl.Stack
 }
 
 func (s S) Name() string {

--- a/test/sandbox/sandbox.go
+++ b/test/sandbox/sandbox.go
@@ -206,7 +206,7 @@ func (s S) LoadMetadata() terramate.Metadata {
 func (s S) Generate() {
 	s.t.Helper()
 
-	err := generate.Do(s.RootDir())
+	err := generate.Do(s.RootDir(), s.RootDir())
 	assert.NoError(s.t, err)
 }
 


### PR DESCRIPTION
Now terramate generate should work with -C / PWD, so you can generate code only for a subset of stacks. Also removed some checks that were redundant (for root/wd/etc) and minor improvements on test error messages/duplication etc.

Example script:

```sh
#!/bin/bash

set -o nounset

basedir=$(mktemp -d)

cd "${basedir}"

cat > terramate.tm.hcl <<- EOM
terramate {
  config {
  }
}
EOM

mkdir -p stacks/stack-{1,2,3}
terramate stacks init stacks/stack-{1,2,3}

cat > stacks/stack-1/terramate.tm.hcl <<- EOM
stack {}

export_as_locals {
  path = terramate.path
}
EOM

cat > stacks/stack-2/terramate.tm.hcl <<- EOM
stack {}

export_as_locals {
  path = terramate.path
}
EOM

cat > stacks/stack-3/terramate.tm.hcl <<- EOM
stack {}

export_as_locals {
  path = terramate.path
}
EOM

echo "initial tree"
tree

echo "generating code only for stack-1 with -C"
terramate generate -C stacks/stack-1

echo "tree after generating for stack-1"
tree

echo "generating code only for stack-2 by changing working dir"
cd stacks/stack-2
terramate generate
cd -

echo "tree after generating for stack-2"
tree

echo "generating code for all project"
terramate generate

echo "tree after generating for all"
tree
terramate generate -C stacks/stack-1
```