### PR TITLE
feat: add --reverse on run

### DIFF
--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -349,16 +349,15 @@ func (c *cli) run() {
 			Msg("Print list of stacks.")
 		c.printStacks()
 	case "run":
-		logger.Debug().
-			Msg("Handle `run` command.")
+		logger.Debug().Msg("Handle `run` command.")
+
 		if len(c.parsedArgs.Run.Command) == 0 {
-			log.Fatal().
-				Msg("no command specified")
+			log.Fatal().Msg("no command specified")
 		}
 		fallthrough
 	case "run <cmd>":
-		logger.Debug().
-			Msg("Handle `run <cmd>` command.")
+		logger.Debug().Msg("Handle `run <cmd>` command.")
+
 		c.runOnStacks()
 	case "generate":
 		report := generate.Do(c.root(), c.wd())
@@ -841,6 +840,8 @@ func (c *cli) runOnStacks() {
 				Msg("failed to plan execution")
 		}
 	}
+
+	// TODO(katcipis): ADD REVERSE OF ORDERED STACKS
 
 	if c.parsedArgs.Run.DryRun {
 		logger.Trace().

--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -103,7 +103,7 @@ type cliSpec struct {
 
 		RunGraph struct {
 			Outfile string `short:"o" default:"" help:"Output .dot file"`
-			Label   string `short:"l" default:"stack.name" help:"Label used in graph nodes (it could be either \"stack.name\" or \"stack.dir\"`
+			Label   string `short:"l" default:"stack.name" help:"Label used in graph nodes (it could be either \"stack.name\" or \"stack.dir\""`
 		} `cmd:"" help:"Generate a graph of the execution order"`
 
 		RunOrder struct {
@@ -842,7 +842,10 @@ func (c *cli) runOnStacks() {
 		}
 	}
 
-	// TODO(katcipis): ADD REVERSE OF ORDERED STACKS
+	if c.parsedArgs.Run.Reverse {
+		logger.Trace().Msg("Reversing stacks order.")
+		stack.Reverse(orderedStacks)
+	}
 
 	if c.parsedArgs.Run.DryRun {
 		logger.Trace().

--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -64,49 +64,50 @@ const (
 )
 
 type cliSpec struct {
-	Version       struct{} `cmd:"" help:"Terramate version."`
-	VersionFlag   bool     `name:"version" help:"Terramate version."`
-	Chdir         string   `short:"C" optional:"true" help:"Sets working directory."`
-	GitChangeBase string   `short:"B" optional:"true" help:"Git base ref for computing changes."`
+	Version       struct{} `cmd:"" help:"Terramate version"`
+	VersionFlag   bool     `name:"version" help:"Terramate version"`
+	Chdir         string   `short:"C" optional:"true" help:"Sets working directory"`
+	GitChangeBase string   `short:"B" optional:"true" help:"Git base ref for computing changes"`
 	Changed       bool     `short:"c" optional:"true" help:"Filter by changed infrastructure"`
 	LogLevel      string   `optional:"true" default:"warn" enum:"trace,debug,info,warn,error,fatal" help:"Log level to use: 'trace', 'debug', 'info', 'warn', 'error', or 'fatal'"`
-	LogFmt        string   `optional:"true" default:"console" enum:"console,text,json" help:"Log format to use: 'console', 'text', or 'json'."`
+	LogFmt        string   `optional:"true" default:"console" enum:"console,text,json" help:"Log format to use: 'console', 'text', or 'json'"`
 
-	DisableCheckGitUntracked   bool `optional:"true" default:"false" help:"Disable git check for untracked files."`
-	DisableCheckGitUncommitted bool `optional:"true" default:"false" help:"Disable git check for uncommitted files."`
+	DisableCheckGitUntracked   bool `optional:"true" default:"false" help:"Disable git check for untracked files"`
+	DisableCheckGitUncommitted bool `optional:"true" default:"false" help:"Disable git check for uncommitted files"`
 
 	List struct {
-		Why bool `help:"Shows the reason why the stack has changed."`
-	} `cmd:"" help:"List stacks."`
+		Why bool `help:"Shows the reason why the stack has changed"`
+	} `cmd:"" help:"List stacks"`
 
 	Run struct {
-		DisableCheckGenCode bool     `optional:"true" default:"false" help:"Disable outdated generated code check."`
-		ContinueOnError     bool     `default:"false" help:"Continue executing in other stacks in case of error."`
+		DisableCheckGenCode bool     `optional:"true" default:"false" help:"Disable outdated generated code check"`
+		ContinueOnError     bool     `default:"false" help:"Continue executing in other stacks in case of error"`
 		DryRun              bool     `default:"false" help:"Plan the execution but do not execute it"`
-		Command             []string `arg:"" name:"cmd" passthrough:"" help:"Command to execute."`
-	} `cmd:"" help:"Run command in the stacks."`
+		Reverse             bool     `default:"false" help:"Reverse the order of execution"`
+		Command             []string `arg:"" name:"cmd" passthrough:"" help:"Command to execute"`
+	} `cmd:"" help:"Run command in the stacks"`
 
-	Generate struct{} `cmd:"" help:"Generate terraform code for stacks."`
+	Generate struct{} `cmd:"" help:"Generate terraform code for stacks"`
 
 	InstallCompletions kongplete.InstallCompletions `cmd:"" help:"Install shell completions"`
 
 	Experimental struct {
 		InitStack struct {
-			StackDirs []string `arg:"" name:"paths" optional:"true" help:"The stack directory (current directory if not set)."`
-		} `cmd:"" help:"Initialize a stack, does nothing if stack already initialized."`
+			StackDirs []string `arg:"" name:"paths" optional:"true" help:"The stack directory (current directory if not set)"`
+		} `cmd:"" help:"Initialize a stack, does nothing if stack already initialized"`
 
 		Metadata struct{} `cmd:"" help:"Shows metadata available on the project"`
 
 		Globals struct {
-		} `cmd:"" help:"List globals for all stacks."`
+		} `cmd:"" help:"List globals for all stacks"`
 
 		RunGraph struct {
-			Outfile string `short:"o" default:"" help:"Output .dot file."`
-			Label   string `short:"l" default:"stack.name" help:"Label used in graph nodes (it could be either \"stack.name\" or \"stack.dir\"."`
-		} `cmd:"" help:"Generate a graph of the execution order."`
+			Outfile string `short:"o" default:"" help:"Output .dot file"`
+			Label   string `short:"l" default:"stack.name" help:"Label used in graph nodes (it could be either \"stack.name\" or \"stack.dir\"`
+		} `cmd:"" help:"Generate a graph of the execution order"`
 
 		RunOrder struct {
-			Basedir string `arg:"" optional:"true" help:"Base directory to search stacks."`
+			Basedir string `arg:"" optional:"true" help:"Base directory to search stacks"`
 		} `cmd:"" help:"Show the topological ordering of the stacks"`
 	} `cmd:"" help:"Experimental features (may change or be removed in the future)"`
 }

--- a/cmd/terramate/e2etests/run_test.go
+++ b/cmd/terramate/e2etests/run_test.go
@@ -714,7 +714,7 @@ func TestRunReverseExecution(t *testing.T) {
 	s := sandbox.New(t)
 	cat := test.LookPath(t, "cat")
 	cli := newCLI(t, s.RootDir())
-	assertRun := func(stacks ...string) {
+	assertRunOrder := func(stacks ...string) {
 		t.Helper()
 
 		want := strings.Join(stacks, "\n")
@@ -747,19 +747,19 @@ func TestRunReverseExecution(t *testing.T) {
 	git := s.Git()
 	git.CheckoutNew("changes")
 
-	assertRun()
+	assertRunOrder()
 
 	addStack("stack-1")
 	git.CommitAll("commit")
-	assertRun("stack-1")
+	assertRunOrder("stack-1")
 
 	addStack("stack-2")
 	git.CommitAll("commit")
-	assertRun("stack-2", "stack-1")
+	assertRunOrder("stack-2", "stack-1")
 
 	addStack("stack-3")
 	git.CommitAll("commit")
-	assertRun("stack-3", "stack-2", "stack-1")
+	assertRunOrder("stack-3", "stack-2", "stack-1")
 }
 
 func TestRunIgnoresAfterBeforeStackRefsOutsideWorkingDir(t *testing.T) {

--- a/cmd/terramate/e2etests/run_test.go
+++ b/cmd/terramate/e2etests/run_test.go
@@ -715,18 +715,23 @@ func TestRunReverseExecution(t *testing.T) {
 	cat := test.LookPath(t, "cat")
 	cli := newCLI(t, s.RootDir())
 	assertRun := func(stacks ...string) {
+		t.Helper()
+
 		want := strings.Join(stacks, "\n")
+		if want != "" {
+			want += "\n"
+		}
 
 		assertRunResult(t, cli.run(
 			"run",
-			"--reversed",
+			"--reverse",
 			cat,
 			testfile,
 		), runExpected{Stdout: want})
 
 		assertRunResult(t, cli.run(
 			"run",
-			"--reversed",
+			"--reverse",
 			"--changed",
 			cat,
 			testfile,
@@ -739,10 +744,12 @@ func TestRunReverseExecution(t *testing.T) {
 		})
 	}
 
+	git := s.Git()
+	git.CheckoutNew("changes")
+
 	assertRun()
 
 	addStack("stack-1")
-	git := s.Git()
 	git.CommitAll("commit")
 	assertRun("stack-1")
 

--- a/cmd/terramate/e2etests/run_test.go
+++ b/cmd/terramate/e2etests/run_test.go
@@ -740,7 +740,7 @@ func TestRunReverseExecution(t *testing.T) {
 	addStack := func(stack string) {
 		s.BuildTree([]string{
 			"s:" + stack,
-			fmt.Sprintf("f:%s/%s:%[1]s\n", stack, testfile),
+			fmt.Sprintf("f:%s/%s:%s\n", stack, testfile, stack),
 		})
 	}
 

--- a/stack/stack.go
+++ b/stack/stack.go
@@ -196,6 +196,19 @@ func Sort(stacks []S) {
 	sort.Sort(stackSlice(stacks))
 }
 
+// Reverse reverses the given stacks slice.
+// It will not do a reverse sort, like what you get
+// by calling sort.Sort(sort.Reverse(slice)), it will just
+// reverse the current stacks slice in place.
+func Reverse(stacks []S) {
+	i, j := 0, len(stacks)-1
+	for i < j {
+		stacks[i], stacks[j] = stacks[j], stacks[i]
+		i++
+		j--
+	}
+}
+
 // stackSlice implements the Sort interface.
 type stackSlice []S
 

--- a/stack/stack.go
+++ b/stack/stack.go
@@ -197,9 +197,6 @@ func Sort(stacks []S) {
 }
 
 // Reverse reverses the given stacks slice.
-// It will not do a reverse sort, like what you get
-// by calling sort.Sort(sort.Reverse(slice)), it will just
-// reverse the current stacks slice in place.
 func Reverse(stacks []S) {
 	i, j := 0, len(stacks)-1
 	for i < j {


### PR DESCRIPTION
Adds the option `--reverse` to `terramate run`. So running:

```
terramate run --reverse
```

Will give the reversed order of whatever ordering defined for the given stack list