### PR TITLE
chore: add codecov patch config

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -4,3 +4,7 @@ coverage:
       default:
         target: 0%
         threshold: null
+    patch:
+      default:
+        target: 0%
+        threshold: null


### PR DESCRIPTION
We also need a patch config, or else the patch target is failing our PRs.