### PR TITLE
fix: code generation does't ignore dotfiles

### DIFF
--- a/generate/genfile/genfile_test.go
+++ b/generate/genfile/genfile_test.go
@@ -69,6 +69,19 @@ func TestLoadGenerateFiles(t *testing.T) {
 			stack: "/stack",
 		},
 		{
+			name:  "dotfile is ignored",
+			stack: "/stack",
+			configs: []hclconfig{
+				{
+					path: "/stack/.test.tm",
+					add: generateFile(
+						labels("test"),
+						str("content", "test"),
+					),
+				},
+			},
+		},
+		{
 			name:  "empty content attribute generates empty body",
 			stack: "/stack",
 			configs: []hclconfig{

--- a/generate/genhcl/genhcl_test.go
+++ b/generate/genhcl/genhcl_test.go
@@ -71,6 +71,22 @@ func TestLoadGeneratedHCL(t *testing.T) {
 			stack: "/stack",
 		},
 		{
+			name:  "dotfile is ignored",
+			stack: "/stack",
+			configs: []hclconfig{
+				{
+					path:     "/stack",
+					filename: ".config.tm",
+					add: generateHCL(
+						labels("config"),
+						content(
+							block("empty"),
+						),
+					),
+				},
+			},
+		},
+		{
 			name:  "empty content block generates empty code",
 			stack: "/stack",
 			configs: []hclconfig{

--- a/hcl/hcl.go
+++ b/hcl/hcl.go
@@ -136,46 +136,27 @@ func (p *TerramateParser) addDir(dir string) error {
 		Str("dir", dir).
 		Logger()
 
-	dirEntries, err := os.ReadDir(dir)
+	tmFiles, err := listTerramateFiles(dir)
 	if err != nil {
 		return errors.E(err, "adding directory to terramate parser")
 	}
 
-	logger.Trace().Msg("looking for Terramate files")
+	for _, filename := range tmFiles {
+		path := filepath.Join(dir, filename)
+		logger.Trace().
+			Str("file", path).
+			Msg("Reading config file.")
 
-	for _, dirEntry := range dirEntries {
-		logger := logger.With().
-			Str("entryName", dirEntry.Name()).
-			Logger()
-
-		if dirEntry.IsDir() {
-			logger.Trace().Msg("ignoring dir")
-			continue
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return errors.E(err, "reading config file %q", path)
 		}
 
-		filename := dirEntry.Name()
-		if strings.HasPrefix(filename, ".") {
-			logger.Trace().Msg("ignoring dotfile")
-			continue
+		if err := p.AddFile(path, data); err != nil {
+			return err
 		}
-		if isTerramateFile(filename) {
-			path := filepath.Join(dir, filename)
 
-			logger.Trace().
-				Str("file", path).
-				Msg("Reading config file.")
-
-			data, err := os.ReadFile(path)
-			if err != nil {
-				return errors.E(err, "reading config file %q", path)
-			}
-
-			if err := p.AddFile(path, data); err != nil {
-				return err
-			}
-
-			logger.Trace().Msg("file added")
-		}
+		logger.Trace().Msg("file added")
 	}
 
 	return nil
@@ -1112,6 +1093,48 @@ func parseBlocks(dir, blocktype string, validate blockValidator) (Blocks, error)
 func (m Module) IsLocal() bool {
 	// As specified here: https://www.terraform.io/docs/language/modules/sources.html#local-paths
 	return m.Source[0:2] == "./" || m.Source[0:3] == "../"
+}
+
+func listTerramateFiles(dir string) ([]string, error) {
+	logger := log.With().
+		Str("action", "listTerramateFiles()").
+		Str("dir", dir).
+		Logger()
+
+	logger.Trace().Msg("listing files")
+
+	dirEntries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, errors.E(err, "reading dir to list Terramate files")
+	}
+
+	logger.Trace().Msg("looking for Terramate files")
+
+	files := []string{}
+
+	for _, dirEntry := range dirEntries {
+		logger := logger.With().
+			Str("entryName", dirEntry.Name()).
+			Logger()
+
+		if strings.HasPrefix(dirEntry.Name(), ".") {
+			logger.Trace().Msg("ignoring dotfile")
+			continue
+		}
+
+		if dirEntry.IsDir() {
+			logger.Trace().Msg("ignoring dir")
+			continue
+		}
+
+		filename := dirEntry.Name()
+		if isTerramateFile(filename) {
+			logger.Trace().Msg("Found Terramate file")
+			files = append(files, filename)
+		}
+	}
+
+	return files, nil
 }
 
 func isTerramateFile(filename string) bool {

--- a/hcl/hcl.go
+++ b/hcl/hcl.go
@@ -158,7 +158,7 @@ func (p *TerramateParser) addDir(dir string) error {
 			logger.Trace().Msg("ignoring dotfile")
 			continue
 		}
-		if strings.HasSuffix(filename, ".tm") || strings.HasSuffix(filename, ".tm.hcl") {
+		if isTerramateFile(filename) {
 			path := filepath.Join(dir, filename)
 
 			logger.Trace().
@@ -857,7 +857,7 @@ func loadCfgBlocks(dir string) (*hclparse.Parser, error) {
 		}
 
 		filename := dirEntry.Name()
-		if strings.HasSuffix(filename, ".tm") || strings.HasSuffix(filename, ".tm.hcl") {
+		if isTerramateFile(filename) {
 			path := filepath.Join(dir, filename)
 
 			logger.Trace().Msg("Reading config file.")
@@ -1112,4 +1112,8 @@ func parseBlocks(dir, blocktype string, validate blockValidator) (Blocks, error)
 func (m Module) IsLocal() bool {
 	// As specified here: https://www.terraform.io/docs/language/modules/sources.html#local-paths
 	return m.Source[0:2] == "./" || m.Source[0:3] == "../"
+}
+
+func isTerramateFile(filename string) bool {
+	return strings.HasSuffix(filename, ".tm") || strings.HasSuffix(filename, ".tm.hcl")
 }


### PR DESCRIPTION
Currently code generation will read dotfiles, but those should be ignored.
