### PR TITLE
docs: update docs on configuration allowing multiple files

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -1,19 +1,24 @@
 # Terramate Configuration
 
 There is a series of different configurations that can be done
-on Terramate, ranging from avoiding duplication to controlling
-order of execution of stacks.
+on Terramate, ranging from avoiding duplication by leveraging
+powerful code generation to flexible orchestration by allowing
+control of stacks order of execution.
 
-In order to do so, Terramate works with configuration files named
-**terramate.tm.hcl**. These files can be found in any directory
-of a Terramate project, but some configurations will be defined
-only once for an entire project, while others provide merge/overriding
-strategies, while others control only behavior specific for
-stacks.
+In order to do so, Terramate works with configuration files that
+have the suffixes:
 
-Here is defined the different kinds of configurations and
+* `tm`
+* `tm.hcl`
+
+Terramate files can be found in any directory of a Terramate project and
+all the files in a single directory will be handled as the concatenation
+of all of them in a single file.
+
+Here we define the different kinds of configurations and
 how you can learn more about them. But before getting into the different
-kinds of configurations, what would be a Terramate project?
+kinds of configurations and all that you can do with Terramate,
+what would be a Terramate project?
 
 A Terramate project is essentially any collection of Terraform code
 organized into stacks. You can have all Terraform code together in a single
@@ -36,35 +41,22 @@ In general, a Terramate project looks like this:
 
 Per project configuration can be defined only once at the project root dir.
 
-Available project-wide configurations can be found [here](project-config.md)
+Available project-wide configurations can be found [here](project-config.md).
 
 # Stack Configuration
 
 Before talking about stack specific configuration, lets define what is a
 Terramate stack:
 
-* Has a valid terramate configuration file (**terramate.tm.hcl**).
-* The terramate configuration file has a `stack {}` block on it.
+* Has one or more Terramate configuration files.
+* One of the configuration files has a `stack {}` block on it.
 * It has no stacks on any of its subdirs (stacks can't have stacks inside them).
 
-Stacks have configurations that are particular to them, like these:
+Here is the list of configurations specific to stacks:
 
 * [Execution Ordering](execution-order.md)
-* [Locals Generation](locals-generation.md)
-
-[Metadata](metadata.md) can be used on any hierarchical configuration,
-it provides information that is useful to stack configuration and is
-always evaluated on the context of a stack.
-
-# Hierarchical Configuration
-
-Hierarchical configuration is all configuration that can be defined on
-any Terramate dir, with each kind of configuration having different semantics
-on how overriding/merging happens when multiple configurations are
-present across the project.
-
-The following configurations have hierarchical behavior:
-
-* [Code Generation](code-generation-config.md)
 * [Globals](globals.md)
+* [HCL Generation](hcl-generation.md)
+* [Code Generation](code-generation-config.md)
+* [Locals Generation](locals-generation.md)
 * [Backend](backend-config.md)


### PR DESCRIPTION
We wont rely on a single `terramate.tm.hcl` anymore. Also removed some redundant info on the config docs.