### PR TITLE
feat: add multiple config files support to globals

### DIFF
--- a/globals.go
+++ b/globals.go
@@ -34,7 +34,8 @@ type Globals struct {
 }
 
 const (
-	ErrGlobalEval      errutil.Error = "global eval failed"
+	ErrGlobalEval      errutil.Error = "globals eval failed"
+	ErrGlobalParse     errutil.Error = "globals parsing failed"
 	ErrGlobalRedefined errutil.Error = "global redefined"
 )
 
@@ -243,7 +244,7 @@ func loadStackGlobalsExprs(rootdir string, cfgdir string) (*globalsExpr, error) 
 
 	blocks, err := hcl.ParseGlobalsBlocks(filepath.Join(rootdir, cfgdir))
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%w: %v", ErrGlobalParse, err)
 	}
 
 	globals := newGlobalsExpr()
@@ -252,8 +253,6 @@ func loadStackGlobalsExprs(rootdir string, cfgdir string) (*globalsExpr, error) 
 
 	for filename, fileblocks := range blocks {
 		logger.Trace().Msg("Range over block attributes.")
-
-		// TODO(katcipis): should check globals cant have blocks inside
 
 		for _, fileblock := range fileblocks {
 			for name, attr := range fileblock.Body.Attributes {

--- a/globals_test.go
+++ b/globals_test.go
@@ -679,6 +679,20 @@ func TestLoadGlobals(t *testing.T) {
 			},
 		},
 		{
+			name:   "globals cant have blocks inside",
+			layout: []string{"s:stack"},
+			configs: []hclconfig{
+				{
+					path: "/",
+					add: globals(
+						str("test", "hallo"),
+						block("notallowed"),
+					),
+				},
+			},
+			wantErr: terramate.ErrGlobalParse,
+		},
+		{
 			name:   "global undefined reference on root",
 			layout: []string{"s:stack"},
 			configs: []hclconfig{

--- a/globals_test.go
+++ b/globals_test.go
@@ -35,8 +35,9 @@ import (
 func TestLoadGlobals(t *testing.T) {
 	type (
 		globalsBlock struct {
-			path string
-			add  *hclwrite.Block
+			path     string
+			filename string
+			add      *hclwrite.Block
 		}
 		testcase struct {
 			name    string
@@ -604,7 +605,11 @@ func TestLoadGlobals(t *testing.T) {
 
 			for _, globalBlock := range tcase.globals {
 				path := filepath.Join(s.RootDir(), globalBlock.path)
-				test.AppendFile(t, path, config.DefaultFilename, globalBlock.add.String())
+				filename := config.DefaultFilename
+				if globalBlock.filename != "" {
+					filename = globalBlock.filename
+				}
+				test.AppendFile(t, path, filename, globalBlock.add.String())
 			}
 
 			wantGlobals := tcase.want

--- a/globals_test.go
+++ b/globals_test.go
@@ -48,11 +48,14 @@ func TestLoadGlobals(t *testing.T) {
 		}
 	)
 
-	globals := func(builders ...hclwrite.BlockBuilder) *hclwrite.Block {
-		return hclwrite.BuildBlock("globals", builders...)
+	labels := func(labels ...string) hclwrite.BlockBuilder {
+		return hclwrite.Labels(labels...)
 	}
 	block := func(name string, builders ...hclwrite.BlockBuilder) *hclwrite.Block {
 		return hclwrite.BuildBlock(name, builders...)
+	}
+	globals := func(builders ...hclwrite.BlockBuilder) *hclwrite.Block {
+		return block("globals", builders...)
 	}
 	expr := hclwrite.Expression
 	attr := func(name, expr string) hclwrite.BlockBuilder {
@@ -687,6 +690,20 @@ func TestLoadGlobals(t *testing.T) {
 					add: globals(
 						str("test", "hallo"),
 						block("notallowed"),
+					),
+				},
+			},
+			wantErr: terramate.ErrGlobalParse,
+		},
+		{
+			name:   "globals cant have labels",
+			layout: []string{"s:stack"},
+			configs: []hclconfig{
+				{
+					path: "/",
+					add: globals(
+						labels("no"),
+						str("test", "hallo"),
 					),
 				},
 			},

--- a/hcl/hcl.go
+++ b/hcl/hcl.go
@@ -310,8 +310,13 @@ func ParseGlobalsBlocks(dir string) (HCLBlocks, error) {
 		}
 
 		for _, block := range blocks {
+			// Not validated with schema because cant find a way to validate
+			// N arbitrary attributes (defined by user/dynamic).
 			if len(block.Body.Blocks) > 0 {
 				return nil, fmt.Errorf("blocks inside globals are not allowed at %q", fname)
+			}
+			if len(block.Labels) > 0 {
+				return nil, fmt.Errorf("labels on globals block are not allowed, found %v at %q", block.Labels, fname)
 			}
 		}
 

--- a/hcl/hcl.go
+++ b/hcl/hcl.go
@@ -308,6 +308,13 @@ func ParseGlobalsBlocks(dir string) (HCLBlocks, error) {
 		if len(blocks) == 0 {
 			continue
 		}
+
+		for _, block := range blocks {
+			if len(block.Body.Blocks) > 0 {
+				return nil, fmt.Errorf("blocks inside globals are not allowed at %q", fname)
+			}
+		}
+
 		hclblocks[fname] = blocks
 	}
 

--- a/hcl/hcl.go
+++ b/hcl/hcl.go
@@ -261,11 +261,11 @@ func ParseDir(dir string) (Config, error) {
 		Str("dir", dir).
 		Logger()
 
-	logger.Trace().Msg("loading parser for configuration files")
+	logger.Trace().Msg("Parsing configuration files")
 
 	loadedParser, err := loadCfgBlocks(dir)
 	if err != nil {
-		return Config{}, fmt.Errorf("loading parser for config files: %w", err)
+		return Config{}, fmt.Errorf("parsing config files: %w", err)
 	}
 
 	logger.Trace().Msg("creating config from loaded parser")
@@ -273,9 +273,45 @@ func ParseDir(dir string) (Config, error) {
 	return newCfgFromParsedHCLs(dir, loadedParser)
 }
 
-// ParseGlobalsBlocks parses globals blocks, ignoring any other blocks
-func ParseGlobalsBlocks(path string) ([]*hclsyntax.Block, error) {
-	return parseBlocksOfType(path, "globals")
+// HCLBlocks maps a filename to a slice of blocks associated with it
+type HCLBlocks map[string][]*hclsyntax.Block
+
+// ParseGlobalsBlocks parses all Terramate files on the given dir, returning
+// only global blocks (other blocks are discarded).
+func ParseGlobalsBlocks(dir string) (HCLBlocks, error) {
+	logger := log.With().
+		Str("action", "ParseGlobalsBlocks").
+		Str("configdir", dir).
+		Logger()
+
+	logger.Trace().Msg("loading config")
+
+	parser, err := loadCfgBlocks(dir)
+	if err != nil {
+		return HCLBlocks{}, fmt.Errorf("parsing globals: %w", err)
+	}
+
+	logger.Trace().Msg("Filtering globals blocks")
+
+	hclblocks := HCLBlocks{}
+
+	for fname, hclfile := range parser.Files() {
+		logger := logger.With().
+			Str("filename", fname).
+			Logger()
+
+		logger.Trace().Msg("Filtering globals blocks")
+		// A cast error here would be a severe programming error on Terramate
+		// side, so we are by design allowing the cast to panic
+		body := hclfile.Body.(*hclsyntax.Body)
+		blocks := filterBlocksByType("globals", body.Blocks)
+		if len(blocks) == 0 {
+			continue
+		}
+		hclblocks[fname] = blocks
+	}
+
+	return hclblocks, nil
 }
 
 // ParseExportAsLocalsBlocks parses export_as_locals blocks, ignoring other blocks
@@ -395,8 +431,8 @@ func parseBlocksOfType(path string, blocktype string) ([]*hclsyntax.Block, error
 		Str("path", path).
 		Logger()
 
-	logger.Trace().
-		Msg("Get file info.")
+	logger.Trace().Msg("Get file info.")
+
 	_, err := os.Stat(path)
 	if err != nil {
 		return nil, err
@@ -783,8 +819,8 @@ func filterBlocksByType(blocktype string, blocks []*hclsyntax.Block) []*hclsynta
 
 	var filtered []*hclsyntax.Block
 
-	logger.Trace().
-		Msg("Range over blocks.")
+	logger.Trace().Msg("Range over blocks.")
+
 	for _, block := range blocks {
 		if block.Type != blocktype {
 			continue


### PR DESCRIPTION
This PR allows globals to be defined on multiple files. We still lack suppor to export_as_locals and generate_hcl.

Example:

```sh
#!/bin/bash

set -o errexit
set -o nounset

basedir=$(mktemp -d)

cd "${basedir}"

cat > terramate.tm.hcl <<- EOM
terramate {
  config {
  }
}
EOM

mkdir -p stacks/stack-1
mkdir -p stacks/stack-2

terramate stacks init stacks/stack-1
terramate stacks init stacks/stack-2

echo "terramate list"
echo

terramate stacks list

echo

cat > stacks/globals1.tm.hcl <<- EOM
globals {
  testing = "test value"
}
EOM

cat > stacks/globals2.tm <<- EOM
globals {
  object = {
    name = "hello"
    data = "world"
  }
}
EOM

echo "terramate stacks globals"

terramate stacks globals
```