### PR TITLE
feat: add tm_ prefix on funcs for globals/export_as_locals

### DIFF
--- a/exported_locals_test.go
+++ b/exported_locals_test.go
@@ -202,7 +202,7 @@ func TestExportAsLocals(t *testing.T) {
 				{
 					path: "/stack",
 					add: exportAsLocals(
-						expr("funny_path", `replace(terramate.path, "/", "@")`),
+						expr("funny_path", `tm_replace(terramate.path, "/", "@")`),
 					),
 				},
 			},

--- a/generate/generate_locals_test.go
+++ b/generate/generate_locals_test.go
@@ -117,7 +117,7 @@ func TestLocalsGeneration(t *testing.T) {
 				{
 					path: "/stack",
 					add: exportAsLocals(
-						expr("funny_path", `replace(terramate.path, "/", "@")`),
+						expr("funny_path", `tm_replace(terramate.path, "/", "@")`),
 					),
 				},
 			},

--- a/globals_test.go
+++ b/globals_test.go
@@ -288,13 +288,13 @@ func TestLoadGlobals(t *testing.T) {
 				{
 					path: "/stacks/stack-1",
 					add: globals(
-						expr("interpolated", `"prefix-${replace(terramate.path, "/", "@")}-suffix"`),
+						expr("interpolated", `"prefix-${tm_replace(terramate.path, "/", "@")}-suffix"`),
 					),
 				},
 				{
 					path: "/stacks/stack-2",
 					add: globals(
-						expr("stack_path", `replace(terramate.path, "/", "-")`),
+						expr("stack_path", `tm_replace(terramate.path, "/", "-")`),
 					),
 				},
 			},
@@ -602,8 +602,8 @@ func TestLoadGlobals(t *testing.T) {
 				{
 					path: "/stack",
 					add: globals(
-						expr("newfield", `replace(global.field, "@", "/")`),
-						expr("splitfun", `split("@", global.field)[1]`),
+						expr("newfield", `tm_replace(global.field, "@", "/")`),
+						expr("splitfun", `tm_split("@", global.field)[1]`),
 					),
 				},
 			},
@@ -624,7 +624,7 @@ func TestLoadGlobals(t *testing.T) {
 					add: globals(
 						attr("team", `{ members = ["aaa"] }`),
 						expr("members", "global.team.members"),
-						expr("members_try", `try(global.team.members, [])`),
+						expr("members_try", `tm_try(global.team.members, [])`),
 					),
 				},
 			},
@@ -644,7 +644,7 @@ func TestLoadGlobals(t *testing.T) {
 					path: "/stack",
 					add: globals(
 						attr("team", `{ members = ["aaa"] }`),
-						expr("members_try", `try(global.team.mistake, [])`),
+						expr("members_try", `tm_try(global.team.mistake, [])`),
 					),
 				},
 			},
@@ -663,7 +663,7 @@ func TestLoadGlobals(t *testing.T) {
 					path: "/",
 					add: globals(
 						expr("team_def", "global.team.def"),
-						expr("team_def_try", `try(global.team.def, {})`),
+						expr("team_def_try", `tm_try(global.team.def, {})`),
 					),
 				},
 				{

--- a/hcl/eval/eval.go
+++ b/hcl/eval/eval.go
@@ -20,6 +20,7 @@ import (
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/rs/zerolog/log"
 	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/function"
 	"github.com/zclconf/go-cty/cty/gocty"
 
 	hhcl "github.com/hashicorp/hcl/v2"
@@ -37,7 +38,7 @@ type Context struct {
 func NewContext(basedir string) *Context {
 	scope := &tflang.Scope{BaseDir: basedir}
 	hclctx := &hhcl.EvalContext{
-		Functions: scope.Functions(),
+		Functions: newTmFunctions(scope.Functions()),
 		Variables: map[string]cty.Value{},
 	}
 	return &Context{
@@ -101,4 +102,12 @@ func fromMapToObject(m map[string]cty.Value) (cty.Value, error) {
 		return cty.Value{}, err
 	}
 	return ctyVal, nil
+}
+
+func newTmFunctions(tffuncs map[string]function.Function) map[string]function.Function {
+	tmfuncs := map[string]function.Function{}
+	for name, function := range tffuncs {
+		tmfuncs["tm_"+name] = function
+	}
+	return tmfuncs
 }


### PR DESCRIPTION
Both globals and export_as_locals now only evaluated functions when prefixed with tm_. 