### PR TITLE
refactor: isolate evaluation context better

### DIFF
--- a/generate/genhcl/genhcl.go
+++ b/generate/genhcl/genhcl.go
@@ -138,7 +138,7 @@ func Load(rootdir string, sm stack.Metadata, globals stack.Globals) (StackHCLs, 
 		logger.Trace().Msg("evaluating block.")
 
 		gen := hclwrite.NewEmptyFile()
-		if err := hcl.CopyBody(gen.Body(), loadedHCL.block.Body, evalctx); err != nil {
+		if err := hcl.CopyBody(gen.Body(), loadedHCL.block.Body, evalctx.PartialEval); err != nil {
 			return StackHCLs{}, errors.E(ErrEval, sm, err,
 				"failed to generate block %q", name,
 			)

--- a/hcl/eval/eval.go
+++ b/hcl/eval/eval.go
@@ -53,11 +53,6 @@ func NewContext(basedir string) *Context {
 	}
 }
 
-// GetHCLContext gets the evaluation context.
-func (c *Context) GetHCLContext() *hhcl.EvalContext {
-	return c.hclctx
-}
-
 // SetNamespace will set the given values inside the given namespace on the
 // evaluation context.
 func (c *Context) SetNamespace(name string, vals map[string]cty.Value) error {

--- a/stack/eval.go
+++ b/stack/eval.go
@@ -15,35 +15,61 @@
 package stack
 
 import (
+	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/mineiros-io/terramate/errors"
 	"github.com/mineiros-io/terramate/hcl/eval"
 	"github.com/rs/zerolog/log"
 	"github.com/zclconf/go-cty/cty"
 )
 
-// NewEvalCtx creates a new evaluation context for a stack
-func NewEvalCtx(stackpath string, sm Metadata, globals Globals) (*eval.Context, error) {
+// EvalCtx represents the evaluation context of a stack.
+type EvalCtx struct {
+	evalctx *eval.Context
+}
+
+// NewEvalCtx creates a new stack evaluation context.
+func NewEvalCtx(stackpath string, sm Metadata, globals Globals) (*EvalCtx, error) {
 	logger := log.With().
 		Str("action", "stack.NewEvalCtx()").
 		Str("path", stackpath).
 		Logger()
 
-	evalctx := eval.NewContext(stackpath)
+	evalctx := &EvalCtx{evalctx: eval.NewContext(stackpath)}
 
 	logger.Trace().Msg("Add stack metadata evaluation namespace.")
 
-	err := evalctx.SetNamespace("terramate", metaToCtyMap(sm))
+	err := evalctx.SetMetadata(sm)
 	if err != nil {
 		return nil, errors.E(sm, err, "setting terramate namespace on eval context")
 	}
 
 	logger.Trace().Msg("Add global evaluation namespace.")
 
-	if err := evalctx.SetNamespace("global", globals.Attributes()); err != nil {
-		return nil, errors.E(sm, err, "setting global namespace on eval context")
+	if err := evalctx.SetGlobals(globals); err != nil {
+		return nil, err
 	}
 
 	return evalctx, nil
+}
+
+// SetGlobals sets the given globals on the stack evaluation context.
+func (e *EvalCtx) SetGlobals(g Globals) error {
+	return e.evalctx.SetNamespace("global", g.Attributes())
+}
+
+// SetMetadata sets the given metadata on the stack evaluation context.
+func (e *EvalCtx) SetMetadata(sm Metadata) error {
+	return e.evalctx.SetNamespace("terramate", metaToCtyMap(sm))
+}
+
+// Eval will evaluate an expression given its context.
+func (e *EvalCtx) Eval(expr hclsyntax.Expression) (cty.Value, error) {
+	return e.evalctx.Eval(expr)
+}
+
+// HasNamespace returns true the evaluation context knows this namespace, false otherwise.
+func (e *EvalCtx) HasNamespace(name string) bool {
+	return e.evalctx.HasNamespace(name)
 }
 
 func metaToCtyMap(m Metadata) map[string]cty.Value {

--- a/stack/eval.go
+++ b/stack/eval.go
@@ -16,6 +16,7 @@ package stack
 
 import (
 	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/mineiros-io/terramate/errors"
 	"github.com/mineiros-io/terramate/hcl/eval"
 	"github.com/rs/zerolog/log"
@@ -65,6 +66,11 @@ func (e *EvalCtx) SetMetadata(sm Metadata) error {
 // Eval will evaluate an expression given its context.
 func (e *EvalCtx) Eval(expr hclsyntax.Expression) (cty.Value, error) {
 	return e.evalctx.Eval(expr)
+}
+
+// PartialEval will partially evaluate an expression given its context.
+func (e *EvalCtx) PartialEval(expr hclsyntax.Expression) (hclwrite.Tokens, error) {
+	return e.evalctx.PartialEval(expr)
 }
 
 // HasNamespace returns true the evaluation context knows this namespace, false otherwise.

--- a/stack/globals.go
+++ b/stack/globals.go
@@ -131,8 +131,6 @@ func (ge *globalsExpr) eval(rootdir string, meta Metadata) (Globals, error) {
 	pendingExprsErrs := map[string]error{}
 	pendingExprs := ge.expressions
 
-	hclctx := evalctx.GetHCLContext()
-
 	for len(pendingExprs) > 0 {
 		amountEvaluated := 0
 
@@ -145,7 +143,7 @@ func (ge *globalsExpr) eval(rootdir string, meta Metadata) (Globals, error) {
 			logger.Trace().Msg("Range vars.")
 
 			for _, namespace := range vars {
-				if _, ok := hclctx.Variables[namespace.RootName()]; !ok {
+				if !evalctx.HasNamespace(namespace.RootName()) {
 					return Globals{}, errors.E(
 						ErrGlobalEval,
 						namespace.SourceRange(),
@@ -173,9 +171,7 @@ func (ge *globalsExpr) eval(rootdir string, meta Metadata) (Globals, error) {
 						)
 					}
 				default:
-					return Globals{}, errors.E(attr.SourceRange(),
-						"unexpected type of traversal - this is a BUG",
-					)
+					panic("unexpected type of traversal - this is a BUG")
 				}
 			}
 
@@ -197,7 +193,7 @@ func (ge *globalsExpr) eval(rootdir string, meta Metadata) (Globals, error) {
 
 			logger.Trace().Msg("Try add proper namespace for globals evaluation context.")
 
-			if err := evalctx.SetNamespace("global", globals.Attributes()); err != nil {
+			if err := evalctx.SetGlobals(globals); err != nil {
 				return Globals{}, errors.E(err, "evaluating globals")
 			}
 		}


### PR DESCRIPTION
Thinking on ways to isolate further the evaluation context so we can easily change the metadata definition in a single place and be confident that there will be no inconsistencies (like some part of the code manipulating the lower level eval ctx directly). The idea is to do it all through the stack.EvalCtx everywhere, since evaluation so far is always done regarding a stack anyway. The only one using more low level hcl eval contexts will be the stack.EvalCtx itself.

Also worked on isolating as much as possible decisions like "what is the name of the namespaces". Im not entirely sure this is a good idea, prone to just dropping it if it is stupid or if we have a better idea :-).