### PR TITLE
fix: errors.AssertIsErrors should check if no err is wanted

### DIFF
--- a/test/errors/errors.go
+++ b/test/errors/errors.go
@@ -66,6 +66,10 @@ func Assert(t *testing.T, err, target error) {
 func AssertIsErrors(t *testing.T, err error, targets []error) {
 	t.Helper()
 
+	if err != nil && len(targets) == 0 {
+		t.Fatalf("wanted no errors but got: %v", err)
+	}
+
 	for _, target := range targets {
 		Assert(t, err, target)
 	}


### PR DESCRIPTION
Currently when we call `errors.AssertIsErrors(err, nil)` if the err is not nil it will pass, which is wrong since passing nil/empty target error list indicates that you want no errors at all (just as passing nil on errors.Is() also fails unless err is also nil). 
