### PR TITLE
fix: git check for outdated main

### DIFF
--- a/cmd/terramate/e2etests/general_test.go
+++ b/cmd/terramate/e2etests/general_test.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/mineiros-io/terramate/cmd/terramate/cli"
 	"github.com/mineiros-io/terramate/test"
 	"github.com/mineiros-io/terramate/test/sandbox"
 )
@@ -299,7 +300,7 @@ func TestFailsOnChangeDetectionIfCurrentBranchIsMainAndItIsOutdated(t *testing.T
 
 	wantRes := runExpected{
 		Status:      1,
-		StderrRegex: "main branch is not reachable",
+		StderrRegex: string(cli.ErrOutdatedLocalRev),
 	}
 
 	assertRunResult(t, ts.listChangedStacks(), wantRes)


### PR DESCRIPTION
# Reason for This Change

The git check for the outdated default branch wasn't properly working but tests were passing because the Manager did them correctly.

## Description of Changes

Fixed the git.IsDefaultBranch() and project.defaultBaseRef.
