### PR TITLE
fix: use default logging before parsing cli args

### DIFF
--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -56,6 +56,11 @@ const (
 	defaultBranchBaseRef = "HEAD^"
 )
 
+const (
+	defaultLogLevel = "info"
+	defaultLogFmt   = "console"
+)
+
 type cliSpec struct {
 	Version       struct{} `cmd:"" help:"Terramate version."`
 	Chdir         string   `short:"C" optional:"true" help:"sets working directory."`
@@ -119,6 +124,7 @@ func Exec(
 	stdout io.Writer,
 	stderr io.Writer,
 ) {
+	configureLogging(defaultLogLevel, defaultLogFmt, stderr)
 	c := newCLI(args, stdin, stdout, stderr)
 	c.run()
 }
@@ -198,6 +204,11 @@ func newCLI(
 	}
 
 	configureLogging(parsedArgs.LogLevel, parsedArgs.LogFmt, stderr)
+	// If we don't re-create the logger after configuring we get some
+	// log entries with a mix of default fmt and selected fmt.
+	logger = log.With().
+		Str("action", "newCli()").
+		Logger()
 
 	if ctx.Command() == "version" {
 		logger.Debug().


### PR DESCRIPTION
Now logging done before configuring the log library will have the same default level/format as the ones configured for the cli options. Now we get this:

```
terramate wrong
2022-02-07T18:54:57+01:00 FTL failed to parse cli args: [wrong] error="unexpected argument wrong" action=newCli()
```

Instead of JSON (which is not the default).