### PR TITLE
chore: add support to --version

### DIFF
--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -62,6 +62,7 @@ const (
 
 type cliSpec struct {
 	Version       struct{} `cmd:"" help:"Terramate version."`
+	VersionFlag   bool     `name:"version" help:"Terramate version."`
 	Chdir         string   `short:"C" optional:"true" help:"sets working directory."`
 	GitChangeBase string   `short:"B" optional:"true" help:"git base ref for computing changes."`
 	Changed       bool     `short:"c" optional:"true" help:"filter by changed infrastructure"`
@@ -186,6 +187,15 @@ func newCLI(args []string, stdin io.Reader, stdout, stderr io.Writer) *cli {
 		return &cli{exit: true}
 	}
 
+	// When we run terramate --version the kong parser just fails
+	// since no subcommand was provided (which is odd..but happens).
+	// So we check if the flag for version is present before checking the error.
+	if parsedArgs.VersionFlag {
+		logger.Debug().Msg("Get terramate version using --version.")
+		fmt.Println(terramate.Version())
+		return &cli{exit: true}
+	}
+
 	if err != nil {
 		logger.Fatal().
 			Err(err).
@@ -201,7 +211,7 @@ func newCLI(args []string, stdin io.Reader, stdout, stderr io.Writer) *cli {
 
 	switch ctx.Command() {
 	case "version":
-		logger.Debug().Msg("Get terramate version.")
+		logger.Debug().Msg("Get terramate version with version subcommand.")
 		fmt.Println(terramate.Version())
 		return &cli{exit: true}
 	case "install-completions":

--- a/cmd/terramate/e2etests/version_check_test.go
+++ b/cmd/terramate/e2etests/version_check_test.go
@@ -38,6 +38,7 @@ func TestVersionCheck(t *testing.T) {
 	}
 	uncheckedCmds := []string{
 		"--help",
+		"--version",
 		"version",
 	}
 
@@ -90,6 +91,21 @@ func TestVersionCheck(t *testing.T) {
 			})
 		})
 	}
+}
+
+func TestProvidesCorrectVersion(t *testing.T) {
+	s := sandbox.New(t)
+	cli := newCLI(t, s.RootDir())
+	want := terramate.Version() + "\n"
+
+	assertRunResult(t, cli.run("version"), runExpected{
+		Status: 0,
+		Stdout: want,
+	})
+	assertRunResult(t, cli.run("--version"), runExpected{
+		Status: 0,
+		Stdout: want,
+	})
 }
 
 func TestTerramateHasValidSemver(t *testing.T) {


### PR DESCRIPTION
Now we have terramate --version  on top of terramate version, both should work. Code is a little odd because kong parsing fails if there is no subcommand (unless for --help...which I suppose it is handled internally by kong). 