### PR TITLE
feat: add disable-check-git-remote

### DIFF
--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -267,8 +267,7 @@ func newCLI(args []string, stdin io.Reader, stdout, stderr io.Writer) *cli {
 			Msg("EvalSymlinks() failed")
 	}
 
-	logger.Trace().
-		Msg("Running in directory")
+	logger.Trace().Msg("Running in directory")
 
 	prj, foundRoot, err := lookupProject(wd)
 	if err != nil {
@@ -367,14 +366,12 @@ func (c *cli) checkGit() {
 		c.prj.baseRef = c.prj.defaultBaseRef()
 	}
 
-	if c.parsedArgs.Changed {
-		logger.Trace().Msg("Change detection is on: check git default branch was updated")
+	logger.Trace().Msg("check git default branch is updated")
 
-		if err := c.prj.checkLocalDefaultIsUpdated(); err != nil {
-			log.Fatal().
-				Err(err).
-				Msg("checking git default branch was updated.")
-		}
+	if err := c.prj.checkLocalDefaultIsUpdated(); err != nil {
+		log.Fatal().
+			Err(err).
+			Msg("checking git default branch was updated.")
 	}
 }
 
@@ -822,7 +819,9 @@ func (c *cli) runOnStacks() {
 		Str("workingDir", c.wd()).
 		Logger()
 
-	c.checkGit()
+	if !c.parsedArgs.Run.DisableCheckGitRemote {
+		c.checkGit()
+	}
 
 	if len(c.parsedArgs.Run.Command) == 0 {
 		logger.Fatal().Msgf("run expects a cmd")

--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -79,11 +79,12 @@ type cliSpec struct {
 	} `cmd:"" help:"List stacks"`
 
 	Run struct {
-		DisableCheckGenCode bool     `optional:"true" default:"false" help:"Disable outdated generated code check"`
-		ContinueOnError     bool     `default:"false" help:"Continue executing in other stacks in case of error"`
-		DryRun              bool     `default:"false" help:"Plan the execution but do not execute it"`
-		Reverse             bool     `default:"false" help:"Reverse the order of execution"`
-		Command             []string `arg:"" name:"cmd" passthrough:"" help:"Command to execute"`
+		DisableCheckGenCode   bool     `optional:"true" default:"false" help:"Disable outdated generated code check"`
+		DisableCheckGitRemote bool     `optional:"true" default:"false" help:"Disable checking if local default branch is updated with remote"`
+		ContinueOnError       bool     `default:"false" help:"Continue executing in other stacks in case of error"`
+		DryRun                bool     `default:"false" help:"Plan the execution but do not execute it"`
+		Reverse               bool     `default:"false" help:"Reverse the order of execution"`
+		Command               []string `arg:"" name:"cmd" passthrough:"" help:"Command to execute"`
 	} `cmd:"" help:"Run command in the stacks"`
 
 	Generate struct{} `cmd:"" help:"Generate terraform code for stacks"`

--- a/cmd/terramate/e2etests/general_test.go
+++ b/cmd/terramate/e2etests/general_test.go
@@ -299,6 +299,12 @@ func TestFailsOnChangeDetectionIfCurrentBranchIsMainAndItIsOutdated(t *testing.T
 	cat := test.LookPath(t, "cat")
 	assertRunResult(t, ts.run(
 		"run",
+		cat,
+		mainTfFile.Path(),
+	), wantRes)
+
+	assertRunResult(t, ts.run(
+		"run",
 		"--changed",
 		cat,
 		mainTfFile.Path(),

--- a/cmd/terramate/e2etests/general_test.go
+++ b/cmd/terramate/e2etests/general_test.go
@@ -467,7 +467,7 @@ func TestCommandsNotRequiringGitSafeguards(t *testing.T) {
 }
 
 func setupLocalMainBranchBehindOriginMain(git *sandbox.Git, changeFiles func()) {
-	// dance below makes makes local main branch behind origin/main by 1 commit.
+	// dance below makes local main branch behind origin/main by 1 commit.
 	//   - a "temp" branch is created to record current commit.
 	//   - go back to main and create 1 additional commit and push to origin/main.
 	//   - switch to "temp" and delete "main" reference.

--- a/cmd/terramate/e2etests/general_test.go
+++ b/cmd/terramate/e2etests/general_test.go
@@ -297,12 +297,6 @@ func TestFailsOnChangeDetectionIfCurrentBranchIsMainAndItIsOutdated(t *testing.T
 	assertRunResult(t, ts.listChangedStacks(), wantRes)
 
 	cat := test.LookPath(t, "cat")
-	// terramate run should also check if local default branch is updated with remote
-	assertRunResult(t, ts.run(
-		"run",
-		cat,
-		mainTfFile.Path(),
-	), wantRes)
 
 	assertRunResult(t, ts.run(
 		"run",

--- a/cmd/terramate/e2etests/general_test.go
+++ b/cmd/terramate/e2etests/general_test.go
@@ -297,6 +297,7 @@ func TestFailsOnChangeDetectionIfCurrentBranchIsMainAndItIsOutdated(t *testing.T
 	assertRunResult(t, ts.listChangedStacks(), wantRes)
 
 	cat := test.LookPath(t, "cat")
+	// terramate run should also check if local default branch is updated with remote
 	assertRunResult(t, ts.run(
 		"run",
 		cat,

--- a/cmd/terramate/e2etests/run_test.go
+++ b/cmd/terramate/e2etests/run_test.go
@@ -1201,13 +1201,11 @@ func TestRunDisableGitCheckRemote(t *testing.T) {
 	})
 
 	// Setup some changes on our outdated local main
-	stack.CreateFile("some-new-file.txt", "testing")
+	stack.CreateFile("another-new-file.txt", "testing")
 	git.Add(".")
 	git.Commit("all")
 
-	wantRes := runExpected{
-		Stdout: fileContents,
-	}
+	wantRes := runExpected{Stdout: fileContents}
 
 	cat := test.LookPath(t, "cat")
 	assertRunResult(t, ts.run(

--- a/cmd/terramate/e2etests/run_test.go
+++ b/cmd/terramate/e2etests/run_test.go
@@ -1200,20 +1200,13 @@ func TestRunDisableGitCheckRemote(t *testing.T) {
 		stack.CreateFile("some-new-file", "testing")
 	})
 
-	// Setup some changes on our outdated local main
-	stack.CreateFile("another-new-file.txt", "testing")
-	git.Add(".")
-	git.Commit("all")
-
-	wantRes := runExpected{Stdout: fileContents}
-
 	cat := test.LookPath(t, "cat")
 	assertRunResult(t, ts.run(
 		"run",
 		"--disable-check-git-remote",
 		cat,
 		someFile.Path(),
-	), wantRes)
+	), runExpected{Stdout: fileContents})
 }
 
 func TestRunFailsIfCurrentBranchIsMainAndItIsOutdated(t *testing.T) {

--- a/cmd/terramate/e2etests/run_test.go
+++ b/cmd/terramate/e2etests/run_test.go
@@ -1214,12 +1214,4 @@ func TestRunDisableGitCheckRemote(t *testing.T) {
 		cat,
 		someFile.Path(),
 	), wantRes)
-
-	assertRunResult(t, ts.run(
-		"run",
-		"--changed",
-		"--disable-check-git-remote",
-		cat,
-		someFile.Path(),
-	), wantRes)
 }


### PR DESCRIPTION
This PR also fixes `terramate run` so it always checks if the local default branch is updated with remote (even without --changed). Given that `terramate run` always checks if the remote is updated, for scenarios where that is not wanted we introduce `--disable-check-git-remote`. So in a scenario where `terramate run` is failing on the git check running `terramate run --disable-check-git-remote` will work.