### PR TITLE
fix: terramate generate: different code gen strategies with same config filename overwrite each other

### DIFF
--- a/generate/generate.go
+++ b/generate/generate.go
@@ -40,6 +40,7 @@ const (
 	ErrLoadingGlobals     errutil.Error = "loading globals"
 	ErrLoadingStackCfg    errutil.Error = "loading stack code gen config"
 	ErrManualCodeExists   errutil.Error = "manually defined code found"
+	ErrConflictingConfig  errutil.Error = "conflicting config detected"
 )
 
 const (

--- a/generate/generate.go
+++ b/generate/generate.go
@@ -743,14 +743,14 @@ func hasTerramateHeader(code []byte) bool {
 }
 
 func checkGeneratedFilesConflicts(genfiles []genfile) error {
-	observed := map[string]genfile{}
+	observed := map[string]struct{}{}
 	for _, genf := range genfiles {
 		if _, ok := observed[genf.name]; ok {
 			// TODO(katcipis): improve error with origin info
 			// Right now it is not as nice/easy as I would like :-(.
 			return fmt.Errorf("two configurations produce same file %s", genf.name)
 		}
-		observed[genf.name] = genf
+		observed[genf.name] = struct{}{}
 	}
 	return nil
 }

--- a/generate/generate.go
+++ b/generate/generate.go
@@ -87,9 +87,7 @@ func Do(root string, workingDir string) error {
 		if err != nil {
 			return fmt.Errorf("%w: %v", ErrBackendConfigGen, err)
 		}
-		if stackBackendCfgCode != "" {
-			genfiles = append(genfiles, genfile{name: cfg.BackendCfgFilename, body: stackBackendCfgCode})
-		}
+		genfiles = append(genfiles, genfile{name: cfg.BackendCfgFilename, body: stackBackendCfgCode})
 
 		logger.Trace().Msg("Generate stack locals.")
 
@@ -97,9 +95,7 @@ func Do(root string, workingDir string) error {
 		if err != nil {
 			return fmt.Errorf("%w: %v", ErrExportingLocalsGen, err)
 		}
-		if stackLocalsCode != "" {
-			genfiles = append(genfiles, genfile{name: cfg.LocalsFilename, body: stackLocalsCode})
-		}
+		genfiles = append(genfiles, genfile{name: cfg.LocalsFilename, body: stackLocalsCode})
 
 		logger.Trace().Msg("Generate stack terraform.")
 
@@ -128,6 +124,12 @@ func Do(root string, workingDir string) error {
 			logger := logger.With().
 				Str("filepath", path).
 				Logger()
+
+			// For now we don't want to generate files just with a header inside.
+			if genfile.body == "" {
+				logger.Trace().Msg("ignoring empty code")
+				continue
+			}
 
 			logger.Trace().Msg("saving generated file")
 
@@ -419,7 +421,7 @@ func generateStackHCLCode(
 
 		hclCode := generatedHCL.String()
 		if hclCode == "" {
-			logger.Trace().Msg("Ignoring empty block.")
+			files = append(files, genfile{name: name, body: hclCode})
 			continue
 		}
 

--- a/generate/generate.go
+++ b/generate/generate.go
@@ -748,7 +748,7 @@ func checkGeneratedFilesConflicts(genfiles []genfile) error {
 		if _, ok := observed[genf.name]; ok {
 			// TODO(katcipis): improve error with origin info
 			// Right now it is not as nice/easy as I would like :-(.
-			return fmt.Errorf("two configurations produce same file %s", genf.name)
+			return fmt.Errorf("two configurations produce same file %q", genf.name)
 		}
 		observed[genf.name] = struct{}{}
 	}

--- a/generate/generate_conflicts_test.go
+++ b/generate/generate_conflicts_test.go
@@ -66,6 +66,47 @@ func TestFilenameConflictsOnGeneration(t *testing.T) {
 			},
 			want: generate.ErrConflictingConfig,
 		},
+		{
+			name:   "empty export_as_locals conflicting with generate_hcl",
+			layout: []string{"s:stacks/stack"},
+			configs: []hclconfig{
+				{
+					path: "stacks",
+					add: hcldoc(
+						terramate(cfg(gen(
+							str("locals_filename", "file.tf"),
+						))),
+						exportAsLocals(),
+						generateHCL(
+							labels("file.tf"),
+							block("test"),
+						),
+					),
+				},
+			},
+			want: generate.ErrConflictingConfig,
+		},
+		{
+			name:   "export_as_locals conflicting with empty generate_hcl",
+			layout: []string{"s:stacks/stack"},
+			configs: []hclconfig{
+				{
+					path: "stacks",
+					add: hcldoc(
+						terramate(cfg(gen(
+							str("locals_filename", "file.tf"),
+						))),
+						exportAsLocals(
+							str("test", "hi"),
+						),
+						generateHCL(
+							labels("file.tf"),
+						),
+					),
+				},
+			},
+			want: generate.ErrConflictingConfig,
+		},
 	}
 
 	for _, tcase := range tcases {

--- a/generate/generate_conflicts_test.go
+++ b/generate/generate_conflicts_test.go
@@ -22,11 +22,9 @@ func TestFilenameConflictsOnGeneration(t *testing.T) {
 		want       error
 	}
 
-	// gen instead of generate because name conflicts with generate pkg
 	gen := func(builders ...hclwrite.BlockBuilder) *hclwrite.Block {
 		return hclwrite.BuildBlock("generate", builders...)
 	}
-	// cfg instead of config because name conflicts with config pkg
 	cfg := func(builders ...hclwrite.BlockBuilder) *hclwrite.Block {
 		return hclwrite.BuildBlock("config", builders...)
 	}
@@ -34,7 +32,7 @@ func TestFilenameConflictsOnGeneration(t *testing.T) {
 	tcases := []testcase{
 		{
 			name:   "export_as_locals conflicting with generate_hcl",
-			layout: []string{"stacks/stack"},
+			layout: []string{"s:stacks/stack"},
 			configs: []hclconfig{
 				{
 					path: "stacks",
@@ -62,7 +60,7 @@ func TestFilenameConflictsOnGeneration(t *testing.T) {
 			s.BuildTree(tcase.layout)
 
 			for _, cfg := range tcase.configs {
-				cfg.Append(t, s.RootDir())
+				cfg.append(t, s.RootDir())
 			}
 
 			workingDir := filepath.Join(s.RootDir(), tcase.workingDir)

--- a/generate/generate_conflicts_test.go
+++ b/generate/generate_conflicts_test.go
@@ -1,3 +1,17 @@
+// Copyright 2022 Mineiros GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package generate_test
 
 import (

--- a/generate/generate_conflicts_test.go
+++ b/generate/generate_conflicts_test.go
@@ -1,0 +1,73 @@
+package generate_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/madlambda/spells/assert"
+	"github.com/mineiros-io/terramate/generate"
+	"github.com/mineiros-io/terramate/test/hclwrite"
+	"github.com/mineiros-io/terramate/test/sandbox"
+)
+
+func TestFilenameConflictsOnGeneration(t *testing.T) {
+	// This test checks for how different code generation strategies
+	// fail if they have conflicting filename configurations.
+	// Like 2 different strategies that will write to the same filename.
+	type testcase struct {
+		name       string
+		layout     []string
+		configs    []hclconfig
+		workingDir string
+		want       error
+	}
+
+	// gen instead of generate because name conflicts with generate pkg
+	gen := func(builders ...hclwrite.BlockBuilder) *hclwrite.Block {
+		return hclwrite.BuildBlock("generate", builders...)
+	}
+	// cfg instead of config because name conflicts with config pkg
+	cfg := func(builders ...hclwrite.BlockBuilder) *hclwrite.Block {
+		return hclwrite.BuildBlock("config", builders...)
+	}
+
+	tcases := []testcase{
+		{
+			name:   "export_as_locals conflicting with generate_hcl",
+			layout: []string{"stacks/stack"},
+			configs: []hclconfig{
+				{
+					path: "stacks",
+					add: hcldoc(
+						terramate(cfg(gen(
+							str("locals_filename", "file.tf"),
+						))),
+						exportAsLocals(
+							str("test", "val"),
+						),
+						generateHCL(
+							labels("file.tf"),
+							block("test"),
+						),
+					),
+				},
+			},
+			want: generate.ErrConflictingConfig,
+		},
+	}
+
+	for _, tcase := range tcases {
+		t.Run(tcase.name, func(t *testing.T) {
+			s := sandbox.New(t)
+			s.BuildTree(tcase.layout)
+
+			for _, cfg := range tcase.configs {
+				cfg.Append(t, s.RootDir())
+			}
+
+			workingDir := filepath.Join(s.RootDir(), tcase.workingDir)
+			err := generate.Do(s.RootDir(), workingDir)
+			assert.IsError(t, err, tcase.want)
+		})
+	}
+}

--- a/generate/generate_hcl_test.go
+++ b/generate/generate_hcl_test.go
@@ -24,17 +24,12 @@ import (
 	"github.com/madlambda/spells/assert"
 	"github.com/mineiros-io/terramate/config"
 	"github.com/mineiros-io/terramate/generate"
-	"github.com/mineiros-io/terramate/test"
 	"github.com/mineiros-io/terramate/test/hclwrite"
 	"github.com/mineiros-io/terramate/test/sandbox"
 )
 
 func TestHCLGeneration(t *testing.T) {
 	type (
-		hclconfig struct {
-			path string
-			add  fmt.Stringer
-		}
 		want struct {
 			stack string
 			hcls  map[string]fmt.Stringer
@@ -279,8 +274,7 @@ func TestHCLGeneration(t *testing.T) {
 			s.BuildTree(tcase.layout)
 
 			for _, cfg := range tcase.configs {
-				path := filepath.Join(s.RootDir(), cfg.path)
-				test.AppendFile(t, path, config.Filename, cfg.add.String())
+				cfg.Append(t, s.RootDir())
 			}
 
 			assertGeneratedHCLs := func(t *testing.T) {

--- a/generate/generate_hcl_test.go
+++ b/generate/generate_hcl_test.go
@@ -274,7 +274,7 @@ func TestHCLGeneration(t *testing.T) {
 			s.BuildTree(tcase.layout)
 
 			for _, cfg := range tcase.configs {
-				cfg.Append(t, s.RootDir())
+				cfg.append(t, s.RootDir())
 			}
 
 			assertGeneratedHCLs := func(t *testing.T) {

--- a/generate/generate_test.go
+++ b/generate/generate_test.go
@@ -15,13 +15,28 @@
 package generate_test
 
 import (
+	"fmt"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/madlambda/spells/assert"
+	"github.com/mineiros-io/terramate/config"
+	"github.com/mineiros-io/terramate/test"
 	"github.com/rs/zerolog"
 )
+
+type hclconfig struct {
+	path string
+	add  fmt.Stringer
+}
+
+func (c hclconfig) Append(t *testing.T, rootdir string) {
+	t.Helper()
+	path := filepath.Join(rootdir, c.path)
+	test.AppendFile(t, path, config.Filename, c.add.String())
+}
 
 func assertHCLEquals(t *testing.T, got string, want string) {
 	t.Helper()

--- a/generate/generate_test.go
+++ b/generate/generate_test.go
@@ -32,7 +32,7 @@ type hclconfig struct {
 	add  fmt.Stringer
 }
 
-func (c hclconfig) Append(t *testing.T, rootdir string) {
+func (c hclconfig) append(t *testing.T, rootdir string) {
 	t.Helper()
 	path := filepath.Join(rootdir, c.path)
 	test.AppendFile(t, path, config.Filename, c.add.String())

--- a/hcl/hcl.go
+++ b/hcl/hcl.go
@@ -895,6 +895,11 @@ func parseGenerateConfig(block *hclsyntax.Block) (GenerateConfig, error) {
 		}
 	}
 
+	if cfg.LocalsFilename != "" && cfg.LocalsFilename == cfg.BackendCfgFilename {
+		return GenerateConfig{}, fmt.Errorf(
+			"terramate.config.generate: locals and backend cfg filenames have the same %q value", cfg.LocalsFilename)
+	}
+
 	return cfg, nil
 }
 

--- a/hcl/hcl.go
+++ b/hcl/hcl.go
@@ -897,7 +897,7 @@ func parseGenerateConfig(block *hclsyntax.Block) (GenerateConfig, error) {
 
 	if cfg.LocalsFilename != "" && cfg.LocalsFilename == cfg.BackendCfgFilename {
 		return GenerateConfig{}, fmt.Errorf(
-			"terramate.config.generate: locals and backend cfg filenames have the same %q value", cfg.LocalsFilename)
+			"terramate.config.generate: locals and backend cfg files have the same name %q", cfg.LocalsFilename)
 	}
 
 	return cfg, nil

--- a/hcl/hcl_test.go
+++ b/hcl/hcl_test.go
@@ -543,6 +543,20 @@ terramate {
 			},
 		},
 		{
+			name: "config.generate with conflicting config fails",
+			input: `terramate {
+				  config {
+				    generate {
+				      backend_config_filename = "file.tf"
+				      locals_filename = "file.tf"
+				    }
+				  }
+				}`,
+			want: want{
+				err: hcl.ErrMalformedTerramateConfig,
+			},
+		},
+		{
 			name: "config.generate block with invalid cfg",
 			input: `terramate {
 				  config {

--- a/test/sandbox/sandbox.go
+++ b/test/sandbox/sandbox.go
@@ -169,20 +169,21 @@ func (s S) BuildTree(layout []string) {
 	for _, spec := range layout {
 		path, data := parsePathData(spec)
 
-		switch spec[0] {
-		case 'd':
+		specKind := string(spec[0:2])
+		switch specKind {
+		case "d:":
 			test.MkdirAll(t, filepath.Join(s.rootdir, spec[2:]))
-		case 's':
+		case "s:":
 			if data == "" {
 				s.CreateStack(path)
 				continue
 			}
 
 			gentmfile(path, data)
-		case 'f':
+		case "f:":
 			test.WriteFile(t, s.rootdir, path, data)
 		default:
-			t.Fatalf("unknown tree identifier: %d", spec[0])
+			t.Fatalf("unknown spec kind: %q", specKind)
 		}
 	}
 }


### PR DESCRIPTION
Now this:

```sh
#!/bin/bash

set -o nounset
set -o errexit

basedir=$(mktemp -d)

cd "${basedir}"

# We need the project root config since it is not git
cat > terramate.tm.hcl <<- EOM
terramate {
  config {
  }
}
EOM

mkdir -p stacks/stack
terramate stacks init stacks/stack

cat > stacks/terramate.tm.hcl <<- EOM
terramate {
  config {
    generate {
      locals_filename = "file.tf"
    }
  }
}
generate_hcl "file.tf" {
    block {}
}
export_as_locals {
    something = "hi"
}
EOM

terramate generate
```

Will fail like this:

```
2022-02-08T16:11:25+01:00 FTL generating code. error="failed to generate code: conflicting config detected: two configurations produce same file \"file.tf\""
```

Instead of overwriting each other. The error message can be improved on the future with information about the origin of the config.