### PR TITLE
tests: add some tests related to for + fix err chaining on genhcl

### DIFF
--- a/generate/genhcl/genhcl.go
+++ b/generate/genhcl/genhcl.go
@@ -119,13 +119,13 @@ func Load(rootdir string, sm stack.Metadata, globals terramate.Globals) (StackHC
 
 		gen := hclwrite.NewEmptyFile()
 		if err := hcl.CopyBody(gen.Body(), loadedHCL.block.Body, evalctx); err != nil {
-			return StackHCLs{}, fmt.Errorf(
-				"%w: stack %q block %q: %v",
+			evalErr := fmt.Errorf(
+				"%w: stack %q block %q",
 				ErrEval,
 				stackpath,
 				name,
-				err,
 			)
+			return StackHCLs{}, errutil.Chain(evalErr, err)
 		}
 		res.hcls[name] = HCL{
 			origin: loadedHCL.origin,


### PR DESCRIPTION
Since we are testing the partial eval logic through genhcl I had to chain errors from eval there (could review which layer of errors to use on tests later, right now just did the smallest change)