### PR TITLE
fix: outdated code detection wont ignore empty generate_hcl

### DIFF
--- a/generate/generate.go
+++ b/generate/generate.go
@@ -611,7 +611,7 @@ func checkFileCanBeOverwritten(path string) error {
 }
 
 // loadGeneratedCode will load the generated code at the given path.
-// It returns an error if it can't read the file of if the file is not
+// It returns an error if it can't read the file or if the file is not
 // a Terramate generated file.
 //
 // The returned boolean indicates if the file exists, so the contents of

--- a/generate/generate.go
+++ b/generate/generate.go
@@ -335,7 +335,7 @@ func generatedHCLOutdatedFiles(
 			return nil, err
 		}
 		if !codeFound && genHCL.String() == "" {
-			logger.Trace().Msg("Updated since file not found and generated_hcl is empty")
+			logger.Trace().Msg("Not outdated since file not found and generated_hcl is empty")
 			continue
 		}
 

--- a/generate/generate_check_test.go
+++ b/generate/generate_check_test.go
@@ -130,7 +130,7 @@ func TestCheckOutdatedIgnoresEmptyGenerateHCLBlocks(t *testing.T) {
 
 	assertOutdatedFiles([]string{})
 
-	// Checking detection when the config isnt empty, is generated, but then becomes empty
+	// Checking detection when the config isnt empty, is generated and then becomes empty
 	stackEntry.CreateConfig(
 		stackConfig(
 			generateHCL(

--- a/generate/generate_hcl_test.go
+++ b/generate/generate_hcl_test.go
@@ -68,7 +68,7 @@ func TestHCLGeneration(t *testing.T) {
 			},
 		},
 		{
-			name: "empty generate_hcl block is ignored",
+			name: "empty generate_hcl block generates nothing",
 			layout: []string{
 				"s:stacks/stack-1",
 				"s:stacks/stack-2",
@@ -341,7 +341,7 @@ func TestHCLGeneration(t *testing.T) {
 					return nil
 				}
 
-				t.Errorf("unwanted file at %q, got %q", path, d.Name())
+				t.Errorf("unwanted file %q", path)
 				return nil
 			})
 

--- a/generate/generate_hcl_test.go
+++ b/generate/generate_hcl_test.go
@@ -507,7 +507,14 @@ func TestGenerateHCLCleanupOldFiles(t *testing.T) {
 	got = stackEntry.ListGenFiles()
 	assertEqualStringList(t, got, []string{"file1.tf"})
 
-	rootConfig.Write("")
+	// empty block generates no code, so it gets deleted
+	rootConfig.Write(
+		hcldoc(
+			generateHCL(
+				labels("file1.tf"),
+			),
+		).String(),
+	)
 
 	s.Generate()
 	got = stackEntry.ListGenFiles()


### PR DESCRIPTION
The following snippet should work, but before this fix it doesn't:

```sh
#!/bin/bash

set -o nounset
set -o errexit

basedir=$(mktemp -d)

cd "${basedir}"

# We need the project root config since it is not git
cat > terramate.tm.hcl <<- EOM
terramate {
  config {
  }
}
EOM

mkdir -p stacks/stack-{1,2}
terramate stacks init stacks/stack-{1,2}

cat > stacks/terramate.tm.hcl <<- EOM
generate_hcl "empty.tf" {}
EOM

terramate run -- echo hi
```

In this scenario there is no way to solve the problem, calling terramate generate won't generate any code and yet the outdated code detection keeps detecting the project as outdated. This PRs fixes this so detection properly ignores when the generated code is empty (empty block) + file does not exist on fs (it shouldn't). 

There is less testing on export_as_locals and backend config because we are converging to replacing them with generate_terraform (backend config is already replaced by generate_hcl, but not export_as_locals), but the fix itself is also applied on them.