### PR TITLE
chore: improve error message on global evals

### DIFF
--- a/generate/genhcl/genhcl.go
+++ b/generate/genhcl/genhcl.go
@@ -25,6 +25,7 @@ import (
 	"github.com/mineiros-io/terramate"
 	"github.com/mineiros-io/terramate/hcl"
 	"github.com/mineiros-io/terramate/hcl/eval"
+	"github.com/mineiros-io/terramate/project"
 	"github.com/mineiros-io/terramate/stack"
 	"github.com/rs/zerolog/log"
 )
@@ -207,13 +208,8 @@ func loadGenHCLBlocks(rootdir string, cfgdir string) (map[string]loadedHCL, erro
 			}
 
 			contentBlock := genhclBlock.Body.Blocks[0]
-			relpath := strings.TrimPrefix(cfgdir, rootdir)
-			if relpath == "" {
-				relpath = "/"
-			}
-			origin := filepath.Join(relpath, filename)
 			res[name] = loadedHCL{
-				origin: origin,
+				origin: project.PrjAbsPath(rootdir, filename),
 				block:  contentBlock,
 			}
 

--- a/globals.go
+++ b/globals.go
@@ -23,6 +23,7 @@ import (
 	"github.com/madlambda/spells/errutil"
 	"github.com/mineiros-io/terramate/hcl"
 	"github.com/mineiros-io/terramate/hcl/eval"
+	"github.com/mineiros-io/terramate/project"
 	"github.com/mineiros-io/terramate/stack"
 	"github.com/rs/zerolog/log"
 	"github.com/zclconf/go-cty/cty"
@@ -82,28 +83,33 @@ func (g Globals) String() string {
 	return hcl.FormatAttributes(g.attributes)
 }
 
-type globalsExpr struct {
-	expressions map[string]hclsyntax.Expression
+type expression struct {
+	origin string
+	value  hclsyntax.Expression
 }
 
-func (r *globalsExpr) merge(other *globalsExpr) {
+type globalsExpr struct {
+	expressions map[string]expression
+}
+
+func (ge *globalsExpr) merge(other *globalsExpr) {
 	for k, v := range other.expressions {
-		if !r.has(k) {
-			r.add(k, v)
+		if !ge.has(k) {
+			ge.add(k, v)
 		}
 	}
 }
 
-func (r *globalsExpr) add(name string, expr hclsyntax.Expression) {
-	r.expressions[name] = expr
+func (ge *globalsExpr) add(name string, expr expression) {
+	ge.expressions[name] = expr
 }
 
-func (r *globalsExpr) has(name string) bool {
-	_, ok := r.expressions[name]
+func (ge *globalsExpr) has(name string) bool {
+	_, ok := ge.expressions[name]
 	return ok
 }
 
-func (r *globalsExpr) eval(meta stack.Metadata) (Globals, error) {
+func (ge *globalsExpr) eval(meta stack.Metadata) (Globals, error) {
 	// FIXME(katcipis): get abs path for stack.
 	// This is relative only to root since meta.Path will look
 	// like: /some/path/relative/project/root
@@ -132,8 +138,8 @@ func (r *globalsExpr) eval(meta stack.Metadata) (Globals, error) {
 		return Globals{}, fmt.Errorf("initializing global eval: %v", err)
 	}
 
-	var errs []error
-	pendingExprs := r.expressions
+	pendingExprsErrs := map[string]error{}
+	pendingExprs := ge.expressions
 
 	hclctx := evalctx.GetHCLContext()
 
@@ -144,10 +150,10 @@ func (r *globalsExpr) eval(meta stack.Metadata) (Globals, error) {
 
 	pendingExpression:
 		for name, expr := range pendingExprs {
-			vars := hclsyntax.Variables(expr)
+			vars := hclsyntax.Variables(expr.value)
 
-			logger.Trace().
-				Msg("Range vars.")
+			logger.Trace().Msg("Range vars.")
+
 			for _, namespace := range vars {
 				if _, ok := hclctx.Variables[namespace.RootName()]; !ok {
 					return Globals{}, fmt.Errorf(
@@ -184,9 +190,9 @@ func (r *globalsExpr) eval(meta stack.Metadata) (Globals, error) {
 
 			logger.Trace().Msg("Evaluate expression.")
 
-			val, err := evalctx.Eval(expr)
+			val, err := evalctx.Eval(expr.value)
 			if err != nil {
-				errs = append(errs, err)
+				pendingExprsErrs[name] = err
 				continue
 			}
 
@@ -196,6 +202,7 @@ func (r *globalsExpr) eval(meta stack.Metadata) (Globals, error) {
 			logger.Trace().Msg("Delete pending expression.")
 
 			delete(pendingExprs, name)
+			delete(pendingExprsErrs, name)
 
 			logger.Trace().Msg("Try add proper namespace for globals evaluation context.")
 
@@ -207,27 +214,16 @@ func (r *globalsExpr) eval(meta stack.Metadata) (Globals, error) {
 		if amountEvaluated == 0 {
 			break
 		}
-
-		errs = nil
 	}
 
 	if len(pendingExprs) > 0 {
-		for name := range pendingExprs {
-			logger.Warn().
+		for name, expr := range pendingExprs {
+			logger.Err(pendingExprsErrs[name]).
 				Str("name", name).
-				Msg("unresolved global")
+				Str("origin", expr.origin).
+				Msg("evaluating global")
 		}
-		return Globals{}, fmt.Errorf("%w: could not resolve all globals", ErrGlobalEval)
-	}
-
-	logger.Trace().Msg("Reduce multiple errors into one.")
-
-	err := errutil.Reduce(func(err1 error, err2 error) error {
-		return fmt.Errorf("%v,%v", err1, err2)
-	}, errs...)
-
-	if err != nil {
-		return Globals{}, fmt.Errorf("%w: %v", ErrGlobalEval, err)
+		return Globals{}, fmt.Errorf("%w: unable to evaluate %d globals", ErrGlobalEval, len(pendingExprs))
 	}
 
 	return globals, nil
@@ -235,7 +231,7 @@ func (r *globalsExpr) eval(meta stack.Metadata) (Globals, error) {
 
 func newGlobalsExpr() *globalsExpr {
 	return &globalsExpr{
-		expressions: map[string]hclsyntax.Expression{},
+		expressions: map[string]expression{},
 	}
 }
 
@@ -268,7 +264,10 @@ func loadStackGlobalsExprs(rootdir string, cfgdir string) (*globalsExpr, error) 
 
 				logger.Trace().Msg("Add attribute to globals.")
 
-				globals.add(name, attr.Expr)
+				globals.add(name, expression{
+					origin: project.PrjAbsPath(rootdir, filename),
+					value:  attr.Expr,
+				})
 			}
 		}
 	}

--- a/globals.go
+++ b/globals.go
@@ -217,6 +217,8 @@ func (ge *globalsExpr) eval(meta stack.Metadata) (Globals, error) {
 	}
 
 	if len(pendingExprs) > 0 {
+		// TODO(katcipis): model proper error list and return that
+		// Caller can decide how to format/log things (like code generation report).
 		for name, expr := range pendingExprs {
 			logger.Err(pendingExprsErrs[name]).
 				Str("name", name).

--- a/hcl/hcl.go
+++ b/hcl/hcl.go
@@ -854,7 +854,7 @@ func loadCfgBlocks(dir string) (*hclparse.Parser, error) {
 
 			logger.Trace().Msg("Parsing config.")
 
-			_, diags := parser.ParseHCL(data, filename)
+			_, diags := parser.ParseHCL(data, path)
 			if diags.HasErrors() {
 				return nil, errutil.Chain(ErrHCLSyntax, diags)
 			}


### PR DESCRIPTION
For now only added origin info like genhcl + improved the error logging. The report from code generation itself still is quite vague, but at least the error log entries should help.

before we had:

```
terramate generate
2022-03-21T16:12:12+01:00 INF project root config has no required_version, skipping version check action=cli.checkVersion() root=/home/katz/workspace/terramate-blueprint-iac-github
2022-03-21T16:12:12+01:00 WRN unresolved global action=eval() name=user_map stack=/stacks/organization/members
2022-03-21T16:12:12+01:00 WRN unresolved global action=eval() name=_members_team stack=/stacks/organization/teams/departments
2022-03-21T16:12:12+01:00 WRN unresolved global action=eval() name=_members_all stack=/stacks/organization/teams/departments
2022-03-21T16:12:12+01:00 WRN unresolved global action=eval() name=user_map stack=/stacks/organization/teams/departments
2022-03-21T16:12:12+01:00 WRN unresolved global action=eval() name=_members_child_teams stack=/stacks/organization/teams/departments
2022-03-21T16:12:12+01:00 WRN unresolved global action=eval() name=member_map stack=/stacks/organization/teams/departments
2022-03-21T16:12:12+01:00 WRN unresolved global action=eval() name=member_map stack=/stacks/organization/teams/teamA
2022-03-21T16:12:12+01:00 WRN unresolved global action=eval() name=user_map stack=/stacks/organization/teams/teamA
2022-03-21T16:12:12+01:00 WRN unresolved global action=eval() name=_members_team stack=/stacks/organization/teams/teamA
2022-03-21T16:12:12+01:00 WRN unresolved global action=eval() name=_members_child_teams stack=/stacks/organization/teams/teamA
2022-03-21T16:12:12+01:00 WRN unresolved global action=eval() name=_members_all stack=/stacks/organization/teams/teamA
2022-03-21T16:12:12+01:00 WRN unresolved global action=eval() name=user_map stack=/stacks/repositories/teamA
2022-03-21T16:12:12+01:00 WRN unresolved global action=eval() name=_maintain_collaborators stack=/stacks/repositories/teamA
2022-03-21T16:12:12+01:00 WRN unresolved global action=eval() name=_write_collaborators stack=/stacks/repositories/teamA
2022-03-21T16:12:12+01:00 WRN unresolved global action=eval() name=_collaborators_all stack=/stacks/repositories/teamA
2022-03-21T16:12:12+01:00 WRN unresolved global action=eval() name=_admin_collaborators stack=/stacks/repositories/teamA
2022-03-21T16:12:12+01:00 WRN unresolved global action=eval() name=_read_collaborators stack=/stacks/repositories/teamA
2022-03-21T16:12:12+01:00 WRN unresolved global action=eval() name=_triage_collaborators stack=/stacks/repositories/teamA
Code generation report

Failures:

- stack /stacks/organization/members
        error: loading globals: globals eval failed: could not resolve all globals

- stack /stacks/organization/teams/departments
        error: loading globals: globals eval failed: could not resolve all globals

- stack /stacks/organization/teams/teamA
        error: loading globals: globals eval failed: could not resolve all globals

- stack /stacks/repositories/teamA
        error: loading globals: globals eval failed: could not resolve all globals

Hint: '+', '~' and '-' means the file was created, changed and deleted, respectively.
```

With this PR we have:

```
2022-03-21T16:59:39+01:00 INF project root config has no required_version, skipping version check action=cli.checkVersion() root=/home/katz/workspace/terramate-blueprint-iac-github
2022-03-21T16:59:39+01:00 ERR evaluating global error="evaluating expression: /home/katz/workspace/terramate-blueprint-iac-github/stacks/config_globals.tm.hcl:25,49-55: Call to unknown function; There is no function named \"wurrul\"." action=eval() name=user_map origin=/stacks/config_globals.tm.hcl stack=/stacks/organization/members
2022-03-21T16:59:39+01:00 ERR evaluating global error="evaluating expression: /home/katz/workspace/terramate-blueprint-iac-github/stacks/config_globals.tm.hcl:25,49-55: Call to unknown function; There is no function named \"wurrul\"." action=eval() name=user_map origin=/stacks/config_globals.tm.hcl stack=/stacks/organization/teams/departments
2022-03-21T16:59:39+01:00 INF evaluating global action=eval() name=member_map origin=/stacks/organization/teams/terraform_main.tf.tm.hcl stack=/stacks/organization/teams/departments
2022-03-21T16:59:39+01:00 INF evaluating global action=eval() name=member_map origin=/stacks/organization/teams/terraform_main.tf.tm.hcl stack=/stacks/organization/teams/teamA
2022-03-21T16:59:39+01:00 ERR evaluating global error="evaluating expression: /home/katz/workspace/terramate-blueprint-iac-github/stacks/config_globals.tm.hcl:25,49-55: Call to unknown function; There is no function named \"wurrul\"." action=eval() name=user_map origin=/stacks/config_globals.tm.hcl stack=/stacks/organization/teams/teamA
2022-03-21T16:59:39+01:00 ERR evaluating global error="evaluating expression: /home/katz/workspace/terramate-blueprint-iac-github/stacks/config_globals.tm.hcl:25,49-55: Call to unknown function; There is no function named \"wurrul\"." action=eval() name=user_map origin=/stacks/config_globals.tm.hcl stack=/stacks/repositories/teamA
Code generation report

Failures:

- stack /stacks/organization/members
        error: loading globals: globals eval failed: unable to evaluate 1 globals

- stack /stacks/organization/teams/departments
        error: loading globals: globals eval failed: unable to evaluate 2 globals

- stack /stacks/organization/teams/teamA
        error: loading globals: globals eval failed: unable to evaluate 2 globals

- stack /stacks/repositories/teamA
        error: loading globals: globals eval failed: unable to evaluate 1 globals

Hint: '+', '~' and '-' means the file was created, changed and deleted, respectively.
```