### PR TITLE
feat: add content block on generate_hcl 

### DIFF
--- a/docs/hcl-generation.md
+++ b/docs/hcl-generation.md
@@ -68,7 +68,6 @@ in the root configuration:
 generate_hcl "provider.tf" {
 
   content {
-
     provider "name" {
       param = global.provider_data
     }

--- a/docs/hcl-generation.md
+++ b/docs/hcl-generation.md
@@ -22,6 +22,9 @@ other reference is just transported to the generated code (partial evaluation).
 Each `generate_hcl` block requires a single label.
 This label is the filename of the generated code.
 
+Inside the `generate_hcl` block a `content` block is required.
+All code inside `content` is going to be used to generate the final code.
+
 Now lets jump to some examples. Lets generate backend and provider configurations
 for all stacks inside a project.
 
@@ -42,8 +45,10 @@ of the project:
 
 ```hcl
 generate_hcl "backend.tf" {
-  backend "local" {
-    param = global.backend_data
+  content {
+    backend "local" {
+      param = global.backend_data
+    }
   }
 }
 ```
@@ -62,22 +67,27 @@ in the root configuration:
 ```hcl
 generate_hcl "provider.tf" {
 
-  provider "name" {
-    param = global.provider_data
-  }
+  content {
 
-  terraform {
-    required_providers {
-      name = {
-        source  = "integrations/name"
-        version = global.provider_version
+    provider "name" {
+      param = global.provider_data
+    }
+
+    terraform {
+      required_providers {
+        name = {
+          source  = "integrations/name"
+          version = global.provider_version
+        }
       }
     }
+
+    terraform {
+      required_version = global.terraform_version
+    }
+
   }
 
-  terraform {
-    required_version = global.terraform_version
-  }
 }
 ```
 

--- a/generate/generate_check_test.go
+++ b/generate/generate_check_test.go
@@ -43,8 +43,10 @@ func TestCheckReturnsOutdatedStackFilenamesForGeneratedHCL(t *testing.T) {
 		stackConfig(
 			generateHCL(
 				labels("test.tf"),
-				terraform(
-					str("required_version", "1.10"),
+				content(
+					terraform(
+						str("required_version", "1.10"),
+					),
 				),
 			),
 		).String())
@@ -59,8 +61,10 @@ func TestCheckReturnsOutdatedStackFilenamesForGeneratedHCL(t *testing.T) {
 		stackConfig(
 			generateHCL(
 				labels("test.tf"),
-				terraform(
-					str("required_version", "1.11"),
+				content(
+					terraform(
+						str("required_version", "1.11"),
+					),
 				),
 			),
 		).String())
@@ -75,8 +79,10 @@ func TestCheckReturnsOutdatedStackFilenamesForGeneratedHCL(t *testing.T) {
 		stackConfig(
 			generateHCL(
 				labels("testnew.tf"),
-				terraform(
-					str("required_version", "1.11"),
+				content(
+					terraform(
+						str("required_version", "1.11"),
+					),
 				),
 			),
 		).String())
@@ -88,14 +94,18 @@ func TestCheckReturnsOutdatedStackFilenamesForGeneratedHCL(t *testing.T) {
 		stackConfig(
 			generateHCL(
 				labels("testnew.tf"),
-				terraform(
-					str("required_version", "1.11"),
+				content(
+					terraform(
+						str("required_version", "1.11"),
+					),
 				),
 			),
 			generateHCL(
 				labels("another.tf"),
-				backend(
-					labels("type"),
+				content(
+					backend(
+						labels("type"),
+					),
 				),
 			),
 		).String())
@@ -135,6 +145,7 @@ func TestCheckOutdatedIgnoresEmptyGenerateHCLBlocks(t *testing.T) {
 		stackConfig(
 			generateHCL(
 				labels("test.tf"),
+				content(),
 			),
 		).String())
 
@@ -145,7 +156,9 @@ func TestCheckOutdatedIgnoresEmptyGenerateHCLBlocks(t *testing.T) {
 		stackConfig(
 			generateHCL(
 				labels("test.tf"),
-				block("whatever"),
+				content(
+					block("whatever"),
+				),
 			),
 		).String())
 
@@ -159,6 +172,7 @@ func TestCheckOutdatedIgnoresEmptyGenerateHCLBlocks(t *testing.T) {
 		stackConfig(
 			generateHCL(
 				labels("test.tf"),
+				content(),
 			),
 		).String())
 

--- a/generate/generate_conflicts_test.go
+++ b/generate/generate_conflicts_test.go
@@ -59,7 +59,9 @@ func TestFilenameConflictsOnGeneration(t *testing.T) {
 						),
 						generateHCL(
 							labels("file.tf"),
-							block("test"),
+							content(
+								block("test"),
+							),
 						),
 					),
 				},
@@ -79,7 +81,9 @@ func TestFilenameConflictsOnGeneration(t *testing.T) {
 						exportAsLocals(),
 						generateHCL(
 							labels("file.tf"),
-							block("test"),
+							content(
+								block("test"),
+							),
 						),
 					),
 				},
@@ -101,6 +105,7 @@ func TestFilenameConflictsOnGeneration(t *testing.T) {
 						),
 						generateHCL(
 							labels("file.tf"),
+							content(),
 						),
 					),
 				},

--- a/generate/generate_hcl_test.go
+++ b/generate/generate_hcl_test.go
@@ -71,7 +71,10 @@ func TestHCLGeneration(t *testing.T) {
 			configs: []hclconfig{
 				{
 					path: "/stacks",
-					add:  generateHCL(labels("empty")),
+					add: generateHCL(
+						labels("empty"),
+						content(),
+					),
 				},
 			},
 		},
@@ -87,37 +90,43 @@ func TestHCLGeneration(t *testing.T) {
 					add: hcldoc(
 						generateHCL(
 							labels("backend.tf"),
-							backend(
-								labels("test"),
-								expr("prefix", "global.backend_prefix"),
+							content(
+								backend(
+									labels("test"),
+									expr("prefix", "global.backend_prefix"),
+								),
 							),
 						),
 						generateHCL(
 							labels("locals.tf"),
-							locals(
-								expr("stackpath", "terramate.path"),
-								expr("local_a", "global.local_a"),
-								expr("local_b", "global.local_b"),
-								expr("local_c", "global.local_c"),
-								expr("local_d", "try(global.local_d.field, null)"),
+							content(
+								locals(
+									expr("stackpath", "terramate.path"),
+									expr("local_a", "global.local_a"),
+									expr("local_b", "global.local_b"),
+									expr("local_c", "global.local_c"),
+									expr("local_d", "try(global.local_d.field, null)"),
+								),
 							),
 						),
 						generateHCL(
 							labels("provider.tf"),
-							provider(
-								labels("name"),
-								expr("data", "global.provider_data"),
-							),
-							terraform(
-								required_providers(
-									expr("name", `{
+							content(
+								provider(
+									labels("name"),
+									expr("data", "global.provider_data"),
+								),
+								terraform(
+									required_providers(
+										expr("name", `{
 										source  = "integrations/name"
 										version = global.provider_version
 									}`),
+									),
 								),
-							),
-							terraform(
-								expr("required_version", "global.terraform_version"),
+								terraform(
+									expr("required_version", "global.terraform_version"),
+								),
 							),
 						),
 					),
@@ -230,10 +239,12 @@ func TestHCLGeneration(t *testing.T) {
 					add: hcldoc(
 						generateHCL(
 							labels("traversal.tf"),
-							block("traversal",
-								expr("locals", "local.hi"),
-								expr("some_anything", "something.should_work"),
-								expr("multiple_traversal", "one.two.three.four.five"),
+							content(
+								block("traversal",
+									expr("locals", "local.hi"),
+									expr("some_anything", "something.should_work"),
+									expr("multiple_traversal", "one.two.three.four.five"),
+								),
 							),
 						),
 					),
@@ -352,8 +363,10 @@ func TestWontOverwriteManuallyDefinedTerraform(t *testing.T) {
 
 	generateHCLConfig := generateHCL(
 		labels(genFilename),
-		terraform(
-			str("required_version", "1.11"),
+		content(
+			terraform(
+				str("required_version", "1.11"),
+			),
 		),
 	)
 
@@ -377,8 +390,10 @@ func TestGenerateHCLOverwriting(t *testing.T) {
 
 	firstConfig := generateHCL(
 		labels(genFilename),
-		terraform(
-			str("required_version", "1.11"),
+		content(
+			terraform(
+				str("required_version", "1.11"),
+			),
 		),
 	)
 	firstWant := terraform(
@@ -397,8 +412,10 @@ func TestGenerateHCLOverwriting(t *testing.T) {
 
 	secondConfig := generateHCL(
 		labels(genFilename),
-		terraform(
-			str("required_version", "2.0"),
+		content(
+			terraform(
+				str("required_version", "2.0"),
+			),
 		),
 	)
 	secondWant := terraform(
@@ -427,8 +444,10 @@ func TestGeneratedHCLHeaders(t *testing.T) {
 	rootEntry.CreateConfig(
 		generateHCL(
 			labels(rootFilename),
-			block("root",
-				str("attr", "root"),
+			content(
+				block("root",
+					str("attr", "root"),
+				),
 			),
 		).String(),
 	)
@@ -438,8 +457,10 @@ func TestGeneratedHCLHeaders(t *testing.T) {
 			stack(),
 			generateHCL(
 				labels(stackFilename),
-				block("stack",
-					str("attr", "stack"),
+				content(
+					block("stack",
+						str("attr", "stack"),
+					),
 				),
 			),
 		).String(),
@@ -468,14 +489,18 @@ func TestGenerateHCLCleanupOldFiles(t *testing.T) {
 		hcldoc(
 			generateHCL(
 				labels("file1.tf"),
-				block("block1",
-					boolean("whatever", true),
+				content(
+					block("block1",
+						boolean("whatever", true),
+					),
 				),
 			),
 			generateHCL(
 				labels("file2.tf"),
-				block("block2",
-					boolean("whatever", true),
+				content(
+					block("block2",
+						boolean("whatever", true),
+					),
 				),
 			),
 		).String(),
@@ -490,8 +515,10 @@ func TestGenerateHCLCleanupOldFiles(t *testing.T) {
 		hcldoc(
 			generateHCL(
 				labels("file1.tf"),
-				block("block1",
-					boolean("whatever", true),
+				content(
+					block("block1",
+						boolean("whatever", true),
+					),
 				),
 			),
 		).String(),
@@ -506,6 +533,7 @@ func TestGenerateHCLCleanupOldFiles(t *testing.T) {
 		hcldoc(
 			generateHCL(
 				labels("file1.tf"),
+				content(),
 			),
 		).String(),
 	)

--- a/generate/generate_hclwrite_utils_test.go
+++ b/generate/generate_hclwrite_utils_test.go
@@ -34,6 +34,10 @@ func generateHCL(builders ...hclwrite.BlockBuilder) *hclwrite.Block {
 	return hclwrite.BuildBlock("generate_hcl", builders...)
 }
 
+func content(builders ...hclwrite.BlockBuilder) *hclwrite.Block {
+	return hclwrite.BuildBlock("content", builders...)
+}
+
 func expr(name string, expr string) hclwrite.BlockBuilder {
 	return hclwrite.Expression(name, expr)
 }

--- a/generate/genhcl/genhcl.go
+++ b/generate/genhcl/genhcl.go
@@ -135,6 +135,8 @@ func Load(rootdir string, sm stack.Metadata, globals *terramate.Globals) (StackH
 		}
 	}
 
+	logger.Trace().Msg("evaluated all blocks with success.")
+
 	return res, nil
 }
 
@@ -196,13 +198,20 @@ func loadGenHCLBlocks(rootdir string, cfgdir string) (map[string]loadedHCL, erro
 		return nil, fmt.Errorf("parsing generate_hcl code: %v", err)
 	}
 
+	logger.Trace().Msg("Parsed generate_hcl blocks.")
+
 	res := map[string]loadedHCL{}
 
 	// TODO(katcipis): improve error messages by including filenames/path
 	for _, genhclBlock := range blocks {
+		logger.Trace().Msg("Validating generate_hcl block.")
+
 		if err := validateGenerateHCLBlock(genhclBlock); err != nil {
-			return nil, fmt.Errorf("%w:%v", ErrInvalidBlock, err)
+			return nil, fmt.Errorf("%w: %v", ErrInvalidBlock, err)
 		}
+
+		logger.Trace().Msg("generate_hcl block is valid.")
+
 		name := genhclBlock.Labels[0]
 		if _, ok := res[name]; ok {
 			return nil, fmt.Errorf(
@@ -216,6 +225,8 @@ func loadGenHCLBlocks(rootdir string, cfgdir string) (map[string]loadedHCL, erro
 			origin: strings.TrimPrefix(cfgpath, rootdir),
 			block:  contentBlock,
 		}
+
+		logger.Trace().Msg("loaded generate_hcl block.")
 	}
 
 	parentRes, err := loadGenHCLBlocks(rootdir, filepath.Dir(cfgdir))
@@ -225,6 +236,8 @@ func loadGenHCLBlocks(rootdir string, cfgdir string) (map[string]loadedHCL, erro
 	if err := join(res, parentRes); err != nil {
 		return nil, fmt.Errorf("%w: %v", ErrMultiLevelConflict, err)
 	}
+
+	logger.Trace().Msg("loaded generate_hcl blocks with success.")
 	return res, nil
 }
 

--- a/generate/genhcl/genhcl_test.go
+++ b/generate/genhcl/genhcl_test.go
@@ -30,9 +30,6 @@ import (
 	"github.com/rs/zerolog"
 )
 
-// TESTS
-// - attributes inside content block should work
-
 func TestLoadGeneratedHCL(t *testing.T) {
 	type (
 		hclconfig struct {
@@ -622,7 +619,7 @@ func TestLoadGeneratedHCL(t *testing.T) {
 			wantErr: genhcl.ErrMultiLevelConflict,
 		},
 		{
-			name:  "block with no label on stack gives err",
+			name:  "block with no label fails",
 			stack: "/stacks/stack",
 			configs: []hclconfig{
 				{
@@ -639,13 +636,64 @@ func TestLoadGeneratedHCL(t *testing.T) {
 			wantErr: genhcl.ErrInvalidBlock,
 		},
 		{
-			name:  "content block is required",
+			name:  "generate_hcl with non-content block inside fails",
+			stack: "/stacks/stack",
+			configs: []hclconfig{
+				{
+					path: "/stacks/stack",
+					add: generateHCL(
+						labels("test"),
+						block("block",
+							str("data", "some literal data"),
+						),
+					),
+				},
+			},
+			wantErr: genhcl.ErrInvalidBlock,
+		},
+		{
+			name:  "generate_hcl with other blocks than content fails",
+			stack: "/stacks/stack",
+			configs: []hclconfig{
+				{
+					path: "/stacks/stack",
+					add: generateHCL(
+						labels("test"),
+						content(
+							str("data", "some literal data"),
+						),
+						block("block",
+							str("data", "some literal data"),
+						),
+					),
+				},
+			},
+			wantErr: genhcl.ErrInvalidBlock,
+		},
+		{
+			name:  "generate_hcl.content block is required",
 			stack: "/stack",
 			configs: []hclconfig{
 				{
 					path: "/stack",
 					add: generateHCL(
 						labels("empty"),
+					),
+				},
+			},
+			wantErr: genhcl.ErrInvalidBlock,
+		},
+		{
+			name:  "generate_hcl.content block with label fails",
+			stack: "/stack",
+			configs: []hclconfig{
+				{
+					path: "/stack",
+					add: generateHCL(
+						labels("empty"),
+						content(
+							labels("not allowed"),
+						),
 					),
 				},
 			},

--- a/generate/genhcl/genhcl_test.go
+++ b/generate/genhcl/genhcl_test.go
@@ -30,6 +30,9 @@ import (
 	"github.com/rs/zerolog"
 )
 
+// TESTS
+// - attributes inside content block should work
+
 func TestLoadGeneratedHCL(t *testing.T) {
 	type (
 		hclconfig struct {
@@ -68,6 +71,9 @@ func TestLoadGeneratedHCL(t *testing.T) {
 	globals := func(builders ...hclwrite.BlockBuilder) *hclwrite.Block {
 		return hclwrite.BuildBlock("globals", builders...)
 	}
+	content := func(builders ...hclwrite.BlockBuilder) *hclwrite.Block {
+		return hclwrite.BuildBlock("content", builders...)
+	}
 	attr := func(name, expr string) hclwrite.BlockBuilder {
 		t.Helper()
 		return hclwrite.AttributeValue(t, name, expr)
@@ -90,13 +96,14 @@ func TestLoadGeneratedHCL(t *testing.T) {
 			stack: "/stack",
 		},
 		{
-			name:  "empty block generates empty code",
+			name:  "empty content block generates empty code",
 			stack: "/stack",
 			configs: []hclconfig{
 				{
 					path: "/stack",
 					add: generateHCL(
 						labels("empty"),
+						content(),
 					),
 				},
 			},
@@ -118,7 +125,9 @@ func TestLoadGeneratedHCL(t *testing.T) {
 					path: "/stack",
 					add: generateHCL(
 						labels("emptytest"),
-						block("empty"),
+						content(
+							block("empty"),
+						),
 					),
 				},
 			},
@@ -140,11 +149,13 @@ func TestLoadGeneratedHCL(t *testing.T) {
 					path: "/stack",
 					add: generateHCL(
 						labels("scope_traversal"),
-						block("traversals",
-							expr("local", "local.something"),
-							expr("mul", "omg.wat.something"),
-							expr("res", "resource.something"),
-							expr("val", "omg.something"),
+						content(
+							block("traversals",
+								expr("local", "local.something"),
+								expr("mul", "omg.wat.something"),
+								expr("res", "resource.something"),
+								expr("val", "omg.something"),
+							),
 						),
 					),
 				},
@@ -180,15 +191,17 @@ func TestLoadGeneratedHCL(t *testing.T) {
 					path: "/stack",
 					add: generateHCL(
 						labels("test"),
-						block("testblock",
-							expr("bool", "global.some_bool"),
-							expr("number", "global.some_number"),
-							expr("string", "global.some_string"),
-							expr("obj", `{
-								string = global.some_string
-								number = global.some_number
-								bool = global.some_bool
-							}`),
+						content(
+							block("testblock",
+								expr("bool", "global.some_bool"),
+								expr("number", "global.some_number"),
+								expr("string", "global.some_string"),
+								expr("obj", `{
+									string = global.some_string
+									number = global.some_number
+									bool = global.some_bool
+								}`),
+							),
 						),
 					),
 				},
@@ -230,12 +243,14 @@ func TestLoadGeneratedHCL(t *testing.T) {
 					path: "/stack",
 					add: generateHCL(
 						labels("test"),
-						block("labeled",
-							labels("label1", "label2"),
-							expr("field_a", "try(global.obj.field_a, null)"),
-							expr("field_b", "try(global.obj.field_b, null)"),
-							expr("field_c", "try(global.obj.field_c, null)"),
-							expr("field_d", "try(global.obj.field_d, null)"),
+						content(
+							block("labeled",
+								labels("label1", "label2"),
+								expr("field_a", "try(global.obj.field_a, null)"),
+								expr("field_b", "try(global.obj.field_b, null)"),
+								expr("field_c", "try(global.obj.field_c, null)"),
+								expr("field_d", "try(global.obj.field_d, null)"),
+							),
 						),
 					),
 				},
@@ -272,17 +287,19 @@ func TestLoadGeneratedHCL(t *testing.T) {
 					path: "/stack",
 					add: generateHCL(
 						labels("nesting"),
-						block("block1",
-							expr("bool", "global.some_bool"),
-							block("block2",
-								expr("number", "global.some_number"),
-								block("block3",
-									expr("string", "global.some_string"),
-									expr("obj", `{
-										string = global.some_string
-										number = global.some_number
-										bool = global.some_bool
-									}`),
+						content(
+							block("block1",
+								expr("bool", "global.some_bool"),
+								block("block2",
+									expr("number", "global.some_number"),
+									block("block3",
+										expr("string", "global.some_string"),
+										expr("obj", `{
+											string = global.some_string
+											number = global.some_number
+											bool = global.some_bool
+										}`),
+									),
 								),
 							),
 						),
@@ -326,23 +343,29 @@ func TestLoadGeneratedHCL(t *testing.T) {
 						),
 						generateHCL(
 							labels("exported_one"),
-							block("block1",
-								expr("bool", "global.some_bool"),
-								block("block2",
-									expr("number", "global.some_number"),
+							content(
+								block("block1",
+									expr("bool", "global.some_bool"),
+									block("block2",
+										expr("number", "global.some_number"),
+									),
 								),
 							),
 						),
 						generateHCL(
 							labels("exported_two"),
-							block("yay",
-								expr("data", "global.some_string"),
+							content(
+								block("yay",
+									expr("data", "global.some_string"),
+								),
 							),
 						),
 						generateHCL(
 							labels("exported_three"),
-							block("something",
-								expr("number", "global.some_number"),
+							content(
+								block("something",
+									expr("number", "global.some_number"),
+								),
 							),
 						),
 					),
@@ -397,12 +420,14 @@ func TestLoadGeneratedHCL(t *testing.T) {
 					path: "/stacks",
 					add: generateHCL(
 						labels("on_parent"),
-						block("on_parent_block",
-							expr("obj", `{
-								string = global.some_string
-								number = global.some_number
-								bool = global.some_bool
-							}`),
+						content(
+							block("on_parent_block",
+								expr("obj", `{
+									string = global.some_string
+									number = global.some_number
+									bool = global.some_bool
+								}`),
+							),
 						),
 					),
 				},
@@ -431,8 +456,10 @@ func TestLoadGeneratedHCL(t *testing.T) {
 					path: "/",
 					add: generateHCL(
 						labels("root"),
-						block("root",
-							expr("test", "terramate.path"),
+						content(
+							block("root",
+								expr("test", "terramate.path"),
+							),
 						),
 					),
 				},
@@ -463,10 +490,12 @@ func TestLoadGeneratedHCL(t *testing.T) {
 						),
 						generateHCL(
 							labels("on_root"),
-							block("on_root_block",
-								expr("obj", `{
-								string = global.some_string
-							}`),
+							content(
+								block("on_root_block",
+									expr("obj", `{
+										string = global.some_string
+									}`),
+								),
 							),
 						),
 					),
@@ -475,10 +504,12 @@ func TestLoadGeneratedHCL(t *testing.T) {
 					path: "/stacks",
 					add: generateHCL(
 						labels("on_parent"),
-						block("on_parent_block",
-							expr("obj", `{
-								number = global.some_number
-							}`),
+						content(
+							block("on_parent_block",
+								expr("obj", `{
+									number = global.some_number
+								}`),
+							),
 						),
 					),
 				},
@@ -486,10 +517,12 @@ func TestLoadGeneratedHCL(t *testing.T) {
 					path: "/stacks/stack",
 					add: generateHCL(
 						labels("on_stack"),
-						block("on_stack_block",
-							expr("obj", `{
-								bool = global.some_bool
-							}`),
+						content(
+							block("on_stack_block",
+								expr("obj", `{
+									bool = global.some_bool
+								}`),
+							),
 						),
 					),
 				},
@@ -538,8 +571,10 @@ func TestLoadGeneratedHCL(t *testing.T) {
 					path: "/stacks",
 					add: generateHCL(
 						labels("repeated"),
-						block("block",
-							str("data", "parent data"),
+						content(
+							block("block",
+								str("data", "parent data"),
+							),
 						),
 					),
 				},
@@ -547,8 +582,10 @@ func TestLoadGeneratedHCL(t *testing.T) {
 					path: "/stacks/stack",
 					add: generateHCL(
 						labels("repeated"),
-						block("block",
-							str("data", "stack data"),
+						content(
+							block("block",
+								str("data", "stack data"),
+							),
 						),
 					),
 				},
@@ -563,8 +600,10 @@ func TestLoadGeneratedHCL(t *testing.T) {
 					path: "/",
 					add: generateHCL(
 						labels("repeated"),
-						block("block",
-							str("data", "root data"),
+						content(
+							block("block",
+								str("data", "root data"),
+							),
 						),
 					),
 				},
@@ -572,8 +611,10 @@ func TestLoadGeneratedHCL(t *testing.T) {
 					path: "/stacks",
 					add: generateHCL(
 						labels("repeated"),
-						block("block",
-							str("data", "parent data"),
+						content(
+							block("block",
+								str("data", "parent data"),
+							),
 						),
 					),
 				},
@@ -586,10 +627,25 @@ func TestLoadGeneratedHCL(t *testing.T) {
 			configs: []hclconfig{
 				{
 					path: "/stacks/stack",
-					add: block("generate_hcl",
-						block("block",
-							str("data", "some literal data"),
+					add: generateHCL(
+						content(
+							block("block",
+								str("data", "some literal data"),
+							),
 						),
+					),
+				},
+			},
+			wantErr: genhcl.ErrInvalidBlock,
+		},
+		{
+			name:  "content block is required",
+			stack: "/stack",
+			configs: []hclconfig{
+				{
+					path: "/stack",
+					add: generateHCL(
+						labels("empty"),
 					),
 				},
 			},
@@ -603,8 +659,10 @@ func TestLoadGeneratedHCL(t *testing.T) {
 					path: "/stacks/stack",
 					add: block("generate_hcl",
 						labels("one", "two"),
-						block("block",
-							str("data", "some literal data"),
+						content(
+							block("block",
+								str("data", "some literal data"),
+							),
 						),
 					),
 				},
@@ -619,8 +677,10 @@ func TestLoadGeneratedHCL(t *testing.T) {
 					path: "/stacks/stack",
 					add: block("generate_hcl",
 						labels(""),
-						block("block",
-							str("data", "some literal data"),
+						content(
+							block("block",
+								str("data", "some literal data"),
+							),
 						),
 					),
 				},
@@ -636,14 +696,18 @@ func TestLoadGeneratedHCL(t *testing.T) {
 					add: hcldoc(
 						generateHCL(
 							labels("duplicated"),
-							terraform(
-								str("data", "some literal data"),
+							content(
+								terraform(
+									str("data", "some literal data"),
+								),
 							),
 						),
 						generateHCL(
 							labels("duplicated"),
-							terraform(
-								str("data2", "some literal data2"),
+							content(
+								terraform(
+									str("data2", "some literal data2"),
+								),
 							),
 						),
 					),
@@ -660,8 +724,10 @@ func TestLoadGeneratedHCL(t *testing.T) {
 					add: hcldoc(
 						generateHCL(
 							labels("test"),
-							terraform(
-								expr("required_version", "global.undefined"),
+							content(
+								terraform(
+									expr("required_version", "global.undefined"),
+								),
 							),
 						),
 					),
@@ -678,8 +744,10 @@ func TestLoadGeneratedHCL(t *testing.T) {
 					add: hcldoc(
 						generateHCL(
 							labels("test"),
-							terraform(
-								expr("much_wrong", "terramate.undefined"),
+							content(
+								terraform(
+									expr("much_wrong", "terramate.undefined"),
+								),
 							),
 						),
 					),
@@ -693,7 +761,7 @@ func TestLoadGeneratedHCL(t *testing.T) {
 			configs: []hclconfig{
 				{
 					path: "/stacks",
-					add: block("generate_hcl",
+					add: generateHCL(
 						block("block",
 							str("data", "some literal data"),
 						),
@@ -704,8 +772,10 @@ func TestLoadGeneratedHCL(t *testing.T) {
 					add: hcldoc(
 						generateHCL(
 							labels("valid"),
-							terraform(
-								str("data", "some literal data"),
+							content(
+								terraform(
+									str("data", "some literal data"),
+								),
 							),
 						),
 					),
@@ -723,8 +793,10 @@ func TestLoadGeneratedHCL(t *testing.T) {
 						generateHCL(
 							labels("test"),
 							str("some_attribute", "whatever"),
-							terraform(
-								str("required_version", "1.11"),
+							content(
+								terraform(
+									str("required_version", "1.11"),
+								),
 							),
 						),
 					),


### PR DESCRIPTION
This PRs changes the behavior of code generation using `generate_hcl`. Instead of generating code by doing:

```hcl
generate_hcl {
  terraform {
  }
}
```

All generated HCL must be inside the `content` block, like this:

```hcl
generate_hcl {
  content {
    terraform {
    }
  }
}
```

A full example:

```sh
#!/bin/bash

set -o nounset
set -o errexit

basedir=$(mktemp -d)

cd "${basedir}"

# We need the project root config since it is not git
cat > terramate.tm.hcl <<- EOM
terramate {
  config {
  }
}
EOM

mkdir -p stacks/stack-{1,2}
terramate stacks init stacks/stack-{1,2}

# Defining some code for all stacks
# Globals are defined on root and also on stacks, to showcase possibilities
# Inspired on: https://github.com/mineiros-io/terramate-blueprint-iac-github/tree/main/stacks/repositories/teamA
cat > stacks/terramate.tm.hcl <<- EOM
globals {
    tf_version = "1.1.3"
    gh_owner = "the-awesome-mineiros"
    gh_provider_version = "4.19.1"
}

generate_hcl "provider.tf" {
    content {
        provider "github" {
          owner = global.gh_owner
        }

        terraform {
          required_providers {
            github = {
              source  = "integrations/github"
              version = global.gh_provider_version
            }
          }
        }

        terraform {
          required_version = global.tf_version
        }
    }
}

generate_hcl "main.tf" {
  content {
      module "repositories" {
        source = "../../../modules/terramate-github-repositories"

        repositories        = global.repositories
        repository_defaults = global.repository_defaults
        member_map          = global.member_map
      }
  }
}
EOM

# Now add some per stack globals

cat > stacks/stack-1/terramate.tm.hcl <<- EOM
globals {
    repositories = [
        {
            name = "stack-1"
            visibility = "private"
        }
    ]
    repository_defaults = {
        config = "stack-1"
    }
    member_map  = {
        "first.lastname" = "powerpuffGirls69"
    }
}
stack {}
EOM

cat > stacks/stack-2/terramate.tm.hcl <<- EOM
globals {
    repositories = [
        {
            name = "stack-2"
            visibility = "public"
        }
    ]
    repository_defaults = {
        config = "stack-2"
    }
    member_map  = {
        "first.lastname" = "onePunchMan666"
    }
}
stack {}
EOM


echo "initial tree"
tree

echo
echo "generating code for all stacks"
terramate generate

echo "tree after generating code"
tree

echo
echo "checking generated main.tf files"
terramate run -- cat main.tf

echo
echo "checking generated provider.tf files"
terramate run -- cat provider.tf
```