### PR TITLE
fix: avoid aborting when we cant get branch name

### DIFF
--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -1165,11 +1165,22 @@ func (p *project) setDefaults(parsedArgs *cliSpec) error {
 				Msg("Get current branch.")
 			branch, err := gw.CurrentBranch()
 			if err != nil {
-				return fmt.Errorf("failed to get current git branch: %v", err)
-			}
-
-			if branch == gitOpt.DefaultBranch {
-				baseRef = gitOpt.DefaultBranchBaseRef
+				// ON CI envs we don't have a clean way to get the branch name
+				// git symbolic-ref will just fail. but we don't want a hard
+				// fail on this case. We need to re-assess this, if we really
+				// need the branch name, is there some other way to solve this ? etc.
+				//
+				// More info on git branch names on GHA:
+				//
+				// - https://github.com/github/feedback/discussions/5251
+				// - https://stackoverflow.com/questions/58033366/how-to-get-the-current-branch-within-github-actions
+				logger.Debug().
+					Str("details", err.Error()).
+					Msg("getting git branch name")
+			} else {
+				if branch == gitOpt.DefaultBranch {
+					baseRef = gitOpt.DefaultBranchBaseRef
+				}
 			}
 		}
 	}

--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -934,7 +934,7 @@ func (c *cli) checkLocalDefaultIsUpdated(g *git.Git) error {
 		Msg("Get local commit ID.")
 	localCommitID, err := g.RevParse(branch)
 	if err != nil {
-		return fmt.Errorf("checking local branch %q is update: %v", branch, err)
+		return fmt.Errorf("checking if local branch %q is updated: %v", branch, err)
 	}
 
 	localRef := git.Ref{CommitID: localCommitID}

--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -910,7 +910,7 @@ func (c *cli) checkLocalDefaultIsUpdated(g *git.Git) error {
 		// - https://github.com/github/feedback/discussions/5251
 		// - https://stackoverflow.com/questions/58033366/how-to-get-the-current-branch-within-github-actions
 		logger.Debug().
-			Str("details", err.Error()).
+			Str("error", err.Error()).
 			Msg("getting git branch name")
 		return nil
 	}
@@ -1184,7 +1184,7 @@ func (p *project) setDefaults(parsedArgs *cliSpec) error {
 				// - https://github.com/github/feedback/discussions/5251
 				// - https://stackoverflow.com/questions/58033366/how-to-get-the-current-branch-within-github-actions
 				logger.Debug().
-					Str("details", err.Error()).
+					Str("error", err.Error()).
 					Msg("getting git branch name")
 			} else {
 				if branch == gitOpt.DefaultBranch {

--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -926,7 +926,7 @@ func (c *cli) checkLocalDefaultIsUpdated(g *git.Git) error {
 		Msg("Fetch remote reference.")
 	remoteRef, err := g.FetchRemoteRev(defaultRemote, defaultBranch)
 	if err != nil {
-		return fmt.Errorf("checking local branch %q is update: %v", branch, err)
+		return fmt.Errorf("checking if local branch %q is updated: %v", branch, err)
 	}
 	c.logerr("retrieved info from remote branch: %s/%s.", defaultRemote, defaultBranch)
 


### PR DESCRIPTION
On some CI envs we can't get the branch name easily, not sure if we really need them TBH but since we want to get this working ASAP I tried to keep the behavior the same when we have the branch name and then on CI the check won't be performed for now. With more time we can improve/review the overall git checks.