### PR TITLE
feat: add multiple errs when parsing hcl.Modules

### DIFF
--- a/errors/error_test.go
+++ b/errors/error_test.go
@@ -302,9 +302,14 @@ func TestErrorIs(t *testing.T) {
 		},
 		{
 			name:    "same file range",
-			err:     E("error", hcl.Range{Filename: "test.hcl"}),
-			target:  E("error", hcl.Range{Filename: "test.hcl"}),
+			err:     E("error", filerange),
+			target:  E("error", filerange),
 			areSame: true,
+		},
+		{
+			name:   "different file ranges",
+			err:    E("error", filerange),
+			target: E("error", otherFileRange),
 		},
 		{
 			name:    "error match wrapped on stderr",

--- a/generate/generate_report_test.go
+++ b/generate/generate_report_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/madlambda/spells/assert"
 	"github.com/mineiros-io/terramate/generate"
-	errtest "github.com/mineiros-io/terramate/test/errors"
 )
 
 func TestReportRepresentation(t *testing.T) {
@@ -256,7 +255,7 @@ func assertEqualReports(t *testing.T, got, want generate.Report) {
 	// WHY: we can't just use cmp.Diff since the errors included on the Report
 	// are not comparable and may contain unexported fields (depending on how errors are built)
 
-	errtest.Assert(t, got.BootstrapErr, want.BootstrapErr)
+	assert.IsError(t, got.BootstrapErr, want.BootstrapErr)
 
 	if diff := cmp.Diff(got.Successes, want.Successes); diff != "" {
 		t.Errorf("success results differs: got(-) want(+)")
@@ -273,6 +272,6 @@ func assertEqualReports(t *testing.T, got, want generate.Report) {
 			t.Fatal(diff)
 		}
 
-		errtest.Assert(t, gotFailure.Error, wantFailure.Error)
+		assert.IsError(t, gotFailure.Error, wantFailure.Error)
 	}
 }


### PR DESCRIPTION
# Reason for This Change

So we can provide better error reporting when supporting LSP integration.

## Description of Changes

Parsing modules now return an error list instead of a single error, and won't stop as soon as it finds an error.