### PR TITLE
refactor: removes base_ref git option

### DIFF
--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -271,8 +271,8 @@ func newCLI(
 			Msg("project root not found")
 	}
 
-	logger.Trace().
-		Msg("Set defaults from parsed command line arguments.")
+	logger.Trace().Msg("Set defaults from parsed command line arguments.")
+
 	err = prj.setDefaults(&parsedArgs)
 	if err != nil {
 		logger.Fatal().
@@ -1177,10 +1177,6 @@ func (p *project) setDefaults(parsedArgs *cliSpec) error {
 	}
 	gitOpt := cfg.Terramate.RootConfig.Git
 
-	if gitOpt.BaseRef == "" {
-		gitOpt.BaseRef = defaultBaseRef
-	}
-
 	if gitOpt.DefaultBranchBaseRef == "" {
 		gitOpt.DefaultBranchBaseRef = defaultBranchBaseRef
 	}
@@ -1195,7 +1191,7 @@ func (p *project) setDefaults(parsedArgs *cliSpec) error {
 
 	baseRef := parsedArgs.GitChangeBase
 	if baseRef == "" {
-		baseRef = gitOpt.BaseRef
+		baseRef = defaultBaseRef
 		if p.isRepo {
 			logger.Trace().
 				Str("configFile", p.root+"/terramate.tm.hcl").

--- a/hcl/hcl.go
+++ b/hcl/hcl.go
@@ -46,7 +46,6 @@ type Config struct {
 }
 
 type GitConfig struct {
-	BaseRef              string // BaseRef is the general base git ref.
 	DefaultBranchBaseRef string // DefaultBranchBaseRef is the baseRef when in default branch.
 	DefaultBranch        string // DefaultBranch is the default branch.
 	DefaultRemote        string // DefaultRemote is the default remote.
@@ -800,16 +799,6 @@ func parseGitConfig(git *GitConfig, block *hclsyntax.Block) error {
 			}
 
 			git.DefaultRemote = attrVal.AsString()
-
-		case "base_ref":
-			logger.Trace().
-				Msg("Attribute name was 'base_ref.")
-			if attrVal.Type() != cty.String {
-				return fmt.Errorf("terramate.config.git.baseRef is not a string but %q",
-					attrVal.Type().FriendlyName())
-			}
-
-			git.BaseRef = attrVal.AsString()
 
 		case "default_branch_base_ref":
 			logger.Trace().

--- a/hcl/hcl_test.go
+++ b/hcl/hcl_test.go
@@ -706,7 +706,6 @@ func TestHCLParserRootConfig(t *testing.T) {
 								git {
 									default_branch = "trunk"
 									default_remote = "upstream"
-									base_ref = "upstream/trunk"
 									default_branch_base_ref = "HEAD~2"
 								}
 							}
@@ -721,7 +720,6 @@ func TestHCLParserRootConfig(t *testing.T) {
 							Git: &hcl.GitConfig{
 								DefaultBranch:        "trunk",
 								DefaultRemote:        "upstream",
-								BaseRef:              "upstream/trunk",
 								DefaultBranchBaseRef: "HEAD~2",
 							},
 						},
@@ -1148,7 +1146,6 @@ func TestHCLParserTerramateBlocksMerging(t *testing.T) {
 								git {
 									default_branch = "trunk"
 									default_remote = "upstream"
-									base_ref = "upstream/trunk"
 									default_branch_base_ref = "HEAD~2"
 								}
 							}
@@ -1161,7 +1158,6 @@ func TestHCLParserTerramateBlocksMerging(t *testing.T) {
 					Terramate: &hcl.Terramate{
 						RootConfig: &hcl.RootConfig{
 							Git: &hcl.GitConfig{
-								BaseRef:              "upstream/trunk",
 								DefaultBranch:        "trunk",
 								DefaultRemote:        "upstream",
 								DefaultBranchBaseRef: "HEAD~2",
@@ -1194,7 +1190,6 @@ func TestHCLParserTerramateBlocksMerging(t *testing.T) {
 								git {
 									default_branch = "trunk"
 									default_remote = "upstream"
-									base_ref = "upstream/trunk"
 									default_branch_base_ref = "HEAD~2"
 								}
 							}
@@ -1207,7 +1202,6 @@ func TestHCLParserTerramateBlocksMerging(t *testing.T) {
 					Terramate: &hcl.Terramate{
 						RootConfig: &hcl.RootConfig{
 							Git: &hcl.GitConfig{
-								BaseRef:              "upstream/trunk",
 								DefaultBranch:        "trunk",
 								DefaultRemote:        "upstream",
 								DefaultBranchBaseRef: "HEAD~2",
@@ -1322,7 +1316,7 @@ func TestHCLParserTerramateBlocksMerging(t *testing.T) {
 						terramate {
 							config {
 								git {
-									base_ref = "trunk"
+									default_remote = "upstream"
 								}
 							}
 						}


### PR DESCRIPTION
It doesn't make much sense and conflicts with the `config.git.default_remote` and `config.git.default_branch` options.