### PR TITLE
chore: extract GH integration test on its own job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,8 +50,6 @@ jobs:
     steps:
       - name: checkout repo
         uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
 
       - name: setup go
         uses: actions/setup-go@v2
@@ -63,7 +61,23 @@ jobs:
 
       - name: make build
         run: make build
-      
+
+  gh_integration_test:
+    name: GH Action Integration Test
+
+    runs-on: "ubuntu-20.04"
+
+    steps:
+      - name: checkout repo
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: setup go
+        uses: actions/setup-go@v2
+        with:
+          go-version: "1.17"
+
       - name: make test/ci
         run: make test/ci
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
         run: make build
 
   gh_integration_test:
-    name: GH Action Integration Test
+    name: GHA Integration Test
 
     runs-on: "ubuntu-20.04"
 


### PR DESCRIPTION
When merging a branch onto another branch the make test/ci may fail and the way it is done today it cancels running tests on other platforms. So it seemed good to extract this check on its own job, decoupled from the usual build/tests that are more isolated (it is also misleading, it seems like basic building/testing is broken, but it is not, and the CI testing thing is more brittle).

Example: https://github.com/mineiros-io/terramate/pull/246