### PR TITLE
chore: add errors.List

### DIFF
--- a/errors/error.go
+++ b/errors/error.go
@@ -69,10 +69,13 @@ type (
 const separator = ": "
 
 // List builds an Errors instance with all errs provided as arguments.
+// Any nil errors on errs will be discarded.
 func List(errs ...error) *Errors {
-	return &Errors{
-		errs: errs,
+	e := &Errors{}
+	for _, err := range errs {
+		e.Append(err)
 	}
+	return e
 }
 
 // Error returns the string representation of the error list.
@@ -104,8 +107,21 @@ func (e *Errors) Detailed() string {
 }
 
 // Append appends a new error on the error list.
+// If the error is nil it will not be added on the error list.
 func (e *Errors) Append(err error) {
+	if err == nil {
+		return
+	}
 	e.errs = append(e.errs, err)
+}
+
+// AsError returns an error instance if the errors list is non-empty.
+// If the list is empty it will return nil.
+func (e *Errors) AsError() error {
+	if len(e.errs) == 0 {
+		return nil
+	}
+	return e
 }
 
 // E builds an error value from its arguments.

--- a/errors/error.go
+++ b/errors/error.go
@@ -45,16 +45,6 @@ type Error struct {
 	Err error
 }
 
-// List represents a list of error instances that also
-// implements Go's error interface.
-//
-// List implements Go's errors.Is protocol matching the
-// target error with all the errors inside it, returning
-// true if any of the errors is a match.
-type List struct {
-	errs []error
-}
-
 type (
 	// Kind defines the kind of an error.
 	Kind string
@@ -68,76 +58,6 @@ type (
 )
 
 const separator = ": "
-
-// L builds a List instance with all errs provided as arguments.
-// Any nil errors on errs will be discarded.
-func L(errs ...error) *List {
-	e := &List{}
-	for _, err := range errs {
-		e.Append(err)
-	}
-	return e
-}
-
-// Error returns the string representation of the error list.
-// Only the first error message is returned, all other errors are elided.
-// For a full representation of all errors use the List.Detailed method.
-func (e *List) Error() string {
-	if len(e.errs) == 0 {
-		return ""
-	}
-	errmsg := e.errs[0].Error()
-	if len(e.errs) == 1 {
-		return errmsg
-	}
-	return fmt.Sprintf("%s (and %d elided errors)", errmsg, len(e.errs)-1)
-}
-
-// Detailed returns a detailed string representation of the error list.
-// It will return all errors contained on the list as a single string.
-// One error per line.
-func (e *List) Detailed() string {
-	if len(e.errs) == 0 {
-		return ""
-	}
-	details := []string{"error list:"}
-	for _, err := range e.errs {
-		details = append(details, "\t-"+err.Error())
-	}
-	return strings.Join(details, "\n")
-}
-
-// Append appends a new error on the error list.
-// If the error is nil it will not be added on the error list.
-func (e *List) Append(err error) {
-	if err == nil {
-		return
-	}
-	e.errs = append(e.errs, err)
-}
-
-// AsError returns an error instance if the errors list is non-empty.
-// If the list is empty it will return nil.
-func (e *List) AsError() error {
-	if len(e.errs) == 0 {
-		return nil
-	}
-	return e
-}
-
-// Is will call errors.Is for each of the errors on its list
-// returning true on the first match it finds or false if no
-// error inside the list matches the given target.
-//
-// If the target error is nil and the error list is empty returns true.
-func (e *List) Is(target error) bool {
-	for _, err := range e.errs {
-		if errors.Is(err, target) {
-			return true
-		}
-	}
-	return false
-}
 
 // E builds an error value from its arguments.
 // There must be at least one argument or E panics.

--- a/errors/error.go
+++ b/errors/error.go
@@ -45,12 +45,13 @@ type Error struct {
 	Err error
 }
 
-// Errors represents a list of error instances that also
+// List represents a list of error instances that also
 // implements Go's error interface.
-// Errors implements Go's errors.Is protocol matching the
+//
+// List implements Go's errors.Is protocol matching the
 // target error with all the errors inside it, returning
 // true if any of the errors is a match.
-type Errors struct {
+type List struct {
 	errs []error
 }
 
@@ -68,10 +69,10 @@ type (
 
 const separator = ": "
 
-// List builds an Errors instance with all errs provided as arguments.
+// L builds a List instance with all errs provided as arguments.
 // Any nil errors on errs will be discarded.
-func List(errs ...error) *Errors {
-	e := &Errors{}
+func L(errs ...error) *List {
+	e := &List{}
 	for _, err := range errs {
 		e.Append(err)
 	}
@@ -80,8 +81,8 @@ func List(errs ...error) *Errors {
 
 // Error returns the string representation of the error list.
 // Only the first error message is returned, all other errors are elided.
-// For a full representation of all errors use the Errors.Detailed method.
-func (e *Errors) Error() string {
+// For a full representation of all errors use the List.Detailed method.
+func (e *List) Error() string {
 	if len(e.errs) == 0 {
 		return ""
 	}
@@ -95,7 +96,7 @@ func (e *Errors) Error() string {
 // Detailed returns a detailed string representation of the error list.
 // It will return all errors contained on the list as a single string.
 // One error per line.
-func (e *Errors) Detailed() string {
+func (e *List) Detailed() string {
 	if len(e.errs) == 0 {
 		return ""
 	}
@@ -108,7 +109,7 @@ func (e *Errors) Detailed() string {
 
 // Append appends a new error on the error list.
 // If the error is nil it will not be added on the error list.
-func (e *Errors) Append(err error) {
+func (e *List) Append(err error) {
 	if err == nil {
 		return
 	}
@@ -117,7 +118,7 @@ func (e *Errors) Append(err error) {
 
 // AsError returns an error instance if the errors list is non-empty.
 // If the list is empty it will return nil.
-func (e *Errors) AsError() error {
+func (e *List) AsError() error {
 	if len(e.errs) == 0 {
 		return nil
 	}
@@ -129,7 +130,7 @@ func (e *Errors) AsError() error {
 // error inside the list matches the given target.
 //
 // If the target error is nil and the error list is empty returns true.
-func (e *Errors) Is(target error) bool {
+func (e *List) Is(target error) bool {
 	for _, err := range e.errs {
 		if errors.Is(err, target) {
 			return true

--- a/errors/error.go
+++ b/errors/error.go
@@ -124,6 +124,20 @@ func (e *Errors) AsError() error {
 	return e
 }
 
+// Is will call errors.Is for each of the errors on its list
+// returning true on the first match it finds or false if no
+// error inside the list matches the given target.
+//
+// If the target error is nil and the error list is empty returns true.
+func (e *Errors) Is(target error) bool {
+	for _, err := range e.errs {
+		if errors.Is(err, target) {
+			return true
+		}
+	}
+	return false
+}
+
 // E builds an error value from its arguments.
 // There must be at least one argument or E panics.
 // The type of each argument determines its meaning. If more than one argument

--- a/errors/error_test.go
+++ b/errors/error_test.go
@@ -170,13 +170,17 @@ func TestErrorString(t *testing.T) {
 			// piggyback on Error formatting tests for Errors list testing
 			t.Run("errors list with single error/"+tc.name, func(t *testing.T) {
 				errs := errors.List(tc.err)
+
 				assert.EqualStrings(t, tc.want, errs.Error())
+				assert.EqualStrings(t, tc.want, errs.AsError().Error())
 			})
 			t.Run("errors list with multiple errors/"+tc.name, func(t *testing.T) {
 				errs := errors.List(tc.err, E("will be elided"))
 				errs.Append(E("will also be elided"))
 				want := fmt("%s (and 2 elided errors)", tc.err.Error())
+
 				assert.EqualStrings(t, want, errs.Error())
+				assert.EqualStrings(t, want, errs.AsError().Error())
 			})
 		})
 	}
@@ -347,6 +351,23 @@ func TestEmptyErrorListStringRepresentationIsEmpty(t *testing.T) {
 	errs := errors.List()
 	assert.EqualStrings(t, "", errs.Error())
 	assert.EqualStrings(t, "", errs.Detailed())
+}
+
+func TestEmptyErrorListAsErrorIsNil(t *testing.T) {
+	errs := errors.List()
+	err := errs.AsError()
+	if err != nil {
+		t.Fatalf("got error %v but want nil", err)
+	}
+}
+
+func TestErrorListIgnoresNilErrors(t *testing.T) {
+	errs := errors.List(nil, nil)
+	errs.Append(nil)
+	err := errs.AsError()
+	if err != nil {
+		t.Fatalf("got error %v but want nil", err)
+	}
 }
 
 func TestErrorListStringDetailedPresentation(t *testing.T) {

--- a/errors/error_test.go
+++ b/errors/error_test.go
@@ -172,13 +172,13 @@ func TestErrorString(t *testing.T) {
 		// piggyback on Error formatting tests for Errors list testing
 
 		t.Run("errors list with single error/"+tc.name, func(t *testing.T) {
-			errs := errors.List(tc.err)
+			errs := errors.L(tc.err)
 
 			assert.EqualStrings(t, tc.want, errs.Error())
 			assert.EqualStrings(t, tc.want, errs.AsError().Error())
 		})
 		t.Run("errors list with multiple errors/"+tc.name, func(t *testing.T) {
-			errs := errors.List(tc.err, E("will be elided"))
+			errs := errors.L(tc.err, E("will be elided"))
 			errs.Append(E("will also be elided"))
 			want := fmt("%s (and 2 elided errors)", tc.err.Error())
 
@@ -331,17 +331,17 @@ func TestErrorIs(t *testing.T) {
 		//piggyback on errors.Error tests
 
 		t.Run("errors list with single err/"+tc.name, func(t *testing.T) {
-			errs := errors.List(tc.err)
+			errs := errors.L(tc.err)
 			assertErrorIsTarget(t, errs)
 		})
 
 		t.Run("errors list match is first/"+tc.name, func(t *testing.T) {
-			errs := errors.List(tc.err, stderrors.New("not match"))
+			errs := errors.L(tc.err, stderrors.New("not match"))
 			assertErrorIsTarget(t, errs)
 		})
 
 		t.Run("errors list match is last/"+tc.name, func(t *testing.T) {
-			errs := errors.List(stderrors.New("not match"), tc.err)
+			errs := errors.L(stderrors.New("not match"), tc.err)
 			assertErrorIsTarget(t, errs)
 		})
 	}
@@ -370,13 +370,13 @@ func TestDetailedRepresentation(t *testing.T) {
 }
 
 func TestEmptyErrorListStringRepresentationIsEmpty(t *testing.T) {
-	errs := errors.List()
+	errs := errors.L()
 	assert.EqualStrings(t, "", errs.Error())
 	assert.EqualStrings(t, "", errs.Detailed())
 }
 
 func TestEmptyErrorListAsErrorIsNil(t *testing.T) {
-	errs := errors.List()
+	errs := errors.L()
 	err := errs.AsError()
 	if err != nil {
 		t.Fatalf("got error %v but want nil", err)
@@ -384,7 +384,7 @@ func TestEmptyErrorListAsErrorIsNil(t *testing.T) {
 }
 
 func TestErrorListIgnoresNilErrors(t *testing.T) {
-	errs := errors.List(nil, nil)
+	errs := errors.L(nil, nil)
 	errs.Append(nil)
 	err := errs.AsError()
 	if err != nil {
@@ -393,7 +393,7 @@ func TestErrorListIgnoresNilErrors(t *testing.T) {
 }
 
 func TestErrorListStringDetailedPresentation(t *testing.T) {
-	errs := errors.List(E("one"))
+	errs := errors.L(E("one"))
 	assert.EqualStrings(t, "error list:\n\t-one", errs.Detailed())
 
 	errs.Append(E("two"))

--- a/errors/error_test.go
+++ b/errors/error_test.go
@@ -369,37 +369,6 @@ func TestDetailedRepresentation(t *testing.T) {
 	}
 }
 
-func TestEmptyErrorListStringRepresentationIsEmpty(t *testing.T) {
-	errs := errors.L()
-	assert.EqualStrings(t, "", errs.Error())
-	assert.EqualStrings(t, "", errs.Detailed())
-}
-
-func TestEmptyErrorListAsErrorIsNil(t *testing.T) {
-	errs := errors.L()
-	err := errs.AsError()
-	if err != nil {
-		t.Fatalf("got error %v but want nil", err)
-	}
-}
-
-func TestErrorListIgnoresNilErrors(t *testing.T) {
-	errs := errors.L(nil, nil)
-	errs.Append(nil)
-	err := errs.AsError()
-	if err != nil {
-		t.Fatalf("got error %v but want nil", err)
-	}
-}
-
-func TestErrorListStringDetailedPresentation(t *testing.T) {
-	errs := errors.L(E("one"))
-	assert.EqualStrings(t, "error list:\n\t-one", errs.Detailed())
-
-	errs.Append(E("two"))
-	assert.EqualStrings(t, "error list:\n\t-one\n\t-two", errs.Detailed())
-}
-
 func fmt(format string, args ...interface{}) string {
 	return stdfmt.Sprintf(format, args...)
 }

--- a/errors/error_test.go
+++ b/errors/error_test.go
@@ -167,21 +167,23 @@ func TestErrorString(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			assert.EqualStrings(t, tc.want, tc.err.Error())
 
-			// piggyback on Error formatting tests for Errors list testing
-			t.Run("errors list with single error/"+tc.name, func(t *testing.T) {
-				errs := errors.List(tc.err)
+		})
 
-				assert.EqualStrings(t, tc.want, errs.Error())
-				assert.EqualStrings(t, tc.want, errs.AsError().Error())
-			})
-			t.Run("errors list with multiple errors/"+tc.name, func(t *testing.T) {
-				errs := errors.List(tc.err, E("will be elided"))
-				errs.Append(E("will also be elided"))
-				want := fmt("%s (and 2 elided errors)", tc.err.Error())
+		// piggyback on Error formatting tests for Errors list testing
 
-				assert.EqualStrings(t, want, errs.Error())
-				assert.EqualStrings(t, want, errs.AsError().Error())
-			})
+		t.Run("errors list with single error/"+tc.name, func(t *testing.T) {
+			errs := errors.List(tc.err)
+
+			assert.EqualStrings(t, tc.want, errs.Error())
+			assert.EqualStrings(t, tc.want, errs.AsError().Error())
+		})
+		t.Run("errors list with multiple errors/"+tc.name, func(t *testing.T) {
+			errs := errors.List(tc.err, E("will be elided"))
+			errs.Append(E("will also be elided"))
+			want := fmt("%s (and 2 elided errors)", tc.err.Error())
+
+			assert.EqualStrings(t, want, errs.Error())
+			assert.EqualStrings(t, want, errs.AsError().Error())
 		})
 	}
 }
@@ -216,10 +218,6 @@ func TestErrorIs(t *testing.T) {
 	}
 
 	for _, tc := range []testcase{
-		{
-			name:    "both nil",
-			areSame: true,
-		},
 		{
 			name:   "nil target is not equal",
 			err:    E("any error"),
@@ -315,12 +313,36 @@ func TestErrorIs(t *testing.T) {
 			areSame: true,
 		},
 	} {
-		t.Run(tc.name, func(t *testing.T) {
-			res := errors.Is(tc.err, tc.target)
+
+		assertErrorIsTarget := func(t *testing.T, err error) {
+			t.Helper()
+
+			res := errors.Is(err, tc.target)
 			if res != tc.areSame {
 				t.Fatalf("error[%v] == target[%v] = %t but want %t",
-					tc.err, tc.target, res, tc.areSame)
+					err, tc.target, res, tc.areSame)
 			}
+		}
+
+		t.Run(tc.name, func(t *testing.T) {
+			assertErrorIsTarget(t, tc.err)
+		})
+
+		//piggyback on errors.Error tests
+
+		t.Run("errors list with single err/"+tc.name, func(t *testing.T) {
+			errs := errors.List(tc.err)
+			assertErrorIsTarget(t, errs)
+		})
+
+		t.Run("errors list match is first/"+tc.name, func(t *testing.T) {
+			errs := errors.List(tc.err, stderrors.New("not match"))
+			assertErrorIsTarget(t, errs)
+		})
+
+		t.Run("errors list match is last/"+tc.name, func(t *testing.T) {
+			errs := errors.List(stderrors.New("not match"), tc.err)
+			assertErrorIsTarget(t, errs)
 		})
 	}
 }

--- a/errors/error_test.go
+++ b/errors/error_test.go
@@ -166,6 +166,18 @@ func TestErrorString(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			assert.EqualStrings(t, tc.want, tc.err.Error())
+
+			// piggyback on Error formatting tests for Errors list testing
+			t.Run("errors list with single error/"+tc.name, func(t *testing.T) {
+				errs := errors.List(tc.err)
+				assert.EqualStrings(t, tc.want, errs.Error())
+			})
+			t.Run("errors list with multiple errors/"+tc.name, func(t *testing.T) {
+				errs := errors.List(tc.err, E("will be elided"))
+				errs.Append(E("will also be elided"))
+				want := fmt("%s (and 2 elided errors)", tc.err.Error())
+				assert.EqualStrings(t, want, errs.Error())
+			})
 		})
 	}
 }
@@ -329,6 +341,20 @@ func TestDetailedRepresentation(t *testing.T) {
 		t.Error("detailed error should be different than default")
 		t.Fatalf("instead both are: %s", e.Error())
 	}
+}
+
+func TestEmptyErrorListStringRepresentationIsEmpty(t *testing.T) {
+	errs := errors.List()
+	assert.EqualStrings(t, "", errs.Error())
+	assert.EqualStrings(t, "", errs.Detailed())
+}
+
+func TestErrorListStringDetailedPresentation(t *testing.T) {
+	errs := errors.List(E("one"))
+	assert.EqualStrings(t, "error list:\n\t-one", errs.Detailed())
+
+	errs.Append(E("two"))
+	assert.EqualStrings(t, "error list:\n\t-one\n\t-two", errs.Detailed())
 }
 
 func fmt(format string, args ...interface{}) string {

--- a/errors/list.go
+++ b/errors/list.go
@@ -1,0 +1,101 @@
+// Copyright 2022 Mineiros GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package errors
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// List represents a list of error instances that also
+// implements Go's error interface.
+//
+// List implements Go's errors.Is protocol matching the
+// target error with all the errors inside it, returning
+// true if any of the errors is a match.
+type List struct {
+	errs []error
+}
+
+// L builds a List instance with all errs provided as arguments.
+// Any nil errors on errs will be discarded.
+func L(errs ...error) *List {
+	e := &List{}
+	for _, err := range errs {
+		e.Append(err)
+	}
+	return e
+}
+
+// Error returns the string representation of the error list.
+// Only the first error message is returned, all other errors are elided.
+// For a full representation of all errors use the List.Detailed method.
+func (l *List) Error() string {
+	if len(l.errs) == 0 {
+		return ""
+	}
+	errmsg := l.errs[0].Error()
+	if len(l.errs) == 1 {
+		return errmsg
+	}
+	return fmt.Sprintf("%s (and %d elided errors)", errmsg, len(l.errs)-1)
+}
+
+// Detailed returns a detailed string representation of the error list.
+// It will return all errors contained on the list as a single string.
+// One error per line.
+func (l *List) Detailed() string {
+	if len(l.errs) == 0 {
+		return ""
+	}
+	details := []string{"error list:"}
+	for _, err := range l.errs {
+		details = append(details, "\t-"+err.Error())
+	}
+	return strings.Join(details, "\n")
+}
+
+// Append appends a new error on the error list.
+// If the error is nil it will not be added on the error list.
+func (l *List) Append(err error) {
+	if err == nil {
+		return
+	}
+	l.errs = append(l.errs, err)
+}
+
+// AsError returns an error instance if the errors list is non-empty.
+// If the list is empty it will return nil.
+func (l *List) AsError() error {
+	if len(l.errs) == 0 {
+		return nil
+	}
+	return l
+}
+
+// Is will call errors.Is for each of the errors on its list
+// returning true on the first match it finds or false if no
+// error inside the list matches the given target.
+//
+// If the target error is nil and the error list is empty returns true.
+func (l *List) Is(target error) bool {
+	for _, err := range l.errs {
+		if errors.Is(err, target) {
+			return true
+		}
+	}
+	return false
+}

--- a/errors/list.go
+++ b/errors/list.go
@@ -77,7 +77,8 @@ func (l *List) Append(err error) {
 	l.errs = append(l.errs, err)
 }
 
-// AsError returns an error instance if the errors list is non-empty.
+// AsError returns the error list as an error instance if the errors
+// list is non-empty.
 // If the list is empty it will return nil.
 func (l *List) AsError() error {
 	if len(l.errs) == 0 {

--- a/errors/list.go
+++ b/errors/list.go
@@ -54,6 +54,20 @@ func (l *List) Error() string {
 	return fmt.Sprintf("%s (and %d elided errors)", errmsg, len(l.errs)-1)
 }
 
+// Errors returns all errors contained on the list that are of the type Error
+// or that have an error of type Error wrapped inside them.
+// Any other errors will be ignored.
+func (l *List) Errors() []*Error {
+	var errs []*Error
+	for _, err := range l.errs {
+		var e *Error
+		if errors.As(err, &e) {
+			errs = append(errs, e)
+		}
+	}
+	return errs
+}
+
 // Detailed returns a detailed string representation of the error list.
 // It will return all errors contained on the list as a single string.
 // One error per line.

--- a/errors/list_test.go
+++ b/errors/list_test.go
@@ -1,0 +1,80 @@
+// Copyright 2022 Mineiros GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package errors_test
+
+import (
+	stderrors "errors"
+	stdfmt "fmt"
+	"testing"
+
+	"github.com/madlambda/spells/assert"
+	"github.com/mineiros-io/terramate/errors"
+)
+
+func TestEmptyErrorListReturnsEmptyErrors(t *testing.T) {
+	e := errors.L()
+	errs := e.Errors()
+
+	assert.EqualInts(t, 0, len(errs))
+}
+
+func TestErrorListReturnsAllErrors(t *testing.T) {
+	e := errors.L()
+
+	assert.EqualInts(t, 0, len(e.Errors()))
+
+	e.Append(E("one"))
+	e.Append(stdfmt.Errorf("wrapped: %w", E("two")))
+	e.Append(stderrors.New("ignored"))
+	e.Append(E("three"))
+
+	errs := e.Errors()
+
+	assert.EqualInts(t, 3, len(errs))
+	assert.IsError(t, errs[0], E("one"))
+	assert.IsError(t, errs[1], E("two"))
+	assert.IsError(t, errs[2], E("three"))
+}
+
+func TestEmptyErrorListStringRepresentationIsEmpty(t *testing.T) {
+	errs := errors.L()
+	assert.EqualStrings(t, "", errs.Error())
+	assert.EqualStrings(t, "", errs.Detailed())
+}
+
+func TestEmptyErrorListAsErrorIsNil(t *testing.T) {
+	errs := errors.L()
+	err := errs.AsError()
+	if err != nil {
+		t.Fatalf("got error %v but want nil", err)
+	}
+}
+
+func TestErrorListIgnoresNilErrors(t *testing.T) {
+	errs := errors.L(nil, nil)
+	errs.Append(nil)
+	err := errs.AsError()
+	if err != nil {
+		t.Fatalf("got error %v but want nil", err)
+	}
+}
+
+func TestErrorListStringDetailedPresentation(t *testing.T) {
+	errs := errors.L(E("one"))
+	assert.EqualStrings(t, "error list:\n\t-one", errs.Detailed())
+
+	errs.Append(E("two"))
+	assert.EqualStrings(t, "error list:\n\t-one\n\t-two", errs.Detailed())
+}


### PR DESCRIPTION
Add new errors.List type + constructor errors.L. Should be enough to represent errors list without giving up using the error interface. Usage will be:

```go
errs := errors.L()
errs.Append(something.Do())
return errs.AsError()
```

It will automatically ignore nil error (sucesses) and if no errors are present errs.AsError() returns nil. Using errors.Is will also work by matching with all errors inside the list, any match is enough for success.

To inspect all errors contained on the LSP server there is a method List.Errors that returns all errors that are of the type Error or have an Error wrapped inside them, so we can use it like this:

```go
for _, err := range errs.Errors() {
    // err type is errors.Error, so we can just acccess information there
}
```

Not in love with any of the names I chose, so feel free to propose different names for anything :laughing: 