### PR TITLE
fix: improve error message of run order

### DIFF
--- a/run/order.go
+++ b/run/order.go
@@ -113,7 +113,7 @@ func BuildDAG(
 		Msg("Load all stacks in dir after current stack.")
 	afterStacks, err := loader.LoadAll(root, s.AbsPath(), s.After()...)
 	if err != nil {
-		return fmt.Errorf("failed to load the \"after\" stacks of the stack %q: %w", s, err)
+		return fmt.Errorf("stack %q: failed to load the \"after\" stacks: %w", s, err)
 	}
 
 	logger.Trace().

--- a/run/order.go
+++ b/run/order.go
@@ -127,7 +127,7 @@ func BuildDAG(
 		Msg("Add new node to DAG.")
 	err = d.AddNode(dag.ID(s.PrjAbsPath()), s, toids(beforeStacks), toids(afterStacks))
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to build DAG for stack %q: %w", s, err)
 	}
 
 	stacks := []stack.S{}
@@ -151,7 +151,7 @@ func BuildDAG(
 			Msg("Build DAG.")
 		err = BuildDAG(d, root, s, loader, visited)
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to build DAG for stack %q: %w", s, err)
 		}
 	}
 	return nil

--- a/run/order.go
+++ b/run/order.go
@@ -151,7 +151,7 @@ func BuildDAG(
 			Msg("Build DAG.")
 		err = BuildDAG(d, root, s, loader, visited)
 		if err != nil {
-			return fmt.Errorf("failed to build DAG for stack %q: %w", s, err)
+			return fmt.Errorf("stack %q: failed to build DAG: %w", s, err)
 		}
 	}
 	return nil

--- a/run/order.go
+++ b/run/order.go
@@ -113,14 +113,14 @@ func BuildDAG(
 		Msg("Load all stacks in dir after current stack.")
 	afterStacks, err := loader.LoadAll(root, s.AbsPath(), s.After()...)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to load the \"after\" stacks of the stack %q: %w", s, err)
 	}
 
 	logger.Trace().
 		Msg("Load all stacks in dir before current stack.")
 	beforeStacks, err := loader.LoadAll(root, s.AbsPath(), s.Before()...)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to load the \"before\" stacks of the stack %q: %w", s, err)
 	}
 
 	logger.Debug().

--- a/run/order.go
+++ b/run/order.go
@@ -120,7 +120,7 @@ func BuildDAG(
 		Msg("Load all stacks in dir before current stack.")
 	beforeStacks, err := loader.LoadAll(root, s.AbsPath(), s.Before()...)
 	if err != nil {
-		return fmt.Errorf("failed to load the \"before\" stacks of the stack %q: %w", s, err)
+		return fmt.Errorf("stack %q: failed to load the \"before\" stacks: %w", s, err)
 	}
 
 	logger.Debug().

--- a/run/order.go
+++ b/run/order.go
@@ -127,7 +127,7 @@ func BuildDAG(
 		Msg("Add new node to DAG.")
 	err = d.AddNode(dag.ID(s.PrjAbsPath()), s, toids(beforeStacks), toids(afterStacks))
 	if err != nil {
-		return fmt.Errorf("failed to build DAG for stack %q: %w", s, err)
+		return fmt.Errorf("stack %q: failed to build DAG: %w", s, err)
 	}
 
 	stacks := []stack.S{}


### PR DESCRIPTION
Before the error was missing which stack had the wrong configuration:

```
$ terramate run --dry-run -- ls
2022-03-29T22:50:24+01:00 FTL failed to plan execution error="parsing config files: reading dir to load config files: open /home/i4k/src/mineiros/tm-example/stack-A: no such file or directory"
```

Now:

```
$ terramate run --dry-run -- ls
2022-03-29T22:57:23+01:00 FTL failed to plan execution error="failed to load the \"before\" stacks of the stack \"/stack-c\": parsing config files: reading dir to load config files: open /home/i4k/src/mineiros/tm-example/stack-A: no such file or directory"
```

The error message is still not ideal, any help is appreciated.

