### PR TITLE
chore: improve test hclwrite

### DIFF
--- a/generate/generate_hcl_test.go
+++ b/generate/generate_hcl_test.go
@@ -168,11 +168,11 @@ func TestHCLGeneration(t *testing.T) {
 							str("prefix", "stack-1-backend"),
 						),
 						"locals.tf": locals(
-							str("stackpath", "/stacks/stack-1"),
 							str("local_a", "stack-1-local"),
 							boolean("local_b", true),
 							number("local_c", 666),
 							str("local_d", "local_d_field"),
+							str("stackpath", "/stacks/stack-1"),
 						),
 						"provider.tf": hcldoc(
 							provider(
@@ -201,11 +201,11 @@ func TestHCLGeneration(t *testing.T) {
 							str("prefix", "stack-2-backend"),
 						),
 						"locals.tf": locals(
-							str("stackpath", "/stacks/stack-2"),
 							str("local_a", "stack-2-local"),
 							boolean("local_b", false),
 							number("local_c", 777),
 							attr("local_d", "null"),
+							str("stackpath", "/stacks/stack-2"),
 						),
 						"provider.tf": hcldoc(
 							provider(

--- a/generate/generate_hclwrite_utils_test.go
+++ b/generate/generate_hclwrite_utils_test.go
@@ -18,15 +18,15 @@ import "github.com/mineiros-io/terramate/test/hclwrite"
 
 // useful function aliases to build HCL documents
 
-func hcldoc(blocks ...*hclwrite.Block) hclwrite.HCL {
-	return hclwrite.NewHCL(blocks...)
+func hcldoc(builders ...hclwrite.BlockBuilder) *hclwrite.Block {
+	return hclwrite.BuildHCL(builders...)
 }
 
 // stackConfig wraps the blocks built by the given builders in a valid stack
 // configuration
-func stackConfig(blocks ...*hclwrite.Block) hclwrite.HCL {
-	b := []*hclwrite.Block{stack()}
-	b = append(b, blocks...)
+func stackConfig(builders ...hclwrite.BlockBuilder) *hclwrite.Block {
+	b := []hclwrite.BlockBuilder{stack()}
+	b = append(b, builders...)
 	return hcldoc(b...)
 }
 

--- a/generate/generate_locals_test.go
+++ b/generate/generate_locals_test.go
@@ -103,9 +103,9 @@ func TestLocalsGeneration(t *testing.T) {
 			want: want{
 				stacksLocals: map[string]*hclwrite.Block{
 					"/stack": locals(
-						str("string_local", "string"),
-						number("number_local", 777),
 						boolean("bool_local", true),
+						number("number_local", 777),
+						str("string_local", "string"),
 					),
 				},
 			},
@@ -224,9 +224,9 @@ func TestLocalsGeneration(t *testing.T) {
 				stacksLocals: map[string]*hclwrite.Block{
 					"/stacks/stack": locals(
 						str("name_local", "stack"),
+						number("num_local", 666),
 						str("path_local", "/stacks/stack"),
 						str("str_local", "string"),
-						number("num_local", 666),
 					),
 				},
 			},
@@ -269,15 +269,15 @@ func TestLocalsGeneration(t *testing.T) {
 				stacksLocals: map[string]*hclwrite.Block{
 					"/stacks/stack-1": locals(
 						str("name_local", "stack-1"),
+						number("num_local", 666),
 						str("path_local", "/stacks/stack-1"),
 						str("str_local", "string"),
-						number("num_local", 666),
 					),
 					"/stacks/stack-2": locals(
 						str("name_local", "stack-2"),
+						number("num_local", 666),
 						str("path_local", "/stacks/stack-2"),
 						str("str_local", "string"),
-						number("num_local", 666),
 					),
 				},
 			},
@@ -323,8 +323,8 @@ func TestLocalsGeneration(t *testing.T) {
 						str("str_local", "string"),
 					),
 					"/stacks/stack-2": locals(
-						str("path_local", "/stacks/stack-2"),
 						number("num_local", 666),
+						str("path_local", "/stacks/stack-2"),
 					),
 				},
 			},

--- a/generate/genhcl/genhcl_test.go
+++ b/generate/genhcl/genhcl_test.go
@@ -54,8 +54,8 @@ func TestLoadGeneratedHCL(t *testing.T) {
 		}
 	)
 
-	hcldoc := func(blocks ...*hclwrite.Block) hclwrite.HCL {
-		return hclwrite.NewHCL(blocks...)
+	hcldoc := func(builders ...hclwrite.BlockBuilder) *hclwrite.Block {
+		return hclwrite.BuildHCL(builders...)
 	}
 	generateHCL := func(builders ...hclwrite.BlockBuilder) *hclwrite.Block {
 		return hclwrite.BuildBlock("generate_hcl", builders...)

--- a/generate/genhcl/genhcl_test.go
+++ b/generate/genhcl/genhcl_test.go
@@ -140,6 +140,64 @@ func TestLoadGeneratedHCL(t *testing.T) {
 			},
 		},
 		{
+			name:  "generate hcl with only attributes on root body",
+			stack: "/stack",
+			configs: []hclconfig{
+				{
+					path: "/stack",
+					add: generateHCL(
+						labels("attrs"),
+						content(
+							number("num", 666),
+							str("str", "hi"),
+						),
+					),
+				},
+			},
+			want: []result{
+				{
+					name: "attrs",
+					hcl: genHCL{
+						origin: defaultCfg("/stack"),
+						body: hcldoc(
+							number("num", 666),
+							str("str", "hi"),
+						),
+					},
+				},
+			},
+		},
+		{
+			name:  "generate hcl with attributes and blocks on root body",
+			stack: "/stack",
+			configs: []hclconfig{
+				{
+					path: "/stack",
+					add: generateHCL(
+						labels("attrs"),
+						content(
+							number("num", 666),
+							block("test"),
+							str("str", "hi"),
+						),
+					),
+				},
+			},
+			want: []result{
+				{
+					name: "attrs",
+					hcl: genHCL{
+						origin: defaultCfg("/stack"),
+						body: hcldoc(
+							number("num", 666),
+							str("str", "hi"),
+							block("test"),
+						),
+					},
+				},
+			},
+		},
+		{
 			name:  "scope traversals of unknown namespaces are copied as is",
 			stack: "/stack",
 			configs: []hclconfig{

--- a/generate/genhcl/genhcl_test.go
+++ b/generate/genhcl/genhcl_test.go
@@ -212,12 +212,12 @@ func TestLoadGeneratedHCL(t *testing.T) {
 						body: block("testblock",
 							boolean("bool", true),
 							number("number", 777),
-							str("string", "string"),
 							attr("obj", `{
 								bool   = true
 								number = 777
 								string = "string"
 							}`),
+							str("string", "string"),
 						),
 					},
 				},
@@ -455,12 +455,12 @@ func TestLoadGeneratedHCL(t *testing.T) {
 							block("block2",
 								number("number", 777),
 								block("block3",
-									str("string", "string"),
 									attr("obj", `{
-									bool   = true
-									number = 777
-									string = "string"
-								}`),
+										bool   = true
+										number = 777
+										string = "string"
+									}`),
+									str("string", "string"),
 								),
 							),
 						),

--- a/globals_test.go
+++ b/globals_test.go
@@ -832,7 +832,7 @@ func TestLoadGlobals(t *testing.T) {
 
 				want, ok := wantGlobals[stackMeta.Path]
 				if !ok {
-					want = hclwrite.NewBlock("globals")
+					want = globals()
 				}
 				delete(wantGlobals, stackMeta.Path)
 

--- a/test/hclwrite/hclwrite_test.go
+++ b/test/hclwrite/hclwrite_test.go
@@ -69,11 +69,11 @@ func TestHCLWrite(t *testing.T) {
 			),
 			want: `
 			  test {
+			    str    = "test"
+			    num    = 666
+			    bool   = true
 			    expr_a = local.name
 			    expr_b = local.name
-			    bool   = true
-			    num    = 666
-			    str    = "test"
 			  }
 			`,
 		},
@@ -86,9 +86,9 @@ func TestHCLWrite(t *testing.T) {
 			),
 			want: `
 			  test {
-			    list    = [1, 2, 3]
-			    nesting = { first = { second = { "hi": 666 } } }
 			    team    = { members = ["aaa"] }
+			    nesting = { first = { second = { "hi": 666 } } }
+			    list    = [1, 2, 3]
 			  }
 			`,
 		},
@@ -259,8 +259,8 @@ func TestHCLWrite(t *testing.T) {
 			    required_version = "~> 0.0.1"
 			  }
 			  stack {
-			    after  = ["/stack/c"]
 			    before = ["/stack/a", "/stack/b"]
+			    after  = ["/stack/c"]
 			  }
 			`,
 		},

--- a/test/hclwrite/hclwrite_test.go
+++ b/test/hclwrite/hclwrite_test.go
@@ -224,7 +224,7 @@ func TestHCLWrite(t *testing.T) {
 			`,
 		},
 		{
-			name: "attributes always come before blocks",
+			name: "attributes can be added after blocks",
 			hcl: hcl(
 				block("a",
 					labels("label"),
@@ -235,29 +235,23 @@ func TestHCLWrite(t *testing.T) {
 				str("rootstr", "hi"),
 			),
 			want: `
-			  rootbool = true
-			  rootnum  = 666
-			  rootstr  = "hi"
 			  a "label" {
 			    str = "level1"
 			  }
+			  rootbool = true
+			  rootnum  = 666
+			  rootstr  = "hi"
 			`,
 		},
 		{
 			name: "terramate stack example",
 			hcl: hcl(
-				block("terramate",
-					str("required_version", "~> 0.0.1"),
-				),
 				block("stack",
 					expr("before", `["/stack/a", "/stack/b"]`),
 					expr("after", `["/stack/c"]`),
 				),
 			),
 			want: `
-			  terramate {
-			    required_version = "~> 0.0.1"
-			  }
 			  stack {
 			    before = ["/stack/a", "/stack/b"]
 			    after  = ["/stack/c"]


### PR DESCRIPTION
Here we:

* Simplify some things on the implementation
* Enforce that the document is generated the same way it was built (no implicit/automatic ordering)
* Allow creation of hcl document with only attributes on root (no blocks)
* Added missing test for genhcl (attributes on root)