### PR TITLE
refactor: move globals to stack pkg

### DIFF
--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -707,7 +707,7 @@ func (c *cli) printStacksGlobals() {
 
 	for _, stackEntry := range c.filterStacksByWorkingDir(report.Stacks) {
 		meta := stack.Metadata(stackEntry.Stack)
-		globals, err := stack.LoadStackGlobals(c.root(), meta)
+		globals, err := stack.LoadGlobals(c.root(), meta)
 		if err != nil {
 			log.Fatal().
 				Err(err).

--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -707,7 +707,7 @@ func (c *cli) printStacksGlobals() {
 
 	for _, stackEntry := range c.filterStacksByWorkingDir(report.Stacks) {
 		meta := stack.Metadata(stackEntry.Stack)
-		globals, err := terramate.LoadStackGlobals(c.root(), meta)
+		globals, err := stack.LoadStackGlobals(c.root(), meta)
 		if err != nil {
 			log.Fatal().
 				Err(err).

--- a/generate/generate.go
+++ b/generate/generate.go
@@ -234,7 +234,7 @@ func CheckStack(root string, st stack.S) ([]string, error) {
 
 	logger.Trace().Msg("Loading globals for stack.")
 
-	globals, err := stack.LoadStackGlobals(root, st)
+	globals, err := stack.LoadGlobals(root, st)
 	if err != nil {
 		return nil, errors.E(err, "checking for outdated code")
 	}
@@ -471,7 +471,7 @@ func forEachStack(root, workingDir string, fn forEachStackFunc) Report {
 
 		logger.Trace().Msg("Load stack globals.")
 
-		globals, err := stack.LoadStackGlobals(root, st)
+		globals, err := stack.LoadGlobals(root, st)
 		if err != nil {
 			report.addFailure(st, errors.E(ErrLoadingGlobals, err))
 			continue

--- a/generate/generate.go
+++ b/generate/generate.go
@@ -74,7 +74,7 @@ const (
 func Do(root string, workingDir string) Report {
 	return forEachStack(root, workingDir, func(
 		stack stack.S,
-		globals terramate.Globals,
+		globals stack.Globals,
 	) stackReport {
 		stackpath := stack.HostPath()
 		logger := log.With().
@@ -223,25 +223,25 @@ func ListStackGenFiles(stack stack.S) ([]string, error) {
 // If the stack has an invalid configuration it will return an error.
 //
 // The provided root must be the project's root directory as an absolute path.
-func CheckStack(root string, stack stack.S) ([]string, error) {
+func CheckStack(root string, st stack.S) ([]string, error) {
 	logger := log.With().
 		Str("action", "generate.CheckStack()").
 		Str("path", root).
-		Stringer("stack", stack).
+		Stringer("stack", st).
 		Logger()
 
 	logger.Trace().Msg("Load stack code generation config.")
 
 	logger.Trace().Msg("Loading globals for stack.")
 
-	globals, err := terramate.LoadStackGlobals(root, stack)
+	globals, err := stack.LoadStackGlobals(root, st)
 	if err != nil {
 		return nil, errors.E(err, "checking for outdated code")
 	}
 
 	logger.Trace().Msg("Listing current generated files.")
 
-	generatedFiles, err := ListStackGenFiles(stack)
+	generatedFiles, err := ListStackGenFiles(st)
 	if err != nil {
 		return nil, errors.E(err, "checking for outdated code")
 	}
@@ -249,11 +249,11 @@ func CheckStack(root string, stack stack.S) ([]string, error) {
 	// We start with the assumption that all gen files on the stack
 	// are outdated and then update the outdated files set as we go.
 	outdatedFiles := newStringSet(generatedFiles...)
-	stackpath := stack.HostPath()
+	stackpath := st.HostPath()
 	err = updateGenHCLOutdatedFiles(
 		root,
 		stackpath,
-		stack,
+		st,
 		globals,
 		outdatedFiles,
 	)
@@ -275,7 +275,7 @@ type genfile struct {
 func updateGenHCLOutdatedFiles(
 	root, stackpath string,
 	stackMeta stack.Metadata,
-	globals terramate.Globals,
+	globals stack.Globals,
 	outdatedFiles *stringSet,
 ) error {
 	logger := log.With().
@@ -328,7 +328,7 @@ func generateStackHCLCode(
 	root string,
 	stackpath string,
 	meta stack.Metadata,
-	globals terramate.Globals,
+	globals stack.Globals,
 ) ([]genfile, error) {
 	logger := log.With().
 		Str("action", "generateStackHCLCode()").
@@ -438,7 +438,7 @@ func loadGeneratedCode(path string) (string, bool, error) {
 	return "", false, errors.E(ErrManualCodeExists, "check file %q", path)
 }
 
-type forEachStackFunc func(stack.S, terramate.Globals) stackReport
+type forEachStackFunc func(stack.S, stack.Globals) stackReport
 
 func forEachStack(root, workingDir string, fn forEachStackFunc) Report {
 	logger := log.With().
@@ -458,28 +458,28 @@ func forEachStack(root, workingDir string, fn forEachStackFunc) Report {
 	}
 
 	for _, entry := range stackEntries {
-		stack := entry.Stack
+		st := entry.Stack
 
 		logger := logger.With().
-			Stringer("stack", stack).
+			Stringer("stack", st).
 			Logger()
 
-		if !strings.HasPrefix(stack.HostPath(), workingDir) {
+		if !strings.HasPrefix(st.HostPath(), workingDir) {
 			logger.Trace().Msg("discarding stack outside working dir")
 			continue
 		}
 
 		logger.Trace().Msg("Load stack globals.")
 
-		globals, err := terramate.LoadStackGlobals(root, stack)
+		globals, err := stack.LoadStackGlobals(root, st)
 		if err != nil {
-			report.addFailure(stack, errors.E(ErrLoadingGlobals, err))
+			report.addFailure(st, errors.E(ErrLoadingGlobals, err))
 			continue
 		}
 
 		logger.Trace().Msg("Calling stack callback.")
 
-		report.addStackReport(stack, fn(stack, globals))
+		report.addStackReport(st, fn(st, globals))
 	}
 	report.sortFilenames()
 	return report

--- a/generate/genhcl/genhcl.go
+++ b/generate/genhcl/genhcl.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/hashicorp/hcl/v2/hclwrite"
-	"github.com/mineiros-io/terramate"
 	"github.com/mineiros-io/terramate/errors"
 	"github.com/mineiros-io/terramate/hcl"
 	"github.com/mineiros-io/terramate/hcl/eval"
@@ -91,7 +90,7 @@ func (b HCL) Origin() string {
 // The returned result only contains evaluated values.
 //
 // The rootdir MUST be an absolute path.
-func Load(rootdir string, sm stack.Metadata, globals terramate.Globals) (StackHCLs, error) {
+func Load(rootdir string, sm stack.Metadata, globals stack.Globals) (StackHCLs, error) {
 	stackpath := filepath.Join(rootdir, sm.Path())
 	logger := log.With().
 		Str("action", "genhcl.Load()").
@@ -142,7 +141,7 @@ func Load(rootdir string, sm stack.Metadata, globals terramate.Globals) (StackHC
 	return res, nil
 }
 
-func newEvalCtx(stackpath string, sm stack.Metadata, globals terramate.Globals) (*eval.Context, error) {
+func newEvalCtx(stackpath string, sm stack.Metadata, globals stack.Globals) (*eval.Context, error) {
 	logger := log.With().
 		Str("action", "genhcl.newEvalCtx()").
 		Str("path", stackpath).

--- a/stack/globals.go
+++ b/stack/globals.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package terramate
+package stack
 
 import (
 	"path/filepath"
@@ -23,7 +23,6 @@ import (
 	"github.com/mineiros-io/terramate/hcl"
 	"github.com/mineiros-io/terramate/hcl/eval"
 	"github.com/mineiros-io/terramate/project"
-	"github.com/mineiros-io/terramate/stack"
 	"github.com/rs/zerolog/log"
 	"github.com/zclconf/go-cty/cty"
 )
@@ -48,7 +47,7 @@ const (
 //
 // Metadata for the stack is used on the evaluation of globals.
 // The rootdir MUST be an absolute path.
-func LoadStackGlobals(rootdir string, meta stack.Metadata) (Globals, error) {
+func LoadStackGlobals(rootdir string, meta Metadata) (Globals, error) {
 	logger := log.With().
 		Str("action", "LoadStackGlobals()").
 		Str("stack", meta.Path()).
@@ -108,7 +107,7 @@ func (ge *globalsExpr) has(name string) bool {
 	return ok
 }
 
-func (ge *globalsExpr) eval(meta stack.Metadata) (Globals, error) {
+func (ge *globalsExpr) eval(meta Metadata) (Globals, error) {
 	// FIXME(katcipis): get abs path for stack.
 	// This is relative only to root since meta.Path will look
 	// like: /some/path/relative/project/root
@@ -123,7 +122,7 @@ func (ge *globalsExpr) eval(meta stack.Metadata) (Globals, error) {
 
 	logger.Trace().Msg("Add proper name space for stack metadata evaluation.")
 
-	if err := evalctx.SetNamespace("terramate", stack.MetaToCtyMap(meta)); err != nil {
+	if err := evalctx.SetNamespace("terramate", MetaToCtyMap(meta)); err != nil {
 		return Globals{}, err
 	}
 

--- a/stack/globals.go
+++ b/stack/globals.go
@@ -38,7 +38,7 @@ const (
 	ErrGlobalRedefined errors.Kind = "global redefined"
 )
 
-// LoadStackGlobals loads from the file system all globals defined for
+// LoadGlobals loads from the file system all globals defined for
 // a given stack. It will navigate the file system from the stack dir until
 // it reaches rootdir, loading globals and merging them appropriately.
 //
@@ -47,7 +47,7 @@ const (
 //
 // Metadata for the stack is used on the evaluation of globals.
 // The rootdir MUST be an absolute path.
-func LoadStackGlobals(rootdir string, meta Metadata) (Globals, error) {
+func LoadGlobals(rootdir string, meta Metadata) (Globals, error) {
 	logger := log.With().
 		Str("action", "LoadStackGlobals()").
 		Str("stack", meta.Path()).

--- a/stack/globals_test.go
+++ b/stack/globals_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package terramate_test
+package stack_test
 
 import (
 	"path/filepath"
@@ -750,7 +750,7 @@ func TestLoadGlobals(t *testing.T) {
 					),
 				},
 			},
-			wantErr: errors.E(terramate.ErrGlobalEval),
+			wantErr: errors.E(stack.ErrGlobalEval),
 		},
 		{
 			name:   "global interpolating list with space fails",
@@ -764,7 +764,7 @@ func TestLoadGlobals(t *testing.T) {
 					),
 				},
 			},
-			wantErr: errors.E(terramate.ErrGlobalEval),
+			wantErr: errors.E(stack.ErrGlobalEval),
 		},
 		{
 			// This tests double check that interpolation on a single object/map
@@ -800,7 +800,7 @@ func TestLoadGlobals(t *testing.T) {
 					),
 				},
 			},
-			wantErr: errors.E(terramate.ErrGlobalEval),
+			wantErr: errors.E(stack.ErrGlobalEval),
 		},
 		{
 			name:   "global interpolating object with space fails",
@@ -814,7 +814,7 @@ func TestLoadGlobals(t *testing.T) {
 					),
 				},
 			},
-			wantErr: errors.E(terramate.ErrGlobalEval),
+			wantErr: errors.E(stack.ErrGlobalEval),
 		},
 		{
 			// This tests double check that interpolation on a single number
@@ -971,7 +971,7 @@ func TestLoadGlobals(t *testing.T) {
 					add:  globals(str("stack", "whatever")),
 				},
 			},
-			wantErr: errors.E(terramate.ErrGlobalEval),
+			wantErr: errors.E(stack.ErrGlobalEval),
 		},
 		{
 			name:   "global undefined reference on stack",
@@ -982,7 +982,7 @@ func TestLoadGlobals(t *testing.T) {
 					add:  globals(expr("field", "global.unknown")),
 				},
 			},
-			wantErr: errors.E(terramate.ErrGlobalEval),
+			wantErr: errors.E(stack.ErrGlobalEval),
 		},
 		{
 			name:   "global undefined references mixed on stack",
@@ -998,7 +998,7 @@ func TestLoadGlobals(t *testing.T) {
 					),
 				},
 			},
-			wantErr: errors.E(terramate.ErrGlobalEval),
+			wantErr: errors.E(stack.ErrGlobalEval),
 		},
 		{
 			name:   "global cyclic reference on stack",
@@ -1013,7 +1013,7 @@ func TestLoadGlobals(t *testing.T) {
 					),
 				},
 			},
-			wantErr: errors.E(terramate.ErrGlobalEval),
+			wantErr: errors.E(stack.ErrGlobalEval),
 		},
 		{
 			name:   "global cyclic references across hierarchy",
@@ -1032,7 +1032,7 @@ func TestLoadGlobals(t *testing.T) {
 					add:  globals(expr("c", "global.a")),
 				},
 			},
-			wantErr: errors.E(terramate.ErrGlobalEval),
+			wantErr: errors.E(stack.ErrGlobalEval),
 		},
 		{
 			name:   "global redefined on different file on stack",
@@ -1049,7 +1049,7 @@ func TestLoadGlobals(t *testing.T) {
 					add:      globals(str("a", "b")),
 				},
 			},
-			wantErr: errors.E(terramate.ErrGlobalRedefined),
+			wantErr: errors.E(stack.ErrGlobalRedefined),
 		},
 	}
 
@@ -1076,21 +1076,21 @@ func TestLoadGlobals(t *testing.T) {
 
 			var stacks []stack.S
 			for _, entry := range stackEntries {
-				stack := entry.Stack
-				stacks = append(stacks, stack)
+				st := entry.Stack
+				stacks = append(stacks, st)
 
-				got, err := terramate.LoadStackGlobals(s.RootDir(), stack)
+				got, err := stack.LoadStackGlobals(s.RootDir(), st)
 
 				errtest.Assert(t, err, tcase.wantErr)
 				if tcase.wantErr != nil {
 					continue
 				}
 
-				want, ok := wantGlobals[stack.Path()]
+				want, ok := wantGlobals[st.Path()]
 				if !ok {
 					want = globals()
 				}
-				delete(wantGlobals, stack.Path())
+				delete(wantGlobals, st.Path())
 
 				// Could have one type for globals configs and another type
 				// for wanted evaluated globals, but that would make
@@ -1232,7 +1232,7 @@ func TestLoadGlobalsErrors(t *testing.T) {
 					`,
 				},
 			},
-			want: errors.E(terramate.ErrGlobalRedefined),
+			want: errors.E(stack.ErrGlobalRedefined),
 		},
 		{
 			name:   "root config has global redefinition on multiple blocks",
@@ -1250,7 +1250,7 @@ func TestLoadGlobalsErrors(t *testing.T) {
 					`,
 				},
 			},
-			want: errors.E(terramate.ErrGlobalRedefined),
+			want: errors.E(stack.ErrGlobalRedefined),
 		},
 	}
 
@@ -1271,7 +1271,7 @@ func TestLoadGlobalsErrors(t *testing.T) {
 			}
 
 			for _, entry := range stackEntries {
-				_, err := terramate.LoadStackGlobals(s.RootDir(), entry.Stack)
+				_, err := stack.LoadStackGlobals(s.RootDir(), entry.Stack)
 				errtest.Assert(t, err, tcase.want)
 			}
 		})
@@ -1287,6 +1287,6 @@ func TestLoadGlobalsErrorOnRelativeDir(t *testing.T) {
 
 	stacks := s.LoadStacks()
 	assert.EqualInts(t, 1, len(stacks))
-	globals, err := terramate.LoadStackGlobals(rel, stacks[0])
+	globals, err := stack.LoadStackGlobals(rel, stacks[0])
 	assert.Error(t, err, "got %v instead of error", globals)
 }

--- a/stack/globals_test.go
+++ b/stack/globals_test.go
@@ -1079,7 +1079,7 @@ func TestLoadGlobals(t *testing.T) {
 				st := entry.Stack
 				stacks = append(stacks, st)
 
-				got, err := stack.LoadStackGlobals(s.RootDir(), st)
+				got, err := stack.LoadGlobals(s.RootDir(), st)
 
 				errtest.Assert(t, err, tcase.wantErr)
 				if tcase.wantErr != nil {
@@ -1271,7 +1271,7 @@ func TestLoadGlobalsErrors(t *testing.T) {
 			}
 
 			for _, entry := range stackEntries {
-				_, err := stack.LoadStackGlobals(s.RootDir(), entry.Stack)
+				_, err := stack.LoadGlobals(s.RootDir(), entry.Stack)
 				errtest.Assert(t, err, tcase.want)
 			}
 		})
@@ -1287,6 +1287,6 @@ func TestLoadGlobalsErrorOnRelativeDir(t *testing.T) {
 
 	stacks := s.LoadStacks()
 	assert.EqualInts(t, 1, len(stacks))
-	globals, err := stack.LoadStackGlobals(rel, stacks[0])
+	globals, err := stack.LoadGlobals(rel, stacks[0])
 	assert.Error(t, err, "got %v instead of error", globals)
 }

--- a/test/sandbox/sandbox.go
+++ b/test/sandbox/sandbox.go
@@ -248,10 +248,10 @@ func (s S) LoadStacks() []stack.S {
 
 // LoadStackGlobals loads globals for specific stack on the sandbox.
 // Fails the caller test if an error is found.
-func (s S) LoadStackGlobals(sm stack.Metadata) terramate.Globals {
+func (s S) LoadStackGlobals(sm stack.Metadata) stack.Globals {
 	s.t.Helper()
 
-	g, err := terramate.LoadStackGlobals(s.RootDir(), sm)
+	g, err := stack.LoadStackGlobals(s.RootDir(), sm)
 	assert.NoError(s.t, err)
 	return g
 }

--- a/test/sandbox/sandbox.go
+++ b/test/sandbox/sandbox.go
@@ -251,7 +251,7 @@ func (s S) LoadStacks() []stack.S {
 func (s S) LoadStackGlobals(sm stack.Metadata) stack.Globals {
 	s.t.Helper()
 
-	g, err := stack.LoadStackGlobals(s.RootDir(), sm)
+	g, err := stack.LoadGlobals(s.RootDir(), sm)
 	assert.NoError(s.t, err)
 	return g
 }


### PR DESCRIPTION
We already had issues with cyclic dependencies multiple times because globals are on the main terramate pkg. I think it makes sense for it to be on the stack, so we have stack.Metadata + stack.Globals, seems to map the domain well. We can improve things more on the future, I focused only on moving it to the package.