### PR TITLE
fix: use GH PAT credential instead of GITHUB_TOKEN

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
           go-version: 1.17
 
       - name: Log in to ghcr.io container registry
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+        run: echo "${{ secrets.MINEIROS_IAC_GITHUB_TOKEN }}" | docker login ghcr.io -u USERNAME --password-stdin
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2


### PR DESCRIPTION
When doing an actual release, goreleaser failed to push the image with:

```
release failed after 76.[87](https://github.com/mineiros-io/terramate/runs/5142899034?check_suite_focus=true#step:5:87)s error=docker images: failed to publish artifacts: failed to push ghcr.io/mineiros-io/terramate:latest: exit status 1: The push refers to repository [ghcr.io/mineiros-io/terramate]
6fce026cb[88](https://github.com/mineiros-io/terramate/runs/5142899034?check_suite_focus=true#step:5:88)e: Preparing
36ffdceb4c77: Preparing
36ffdceb4c77: Layer already exists
denied: installation not allowed to Write organization package
Error: The process '/opt/hostedtoolcache/goreleaser-action/1.2.5/x64/goreleaser' failed with exit code 1
```

It is quite odd since using docker push worked to push the images, at least when testing on the CI workflow: https://github.com/mineiros-io/terramate/runs/5143013962?check_suite_focus=true

For the future support for homebrew we will need a PAT token anyway since access is cross-repo, from go releaser docs: https://goreleaser.com/ci/actions/#token-permissions

"
If you need to push the homebrew tap to another repository, you must therefore create a custom [Personal Access Token](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/) with repo permissions and [add it as a secret in the repository](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/creating-and-using-encrypted-secrets).
"