### PR TITLE
chore: change release tar names

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -23,9 +23,9 @@ builds:
       #
 archives:
   - replacements:
-      darwin: Darwin
-      linux: Linux
-      #windows: Windows (when we add win support)
+      darwin: darwin
+      linux: linux
+      #windows: win (when we add win support)
       386: i386
       amd64: x86_64
 


### PR DESCRIPTION
Copied the config from GoReleaser but using Linux instead of linux on the tar file is just odd :laughing: 