### PR TITLE
fix: disallow the use of --why without --changed

### DIFF
--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -467,6 +467,11 @@ func (c *cli) printStacks() {
 		Str("action", "printStacks()").
 		Logger()
 
+	if c.parsedArgs.List.Why && !c.parsedArgs.Changed {
+		logger.Fatal().
+			Msg("the --why flag must be used together with --changed")
+	}
+
 	logger.Trace().
 		Str("workingDir", c.wd()).
 		Msg("Create a new stack manager.")


### PR DESCRIPTION
Currently it allows `terramate list --why` but then it shows an empty reason...

```
apps/a - 
apps/b - 
apps/c - 
apps/d - 
```