### PR TITLE
refactor: move e2e tests to specific package

### DIFF
--- a/cmd/terramate/e2etests/general_test.go
+++ b/cmd/terramate/e2etests/general_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package cli_test
+package e2etest
 
 import (
 	"fmt"

--- a/cmd/terramate/e2etests/loglevel_test.go
+++ b/cmd/terramate/e2etests/loglevel_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package cli_test
+package e2etest
 
 import "github.com/rs/zerolog"
 

--- a/cmd/terramate/e2etests/main_test.go
+++ b/cmd/terramate/e2etests/main_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package cli_test
+package e2etest
 
 import (
 	"fmt"

--- a/cmd/terramate/e2etests/metadata_test.go
+++ b/cmd/terramate/e2etests/metadata_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package cli_test
+package e2etest
 
 import (
 	"testing"

--- a/cmd/terramate/e2etests/order_test.go
+++ b/cmd/terramate/e2etests/order_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package cli_test
+package e2etest
 
 import (
 	"strings"

--- a/cmd/terramate/e2etests/run_test.go
+++ b/cmd/terramate/e2etests/run_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package cli_test
+package e2etest
 
 import (
 	"fmt"

--- a/cmd/terramate/e2etests/runner_test.go
+++ b/cmd/terramate/e2etests/runner_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package cli_test
+package e2etest
 
 import (
 	"bytes"

--- a/cmd/terramate/e2etests/stacks_globals_test.go
+++ b/cmd/terramate/e2etests/stacks_globals_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package cli_test
+package e2etest
 
 import (
 	"path/filepath"

--- a/cmd/terramate/e2etests/stacks_init_test.go
+++ b/cmd/terramate/e2etests/stacks_init_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package cli_test
+package e2etest
 
 import (
 	"fmt"

--- a/cmd/terramate/e2etests/stacks_list_test.go
+++ b/cmd/terramate/e2etests/stacks_list_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package cli_test
+package e2etest
 
 import (
 	"testing"


### PR DESCRIPTION
As we are moving away from the previous cli package/cli function testing to full e2e the idea is to make this more explicit (+ we are thinking on merging code on main anyway, so the cli package may not exist soon). Not so sure about the name TBH. Maybe just "tests" and the e2e could be implicit, or just e2e and the testing part is implicit =P.