### PR TITLE
refactor: use Go's unwrap/Is protocol

### DIFF
--- a/errors/error.go
+++ b/errors/error.go
@@ -326,21 +326,6 @@ func As(err error, target interface{}) bool {
 	return errors.As(err, target)
 }
 
-func hasDesc(err error, desc string) bool {
-	e, ok := err.(*Error)
-	if !ok {
-		return false
-	}
-
-	if e.Description == desc {
-		return true
-	}
-	if e.Err != nil {
-		return hasDesc(e.Err, desc)
-	}
-	return false
-}
-
 // hasSameStack recursively check if err or any of its underlying errors has the
 // provided stack set.
 func hasSameStack(err error, stack StackMeta) bool {

--- a/errors/error.go
+++ b/errors/error.go
@@ -274,7 +274,7 @@ func (e *Error) Is(target error) bool {
 		return false
 	}
 
-	if t.Kind != "" && !IsKind(e, t.Kind) {
+	if t.Kind != "" && e.Kind != t.Kind {
 		return false
 	}
 
@@ -282,7 +282,7 @@ func (e *Error) Is(target error) bool {
 		return false
 	}
 
-	if t.Stack != nil && !hasSameStack(e, t.Stack) {
+	if t.Stack != nil && !equalStack(e.Stack, t.Stack) {
 		return false
 	}
 
@@ -300,20 +300,9 @@ func (e *Error) Unwrap() error {
 }
 
 // IsKind tells if err is of kind k.
-// It returns false if err is nil or not an *errors.Error.
-// It also recursively checks if any underlying error is of kind k.
+// It is a small wrapper around calling errors.Is(err, errors.Kind(k)).
 func IsKind(err error, k Kind) bool {
-	if err == nil {
-		return false
-	}
-	e, ok := err.(*Error)
-	if !ok {
-		return false
-	}
-	if e.Kind != "" && e.Kind == k {
-		return true
-	}
-	return IsKind(e.Err, k)
+	return Is(err, E(k))
 }
 
 // Is is just an alias to Go stdlib errors.Is
@@ -324,22 +313,6 @@ func Is(err, target error) bool {
 // As is just an alias to Go stdlib errors.As
 func As(err error, target interface{}) bool {
 	return errors.As(err, target)
-}
-
-// hasSameStack recursively check if err or any of its underlying errors has the
-// provided stack set.
-func hasSameStack(err error, stack StackMeta) bool {
-	e, ok := err.(*Error)
-	if !ok {
-		return false
-	}
-	if equalStack(e.Stack, stack) {
-		return true
-	}
-	if e.Err != nil {
-		return hasSameStack(e.Err, stack)
-	}
-	return false
 }
 
 func equalStack(s1, s2 StackMeta) bool {

--- a/errors/error.go
+++ b/errors/error.go
@@ -278,7 +278,7 @@ func (e *Error) Is(target error) bool {
 		return false
 	}
 
-	if t.Description != "" && !hasDesc(e, t.Description) {
+	if t.Description != "" && e.Description != t.Description {
 		return false
 	}
 

--- a/errors/error.go
+++ b/errors/error.go
@@ -269,12 +269,6 @@ func (e *Error) Detailed() string {
 // - FileRange
 // Any fields absent (empty) on the target error are ignored even if they exist on err (partial match).
 func (e *Error) Is(target error) bool {
-	if (e == nil) != (target == nil) {
-		return false
-	}
-	if target == nil {
-		return e == target
-	}
 	t, ok := target.(*Error)
 	if !ok {
 		return false

--- a/errors/error_test.go
+++ b/errors/error_test.go
@@ -156,7 +156,11 @@ func TestErrorString(t *testing.T) {
 		},
 		{
 			name: "simple message with stack",
-			err:  E(syntaxError, "failed to parse config", stackmeta{}),
+			err: E(syntaxError, "failed to parse config", stackmeta{
+				name: "test",
+				path: "/test",
+				desc: "test desc",
+			}),
 			want: fmt("%s: failed to parse config: at stack \"/test\"", syntaxError),
 		},
 	} {
@@ -175,6 +179,26 @@ func TestErrorIs(t *testing.T) {
 	}
 
 	stderr := stderrors.New("other")
+	stack := stackmeta{
+		name: "stack",
+		desc: "desc",
+		path: "/stack",
+	}
+	otherStack := stackmeta{
+		name: "otherstack",
+		desc: "other desc",
+		path: "/otherstack",
+	}
+	filerange := hcl.Range{
+		Filename: "test.tm",
+		Start:    hcl.Pos{Line: 1, Column: 5, Byte: 3},
+		End:      hcl.Pos{Line: 1, Column: 10, Byte: 13},
+	}
+	otherFileRange := hcl.Range{
+		Filename: "other.tm",
+		Start:    hcl.Pos{Line: 6, Column: 3, Byte: 4},
+		End:      hcl.Pos{Line: 7, Column: 1, Byte: 10},
+	}
 
 	for _, tc := range []testcase{
 		{
@@ -198,6 +222,12 @@ func TestErrorIs(t *testing.T) {
 			areSame: true,
 		},
 		{
+			name:    "same wrapped description",
+			err:     E("msg", E("any error")),
+			target:  E("any error"),
+			areSame: true,
+		},
+		{
 			name:    "same kind",
 			err:     E(syntaxError, "error"),
 			target:  E(syntaxError),
@@ -213,6 +243,42 @@ func TestErrorIs(t *testing.T) {
 			name:    "same underlying kind (deep nested)",
 			err:     E("error", E(tfSchemaError, E(tmSchemaError, E(syntaxError)))),
 			target:  E(syntaxError),
+			areSame: true,
+		},
+		{
+			name:    "same stack",
+			err:     E("error", stack),
+			target:  E(stack),
+			areSame: true,
+		},
+		{
+			name:    "same underlying stack",
+			err:     E("error", E(stack)),
+			target:  E(stack),
+			areSame: true,
+		},
+		{
+			name:    "same underlying stack (deep nested)",
+			err:     E("error", E(otherStack, E("msg", E(stack)))),
+			target:  E(stack),
+			areSame: true,
+		},
+		{
+			name:    "same file range",
+			err:     E("error", filerange),
+			target:  E(filerange),
+			areSame: true,
+		},
+		{
+			name:    "same underlying stack",
+			err:     E("error", E(filerange)),
+			target:  E(filerange),
+			areSame: true,
+		},
+		{
+			name:    "same underlying stack (deep nested)",
+			err:     E("error", E(otherFileRange, E("msg", E(filerange)))),
+			target:  E(filerange),
 			areSame: true,
 		},
 		{
@@ -248,8 +314,12 @@ func fmt(format string, args ...interface{}) string {
 	return stdfmt.Sprintf(format, args...)
 }
 
-type stackmeta struct{}
+type stackmeta struct {
+	name string
+	desc string
+	path string
+}
 
-func (s stackmeta) Name() string { return "test" }
-func (s stackmeta) Path() string { return "/test" }
-func (s stackmeta) Desc() string { return "test stack" }
+func (s stackmeta) Name() string { return s.name }
+func (s stackmeta) Path() string { return s.path }
+func (s stackmeta) Desc() string { return s.desc }

--- a/errors/error_test.go
+++ b/errors/error_test.go
@@ -292,6 +292,12 @@ func TestErrorIs(t *testing.T) {
 			target:  E("error", hcl.Range{Filename: "test.hcl"}),
 			areSame: true,
 		},
+		{
+			name:    "error match wrapped on stderr",
+			err:     stdfmt.Errorf("stderr : %w", E(syntaxError)),
+			target:  E(syntaxError),
+			areSame: true,
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			res := errors.Is(tc.err, tc.target)

--- a/errors/error_test.go
+++ b/errors/error_test.go
@@ -216,7 +216,7 @@ func TestErrorIs(t *testing.T) {
 			areSame: true,
 		},
 		{
-			name:    "underlying error is of the provided stderror",
+			name:    "underlying error is a stderror",
 			err:     E("some error wrapping a stderror", os.ErrNotExist),
 			target:  os.ErrNotExist,
 			areSame: true,

--- a/errors/error_test.go
+++ b/errors/error_test.go
@@ -178,7 +178,6 @@ func TestErrorIs(t *testing.T) {
 		areSame bool
 	}
 
-	stderr := stderrors.New("other")
 	stack := stackmeta{
 		name: "stack",
 		desc: "desc",
@@ -291,12 +290,6 @@ func TestErrorIs(t *testing.T) {
 			name:    "same file range",
 			err:     E("error", hcl.Range{Filename: "test.hcl"}),
 			target:  E("error", hcl.Range{Filename: "test.hcl"}),
-			areSame: true,
-		},
-		{
-			name:    "std error comparison works",
-			err:     stdfmt.Errorf("test: %w", stderr),
-			target:  stderr,
 			areSame: true,
 		},
 	} {

--- a/errors/error_test.go
+++ b/errors/error_test.go
@@ -309,6 +309,28 @@ func TestErrorIs(t *testing.T) {
 	}
 }
 
+func TestDetailedRepresentation(t *testing.T) {
+	stack := stackmeta{
+		name: "stack",
+		desc: "desc",
+		path: "/stack",
+	}
+	filerange := hcl.Range{
+		Filename: "test.tm",
+		Start:    hcl.Pos{Line: 1, Column: 5, Byte: 3},
+		End:      hcl.Pos{Line: 1, Column: 10, Byte: 13},
+	}
+
+	var e *errors.Error
+	err := E("error", stack, filerange)
+	errors.As(err, &e)
+
+	if e.Error() == e.Detailed() {
+		t.Error("detailed error representation should be different then default")
+		t.Fatalf("instead both are: %s", e.Error())
+	}
+}
+
 func fmt(format string, args ...interface{}) string {
 	return stdfmt.Sprintf(format, args...)
 }

--- a/errors/error_test.go
+++ b/errors/error_test.go
@@ -326,7 +326,7 @@ func TestDetailedRepresentation(t *testing.T) {
 	errors.As(err, &e)
 
 	if e.Error() == e.Detailed() {
-		t.Error("detailed error representation should be different then default")
+		t.Error("detailed error should be different than default")
 		t.Fatalf("instead both are: %s", e.Error())
 	}
 }


### PR DESCRIPTION
So we can focus on implementing just the Is method specific for each error type, no need to rollout our own Is implementation/recursion/unwrapping logic. Will make it easier for us to add the error list type.