### PR TITLE
chore: flatten diagnostics + error list when appending on an error list

### DIFF
--- a/errors/error.go
+++ b/errors/error.go
@@ -131,6 +131,11 @@ func E(args ...interface{}) *Error {
 			if diag.Subject != nil {
 				e.FileRange = *diag.Subject
 			}
+		case *hcl.Diagnostic:
+			diag = arg
+			if diag.Subject != nil {
+				e.FileRange = *diag.Subject
+			}
 		case StackMeta:
 			e.Stack = arg
 		case error:

--- a/errors/error.go
+++ b/errors/error.go
@@ -75,9 +75,12 @@ const separator = ": "
 //		The underlying error that triggered this one.
 //	hcl.Diagnostics
 //		The underlying hcl error that triggered this one.
+//		Only the first hcl.Diagnostic will be used.
 //		If hcl.Range is not set, the diagnostic subject range is pulled.
 //		If the string Description is not set, the diagnostic detail field is
 //		pulled.
+//	hcl.Diagnostic
+//		Same behavior as hcl.Diagnostics but for a single diagnostic.
 //	string
 //		The error description. It supports formatting using the Go's fmt verbs
 //		as long as the arguments are not one of the defined types.
@@ -102,7 +105,7 @@ func E(args ...interface{}) error {
 	}
 
 	var (
-		diags  hcl.Diagnostics
+		diag   *hcl.Diagnostic
 		format *string
 	)
 
@@ -116,12 +119,17 @@ func E(args ...interface{}) error {
 		case hcl.Range:
 			e.FileRange = arg
 		case hcl.Diagnostics:
-			diags = arg
+			diags := arg
 			if diags.HasErrors() {
-				diag := diags[0]
+				diag = diags[0]
 				if diag.Subject != nil {
 					e.FileRange = *diag.Subject
 				}
+			}
+		case hcl.Diagnostic:
+			diag = &arg
+			if diag.Subject != nil {
+				e.FileRange = *diag.Subject
 			}
 		case StackMeta:
 			e.Stack = arg
@@ -142,14 +150,14 @@ func E(args ...interface{}) error {
 	if format != nil {
 		e.Description = fmt.Sprintf(*format, fmtargs...)
 	} else if len(fmtargs) > 0 {
-		panic(errors.New("errors.E called with arbitraty types and no format"))
+		panic(errors.New("errors.E called with arbitrary types and no format"))
 	}
 
-	if diags.HasErrors() {
+	if diag != nil {
 		if e.Description == "" {
-			e.Description = diags[0].Detail
+			e.Description = diag.Detail
 		} else if e.Err == nil {
-			e.Err = diags
+			e.Err = diag
 		}
 	}
 

--- a/errors/error.go
+++ b/errors/error.go
@@ -133,7 +133,7 @@ func E(args ...interface{}) *Error {
 			}
 		case *hcl.Diagnostic:
 			diag = arg
-			if diag.Subject != nil {
+			if diag != nil && diag.Subject != nil {
 				e.FileRange = *diag.Subject
 			}
 		case StackMeta:

--- a/errors/error.go
+++ b/errors/error.go
@@ -99,7 +99,7 @@ const separator = ": "
 //
 // In order to avoid duplicated messages, we erase the fields present in the
 // underlying error if already set with same value in this error.
-func E(args ...interface{}) error {
+func E(args ...interface{}) *Error {
 	if len(args) == 0 {
 		panic("called with no args")
 	}

--- a/errors/error_test.go
+++ b/errors/error_test.go
@@ -155,6 +155,20 @@ func TestErrorString(t *testing.T) {
 			want: "test.tm:1,5-10: some error",
 		},
 		{
+			name: "single diag sets range and description",
+			err: E(hcl.Diagnostic{
+				Detail:   "some error",
+				Severity: hcl.DiagError,
+				Subject: &hcl.Range{
+					Filename: "test.tm",
+					Start:    hcl.Pos{Line: 1, Column: 5, Byte: 3},
+					End:      hcl.Pos{Line: 1, Column: 10, Byte: 13},
+				},
+			},
+			),
+			want: "test.tm:1,5-10: some error",
+		},
+		{
 			name: "simple message with stack",
 			err: E(syntaxError, "failed to parse config", stackmeta{
 				name: "test",
@@ -279,6 +293,16 @@ func TestErrorIs(t *testing.T) {
 		{
 			name:    "same file range",
 			err:     E("error", filerange),
+			target:  E(filerange),
+			areSame: true,
+		},
+		{
+			name: "same file range built from hcl.Diagnostic",
+			err: E("error", hcl.Diagnostic{
+				Detail:   "some error",
+				Severity: hcl.DiagError,
+				Subject:  &filerange,
+			}),
 			target:  E(filerange),
 			areSame: true,
 		},

--- a/errors/error_test.go
+++ b/errors/error_test.go
@@ -70,6 +70,8 @@ func TestErrorString(t *testing.T) {
 		want string
 	}
 
+	var nildiagnostic *hcl.Diagnostic
+
 	for _, tc := range []testcase{
 		{
 			name: "simple message",
@@ -181,6 +183,11 @@ func TestErrorString(t *testing.T) {
 			},
 			),
 			want: "test.tm:1,5-10: some error",
+		},
+		{
+			name: "nil diag pointer is ignored",
+			err:  E("error", nildiagnostic),
+			want: "error",
 		},
 		{
 			name: "simple message with stack",

--- a/errors/error_test.go
+++ b/errors/error_test.go
@@ -169,6 +169,20 @@ func TestErrorString(t *testing.T) {
 			want: "test.tm:1,5-10: some error",
 		},
 		{
+			name: "single diag pointer sets range and description",
+			err: E(&hcl.Diagnostic{
+				Detail:   "some error",
+				Severity: hcl.DiagError,
+				Subject: &hcl.Range{
+					Filename: "test.tm",
+					Start:    hcl.Pos{Line: 1, Column: 5, Byte: 3},
+					End:      hcl.Pos{Line: 1, Column: 10, Byte: 13},
+				},
+			},
+			),
+			want: "test.tm:1,5-10: some error",
+		},
+		{
 			name: "simple message with stack",
 			err: E(syntaxError, "failed to parse config", stackmeta{
 				name: "test",

--- a/errors/list.go
+++ b/errors/list.go
@@ -18,6 +18,8 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+
+	"github.com/hashicorp/hcl/v2"
 )
 
 // List represents a list of error instances that also
@@ -32,6 +34,12 @@ type List struct {
 
 // L builds a List instance with all errs provided as arguments.
 // Any nil errors on errs will be discarded.
+//
+// Any error of type hcl.Diagnostics will be flattened inside
+// the error list, each hcl.Diagnostic will become an error.Error.
+//
+// Any error of type errors.List will be flattened inside
+// the error list, each  will become an error.Error.
 func L(errs ...error) *List {
 	e := &List{}
 	for _, err := range errs {
@@ -84,11 +92,26 @@ func (l *List) Detailed() string {
 
 // Append appends a new error on the error list.
 // If the error is nil it will not be added on the error list.
+//
+// Any error of type hcl.Diagnostics will be flattened inside
+// the error list, each hcl.Diagnostic will become an error.Error.
+//
+// Any error of type errors.List will be flattened inside
+// the error list.
 func (l *List) Append(err error) {
 	if err == nil {
 		return
 	}
-	l.errs = append(l.errs, err)
+	switch e := err.(type) {
+	case hcl.Diagnostics:
+		{
+			for _, diag := range e {
+				l.errs = append(l.errs, E(*diag))
+			}
+		}
+	default:
+		l.errs = append(l.errs, err)
+	}
 }
 
 // AsError returns the error list as an error instance if the errors

--- a/errors/list.go
+++ b/errors/list.go
@@ -106,7 +106,7 @@ func (l *List) Append(err error) {
 	case hcl.Diagnostics:
 		{
 			for _, diag := range e {
-				l.errs = append(l.errs, E(*diag))
+				l.errs = append(l.errs, E(diag))
 			}
 		}
 	case *List:

--- a/errors/list.go
+++ b/errors/list.go
@@ -109,6 +109,10 @@ func (l *List) Append(err error) {
 				l.errs = append(l.errs, E(*diag))
 			}
 		}
+	case *List:
+		{
+			l.errs = append(l.errs, e.errs...)
+		}
 	default:
 		l.errs = append(l.errs, err)
 	}

--- a/errors/list_test.go
+++ b/errors/list_test.go
@@ -73,7 +73,7 @@ func TestErrorListIgnoresNilErrors(t *testing.T) {
 	}
 }
 
-func TestErrorListAppendAllDiagnostics(t *testing.T) {
+func TestErrorListFlattensAllDiagnostics(t *testing.T) {
 	const (
 		detail1 = "error 1"
 		detail2 = "error 2"
@@ -117,6 +117,28 @@ func TestErrorListAppendAllDiagnostics(t *testing.T) {
 			FileRange:   *range2,
 		},
 	}
+	gotErrs := errs.Errors()
+
+	if diff := cmp.Diff(gotErrs, wantErrs); diff != "" {
+		t.Fatalf("-(got) +(want):\n%s", diff)
+	}
+}
+
+func TestErrorListFlattensOtherErrorList(t *testing.T) {
+	const (
+		kind1 errors.Kind = "kind1"
+		kind2 errors.Kind = "kind2"
+		kind3 errors.Kind = "kind3"
+	)
+
+	error1 := &errors.Error{Kind: kind1}
+	error2 := &errors.Error{Kind: kind2}
+	error3 := &errors.Error{Kind: kind3}
+
+	errs := errors.L(error1)
+	errs.Append(errors.L(error2, error3))
+
+	wantErrs := []*errors.Error{error1, error2, error3}
 	gotErrs := errs.Errors()
 
 	if diff := cmp.Diff(gotErrs, wantErrs); diff != "" {

--- a/errors/list_test.go
+++ b/errors/list_test.go
@@ -19,6 +19,8 @@ import (
 	stdfmt "fmt"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/hcl/v2"
 	"github.com/madlambda/spells/assert"
 	"github.com/mineiros-io/terramate/errors"
 )
@@ -68,6 +70,57 @@ func TestErrorListIgnoresNilErrors(t *testing.T) {
 	err := errs.AsError()
 	if err != nil {
 		t.Fatalf("got error %v but want nil", err)
+	}
+}
+
+func TestErrorListAppendAllDiagnostics(t *testing.T) {
+	const (
+		detail1 = "error 1"
+		detail2 = "error 2"
+	)
+	var (
+		range1 = &hcl.Range{
+			Filename: "file1.tm",
+			Start:    hcl.Pos{Line: 1, Column: 5, Byte: 3},
+			End:      hcl.Pos{Line: 1, Column: 10, Byte: 13},
+		}
+
+		range2 = &hcl.Range{
+			Filename: "file2.tm",
+			Start:    hcl.Pos{Line: 2, Column: 6, Byte: 4},
+			End:      hcl.Pos{Line: 2, Column: 11, Byte: 14},
+		}
+	)
+	diags := hcl.Diagnostics{
+		&hcl.Diagnostic{
+			Detail:   detail1,
+			Severity: hcl.DiagError,
+			Subject:  range1,
+		},
+		&hcl.Diagnostic{
+			Detail:   detail2,
+			Severity: hcl.DiagError,
+			Subject:  range2,
+		},
+	}
+
+	errs := errors.L()
+	errs.Append(diags)
+
+	wantErrs := []*errors.Error{
+		{
+			Description: detail1,
+			FileRange:   *range1,
+		},
+		{
+			Description: detail2,
+			FileRange:   *range2,
+		},
+	}
+	gotErrs := errs.Errors()
+
+	if diff := cmp.Diff(gotErrs, wantErrs); diff != "" {
+		t.Fatalf("-(got) +(want):\n%s", diff)
 	}
 }
 

--- a/errors/list_test.go
+++ b/errors/list_test.go
@@ -131,9 +131,9 @@ func TestErrorListFlattensOtherErrorList(t *testing.T) {
 		kind3 errors.Kind = "kind3"
 	)
 
-	error1 := &errors.Error{Kind: kind1}
-	error2 := &errors.Error{Kind: kind2}
-	error3 := &errors.Error{Kind: kind3}
+	error1 := errors.E(kind1)
+	error2 := errors.E(kind2)
+	error3 := errors.E(kind3)
 
 	errs := errors.L(error1)
 	errs.Append(errors.L(error2, error3))


### PR DESCRIPTION
So it is easier to build error list from operations that produce a diagnostic from HCL (which is also a list) or even our own list. It seems that the most desireable behavior is flattening, but I could be wong.
