### PR TITLE
Add homebrew installation to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,12 @@ or you can just install the **latest** release:
 go install github.com/mineiros-io/terramate/cmd/terramate@latest
 ```
 
+#### Using a package manager
+
+- macOS: You can install Terramate on macOS using
+  [Homebrew](https://formulae.brew.sh/formula/terramate): `brew install terramate`
+
+
 #### Using Release Binaries
 
 To install Terramate using a release binary, find the


### PR DESCRIPTION
Adds instructions on how to install Terramate via Homebrew to the README.