### PR TITLE
feat: move stack metadata related to terramate.stack

### DIFF
--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -816,9 +816,9 @@ func (c *cli) printMetadata() {
 			Msg("Print metadata for individual stack.")
 
 		c.log("\nstack %q:", stackMeta.Path())
-		c.log("\tterramate.name=%q", stackMeta.Name())
-		c.log("\tterramate.path=%q", stackMeta.Path())
-		c.log("\tterramate.description=%q", stackMeta.Desc())
+		c.log("\tterramate.stack.name=%q", stackMeta.Name())
+		c.log("\tterramate.stack.description=%q", stackMeta.Desc())
+		c.log("\tterramate.stack.path.absolute=%q", stackMeta.Path())
 	}
 }
 

--- a/cmd/terramate/e2etests/exp_metadata_test.go
+++ b/cmd/terramate/e2etests/exp_metadata_test.go
@@ -42,9 +42,9 @@ func TestCliMetadata(t *testing.T) {
 				Stdout: `Available metadata:
 
 stack "/stack":
-	terramate.name="stack"
-	terramate.path="/stack"
-	terramate.description=""
+	terramate.stack.name="stack"
+	terramate.stack.path.absolute="/stack"
+	terramate.stack.description=""
 `,
 			},
 		},
@@ -60,24 +60,24 @@ stack "/stack":
 				Stdout: `Available metadata:
 
 stack "/somedir/stack3":
-	terramate.name="stack3"
-	terramate.path="/somedir/stack3"
-	terramate.description=""
+	terramate.stack.name="stack3"
+	terramate.stack.path.absolute="/somedir/stack3"
+	terramate.stack.description=""
 
 stack "/somedir/stack4":
-	terramate.name="stack4"
-	terramate.path="/somedir/stack4"
-	terramate.description=""
+	terramate.stack.name="stack4"
+	terramate.stack.path.absolute="/somedir/stack4"
+	terramate.stack.description=""
 
 stack "/stack1":
-	terramate.name="stack1"
-	terramate.path="/stack1"
-	terramate.description=""
+	terramate.stack.name="stack1"
+	terramate.stack.path.absolute="/stack1"
+	terramate.stack.description=""
 
 stack "/stack2":
-	terramate.name="stack2"
-	terramate.path="/stack2"
-	terramate.description=""
+	terramate.stack.name="stack2"
+	terramate.stack.path.absolute="/stack2"
+	terramate.stack.description=""
 `,
 			},
 		},
@@ -94,9 +94,9 @@ stack "/stack2":
 				Stdout: `Available metadata:
 
 stack "/stack1":
-	terramate.name="stack1"
-	terramate.path="/stack1"
-	terramate.description=""
+	terramate.stack.name="stack1"
+	terramate.stack.path.absolute="/stack1"
+	terramate.stack.description=""
 `,
 			},
 		},
@@ -113,14 +113,14 @@ stack "/stack1":
 				Stdout: `Available metadata:
 
 stack "/somedir/stack3":
-	terramate.name="stack3"
-	terramate.path="/somedir/stack3"
-	terramate.description=""
+	terramate.stack.name="stack3"
+	terramate.stack.path.absolute="/somedir/stack3"
+	terramate.stack.description=""
 
 stack "/somedir/stack4":
-	terramate.name="stack4"
-	terramate.path="/somedir/stack4"
-	terramate.description=""
+	terramate.stack.name="stack4"
+	terramate.stack.path.absolute="/somedir/stack4"
+	terramate.stack.description=""
 `,
 			},
 		},

--- a/cmd/terramate/e2etests/exp_metadata_test.go
+++ b/cmd/terramate/e2etests/exp_metadata_test.go
@@ -43,8 +43,8 @@ func TestCliMetadata(t *testing.T) {
 
 stack "/stack":
 	terramate.stack.name="stack"
-	terramate.stack.path.absolute="/stack"
 	terramate.stack.description=""
+	terramate.stack.path.absolute="/stack"
 `,
 			},
 		},
@@ -61,23 +61,23 @@ stack "/stack":
 
 stack "/somedir/stack3":
 	terramate.stack.name="stack3"
-	terramate.stack.path.absolute="/somedir/stack3"
 	terramate.stack.description=""
+	terramate.stack.path.absolute="/somedir/stack3"
 
 stack "/somedir/stack4":
 	terramate.stack.name="stack4"
-	terramate.stack.path.absolute="/somedir/stack4"
 	terramate.stack.description=""
+	terramate.stack.path.absolute="/somedir/stack4"
 
 stack "/stack1":
 	terramate.stack.name="stack1"
-	terramate.stack.path.absolute="/stack1"
 	terramate.stack.description=""
+	terramate.stack.path.absolute="/stack1"
 
 stack "/stack2":
 	terramate.stack.name="stack2"
-	terramate.stack.path.absolute="/stack2"
 	terramate.stack.description=""
+	terramate.stack.path.absolute="/stack2"
 `,
 			},
 		},
@@ -95,8 +95,8 @@ stack "/stack2":
 
 stack "/stack1":
 	terramate.stack.name="stack1"
-	terramate.stack.path.absolute="/stack1"
 	terramate.stack.description=""
+	terramate.stack.path.absolute="/stack1"
 `,
 			},
 		},
@@ -114,13 +114,13 @@ stack "/stack1":
 
 stack "/somedir/stack3":
 	terramate.stack.name="stack3"
-	terramate.stack.path.absolute="/somedir/stack3"
 	terramate.stack.description=""
+	terramate.stack.path.absolute="/somedir/stack3"
 
 stack "/somedir/stack4":
 	terramate.stack.name="stack4"
-	terramate.stack.path.absolute="/somedir/stack4"
 	terramate.stack.description=""
+	terramate.stack.path.absolute="/somedir/stack4"
 `,
 			},
 		},

--- a/docs/sharing-data.md
+++ b/docs/sharing-data.md
@@ -42,7 +42,7 @@ globals {
 }
 ```
 
-Globals can reference [metadata](metadata.md):
+Globals can reference [metadata](#metadata):
 
 ```hcl
 globals {

--- a/docs/sharing-data.md
+++ b/docs/sharing-data.md
@@ -243,7 +243,7 @@ accessed through the variable namespace **terramate**.
 This can be referenced from any Terramate code to reference
 information like the path of the stack or its name.
 
-## terramate.stack.path (string) 
+## terramate.stack.path.absolute (string) 
 
 The absolute path of the stack relative to the project
 root directory, not the host root directory. So it is absolute
@@ -295,7 +295,7 @@ process of deprecation.
 
 ### terramate.path (string) 
 
-Superseded by terramate.stack.path.
+Superseded by terramate.stack.path.absolute.
 
 ### terramate.name (string) 
 

--- a/docs/sharing-data.md
+++ b/docs/sharing-data.md
@@ -243,7 +243,7 @@ accessed through the variable namespace **terramate**.
 This can be referenced from any Terramate code to reference
 information like the path of the stack or its name.
 
-## terramate.path (string) 
+## terramate.stack.path (string) 
 
 The absolute path of the stack relative to the project
 root directory, not the host root directory. So it is absolute
@@ -261,7 +261,7 @@ Given this project layout:
 * terramate.path for **stack-a** = /stacks/stack-a
 * terramate.path for **stack-b** = /stacks/stack-b
 
-## terramate.name (string) 
+## terramate.stack.name (string) 
 
 The name of the stack.
 
@@ -280,10 +280,27 @@ Given this stack layout (from the root of the project):
 Please consider [stack configuration](stack.md) to see how
 you can change the default stack name.
 
-## terramate.description (string) 
+## terramate.stack.description (string) 
 
 The description of the stack, if it has any.
 The default value is an empty string.
 
 Please consider [stack configuration](stack.md) to see how
 you can change the default stack description.
+
+## Deprecated
+
+Here is a list of older metadata that still can be used but are in the
+process of deprecation.
+
+### terramate.path (string) 
+
+Superseded by terramate.stack.path.
+
+### terramate.name (string) 
+
+Superseded by terramate.stack.name.
+
+### terramate.description (string) 
+
+Superseded by terramate.stack.description.

--- a/docs/sharing-data.md
+++ b/docs/sharing-data.md
@@ -258,8 +258,8 @@ Given this project layout:
     └── stack-b
 ```
 
-* terramate.path for **stack-a** = /stacks/stack-a
-* terramate.path for **stack-b** = /stacks/stack-b
+* **stack-a** = /stacks/stack-a
+* **stack-b** = /stacks/stack-b
 
 ## terramate.stack.name (string) 
 
@@ -274,8 +274,8 @@ Given this stack layout (from the root of the project):
     └── stack-b
 ```
 
-* terramate.name for **stack-a** = stack-a
-* terramate.name for **stack-b** = stack-b
+* **stack-a** = stack-a
+* **stack-b** = stack-b
 
 Please consider [stack configuration](stack.md) to see how
 you can change the default stack name.

--- a/generate/genfile/genfile_test.go
+++ b/generate/genfile/genfile_test.go
@@ -133,6 +133,29 @@ func TestLoadGenerateFiles(t *testing.T) {
 			},
 		},
 		{
+			name:  "all metadata available",
+			stack: "/stack",
+			configs: []hclconfig{
+				{
+					path: "/stack/test.tm",
+					add: generateFile(
+						labels("test"),
+						str("content", "${terramate.stack.path}-${terramate.stack.name}-${terramate.stack.description}"),
+					),
+				},
+			},
+			want: []result{
+				{
+					name:      "test",
+					condition: true,
+					file: genFile{
+						origin: "/stack/test.tm",
+						body:   "/stack-stack-",
+					},
+				},
+			},
+		},
+		{
 			name:  "using globals and metadata with interpolation",
 			stack: "/stack",
 			configs: []hclconfig{
@@ -146,7 +169,7 @@ func TestLoadGenerateFiles(t *testing.T) {
 					path: "/stack/test.tm",
 					add: generateFile(
 						labels("test"),
-						str("content", "${global.data}-${terramate.path}"),
+						str("content", "${global.data}-${terramate.stack.path}"),
 					),
 				},
 			},
@@ -384,7 +407,7 @@ func TestLoadGenerateFiles(t *testing.T) {
 					path: "/stack/yaml.tm",
 					add: generateFile(
 						labels("test.yml"),
-						expr("content", "tm_yamlencode({field = terramate.path})"),
+						expr("content", "tm_yamlencode({field = terramate.stack.path})"),
 					),
 				},
 			},

--- a/generate/genfile/genfile_test.go
+++ b/generate/genfile/genfile_test.go
@@ -140,7 +140,7 @@ func TestLoadGenerateFiles(t *testing.T) {
 					path: "/stack/test.tm",
 					add: generateFile(
 						labels("test"),
-						str("content", "${terramate.stack.path}-${terramate.stack.name}-${terramate.stack.description}"),
+						str("content", "${terramate.stack.path.absolute}-${terramate.stack.name}-${terramate.stack.description}"),
 					),
 				},
 			},
@@ -169,7 +169,7 @@ func TestLoadGenerateFiles(t *testing.T) {
 					path: "/stack/test.tm",
 					add: generateFile(
 						labels("test"),
-						str("content", "${global.data}-${terramate.stack.path}"),
+						str("content", "${global.data}-${terramate.stack.path.absolute}"),
 					),
 				},
 			},
@@ -407,7 +407,7 @@ func TestLoadGenerateFiles(t *testing.T) {
 					path: "/stack/yaml.tm",
 					add: generateFile(
 						labels("test.yml"),
-						expr("content", "tm_yamlencode({field = terramate.stack.path})"),
+						expr("content", "tm_yamlencode({field = terramate.stack.path.absolute})"),
 					),
 				},
 			},

--- a/generate/genhcl/genhcl_test.go
+++ b/generate/genhcl/genhcl_test.go
@@ -859,9 +859,9 @@ func TestLoadGeneratedHCL(t *testing.T) {
 					add: generateHCL(
 						labels("root"),
 						content(
-							expr("terramate.stack.path.absolute", "terramate.stack.path.absolute"),
-							expr("terramate_stack_name", "terramate.stack.name"),
-							expr("terramate_stack_description", "terramate.stack.description"),
+							expr("stack_path_absolute", "terramate.stack.path.absolute"),
+							expr("stack_name", "terramate.stack.name"),
+							expr("stack_description", "terramate.stack.description"),
 						),
 					),
 				},
@@ -873,9 +873,9 @@ func TestLoadGeneratedHCL(t *testing.T) {
 						origin:    defaultCfg("/"),
 						condition: true,
 						body: hcldoc(
-							str("terramate.stack.path.absolute", "/stacks/stack"),
-							str("terramate_stack_name", "stack"),
-							str("terramate_stack_description", ""),
+							str("stack_path_absolute", "/stacks/stack"),
+							str("stack_name", "stack"),
+							str("stack_description", ""),
 						),
 					},
 				},

--- a/generate/genhcl/genhcl_test.go
+++ b/generate/genhcl/genhcl_test.go
@@ -851,6 +851,37 @@ func TestLoadGeneratedHCL(t *testing.T) {
 			},
 		},
 		{
+			name:  "all metadata available",
+			stack: "/stacks/stack",
+			configs: []hclconfig{
+				{
+					path: "/",
+					add: generateHCL(
+						labels("root"),
+						content(
+							expr("terramate_stack_path", "terramate.stack.path"),
+							expr("terramate_stack_name", "terramate.stack.name"),
+							expr("terramate_stack_description", "terramate.stack.description"),
+						),
+					),
+				},
+			},
+			want: []result{
+				{
+					name: "root",
+					hcl: genHCL{
+						origin:    defaultCfg("/"),
+						condition: true,
+						body: hcldoc(
+							str("terramate_stack_path", "/stacks/stack"),
+							str("terramate_stack_name", "stack"),
+							str("terramate_stack_description", ""),
+						),
+					},
+				},
+			},
+		},
+		{
 			name:  "generate HCL on project root dir",
 			stack: "/stacks/stack",
 			configs: []hclconfig{
@@ -860,7 +891,7 @@ func TestLoadGeneratedHCL(t *testing.T) {
 						labels("root"),
 						content(
 							block("root",
-								expr("test", "terramate.path"),
+								expr("test", "terramate.stack.path"),
 							),
 						),
 					),
@@ -2443,7 +2474,7 @@ func TestPartialEval(t *testing.T) {
 		{
 			name: "terramate.path interpolation",
 			config: hcldoc(
-				str("string", `${terramate.path} test`),
+				str("string", `${terramate.stack.path} test`),
 			),
 			want: hcldoc(
 				str("string", `/stack test`),

--- a/generate/genhcl/genhcl_test.go
+++ b/generate/genhcl/genhcl_test.go
@@ -873,9 +873,9 @@ func TestLoadGeneratedHCL(t *testing.T) {
 						origin:    defaultCfg("/"),
 						condition: true,
 						body: hcldoc(
-							str("stack_path_absolute", "/stacks/stack"),
-							str("stack_name", "stack"),
 							str("stack_description", ""),
+							str("stack_name", "stack"),
+							str("stack_path_absolute", "/stacks/stack"),
 						),
 					},
 				},

--- a/generate/genhcl/genhcl_test.go
+++ b/generate/genhcl/genhcl_test.go
@@ -859,7 +859,7 @@ func TestLoadGeneratedHCL(t *testing.T) {
 					add: generateHCL(
 						labels("root"),
 						content(
-							expr("terramate_stack_path", "terramate.stack.path"),
+							expr("terramate.stack.path.absolute", "terramate.stack.path.absolute"),
 							expr("terramate_stack_name", "terramate.stack.name"),
 							expr("terramate_stack_description", "terramate.stack.description"),
 						),
@@ -873,7 +873,7 @@ func TestLoadGeneratedHCL(t *testing.T) {
 						origin:    defaultCfg("/"),
 						condition: true,
 						body: hcldoc(
-							str("terramate_stack_path", "/stacks/stack"),
+							str("terramate.stack.path.absolute", "/stacks/stack"),
 							str("terramate_stack_name", "stack"),
 							str("terramate_stack_description", ""),
 						),
@@ -891,7 +891,7 @@ func TestLoadGeneratedHCL(t *testing.T) {
 						labels("root"),
 						content(
 							block("root",
-								expr("test", "terramate.stack.path"),
+								expr("test", "terramate.stack.path.absolute"),
 							),
 						),
 					),
@@ -2474,7 +2474,7 @@ func TestPartialEval(t *testing.T) {
 		{
 			name: "terramate.path interpolation",
 			config: hcldoc(
-				str("string", `${terramate.stack.path} test`),
+				str("string", `${terramate.stack.path.absolute} test`),
 			),
 			want: hcldoc(
 				str("string", `/stack test`),

--- a/stack/globals_test.go
+++ b/stack/globals_test.go
@@ -255,7 +255,7 @@ func TestLoadGlobals(t *testing.T) {
 				{
 					path: "/stacks/stack-1",
 					add: globals(
-						expr("stack_path", "terramate.stack.path"),
+						expr("stack_path", "terramate.stack.path.absolute"),
 						expr("stack_name", "terramate.stack.name"),
 						expr("stack_description", "terramate.stack.description"),
 					),
@@ -263,7 +263,7 @@ func TestLoadGlobals(t *testing.T) {
 				{
 					path: "/stacks/stack-2",
 					add: globals(
-						expr("stack_path", "terramate.stack.path"),
+						expr("stack_path", "terramate.stack.path.absolute"),
 						expr("stack_name", "terramate.stack.name"),
 						expr("stack_description", "terramate.stack.description"),
 					),
@@ -292,13 +292,13 @@ func TestLoadGlobals(t *testing.T) {
 				{
 					path: "/stacks/stack-1",
 					add: globals(
-						expr("interpolated", `"prefix-${tm_replace(terramate.stack.path, "/", "@")}-suffix"`),
+						expr("interpolated", `"prefix-${tm_replace(terramate.stack.path.absolute, "/", "@")}-suffix"`),
 					),
 				},
 				{
 					path: "/stacks/stack-2",
 					add: globals(
-						expr("stack_path", `tm_replace(terramate.stack.path, "/", "-")`),
+						expr("stack_path", `tm_replace(terramate.stack.path.absolute, "/", "-")`),
 					),
 				},
 			},
@@ -317,7 +317,7 @@ func TestLoadGlobals(t *testing.T) {
 					path: "/stack",
 					add: globals(
 						str("field", "some-string"),
-						expr("stack_path", "terramate.stack.path"),
+						expr("stack_path", "terramate.stack.path.absolute"),
 						expr("ref_field", "global.field"),
 						expr("ref_stack_path", "global.stack_path"),
 						expr("interpolation", `"${global.ref_stack_path}-${global.ref_field}"`),
@@ -345,7 +345,7 @@ func TestLoadGlobals(t *testing.T) {
 					filename: "globals_1.tm.hcl",
 					add: globals(
 						str("field", "some-string"),
-						expr("stack_path", "terramate.stack.path"),
+						expr("stack_path", "terramate.stack.path.absolute"),
 					),
 				},
 				{
@@ -388,7 +388,7 @@ func TestLoadGlobals(t *testing.T) {
 					filename: "globals_1.tm.hcl",
 					add: globals(
 						str("field", "some-string"),
-						expr("stack_path", "terramate.stack.path"),
+						expr("stack_path", "terramate.stack.path.absolute"),
 					),
 				},
 				{
@@ -443,7 +443,7 @@ func TestLoadGlobals(t *testing.T) {
 				{
 					path: "/envs",
 					add: globals(
-						expr("env_metadata", "terramate.stack.path"),
+						expr("env_metadata", "terramate.stack.path.absolute"),
 						expr("env_root_ref", "global.root_field"),
 					),
 				},

--- a/stack/globals_test.go
+++ b/stack/globals_test.go
@@ -246,7 +246,7 @@ func TestLoadGlobals(t *testing.T) {
 			},
 		},
 		{
-			name: "stacks referencing metadata",
+			name: "stacks referencing all metadata",
 			layout: []string{
 				"s:stacks/stack-1",
 				"s:stacks/stack-2:description=someDescriptionStack2",
@@ -255,27 +255,29 @@ func TestLoadGlobals(t *testing.T) {
 				{
 					path: "/stacks/stack-1",
 					add: globals(
-						expr("stack_path", "terramate.path"),
-						expr("interpolated", `"prefix-${terramate.name}-suffix"`),
-						expr("stack_description", "terramate.description"),
+						expr("stack_path", "terramate.stack.path"),
+						expr("stack_name", "terramate.stack.name"),
+						expr("stack_description", "terramate.stack.description"),
 					),
 				},
 				{
 					path: "/stacks/stack-2",
 					add: globals(
-						expr("stack_path", "terramate.path"),
-						expr("stack_description", "terramate.description"),
+						expr("stack_path", "terramate.stack.path"),
+						expr("stack_name", "terramate.stack.name"),
+						expr("stack_description", "terramate.stack.description"),
 					),
 				},
 			},
 			want: map[string]*hclwrite.Block{
 				"/stacks/stack-1": globals(
 					str("stack_path", "/stacks/stack-1"),
-					str("interpolated", "prefix-stack-1-suffix"),
+					str("stack_name", "stack-1"),
 					str("stack_description", ""),
 				),
 				"/stacks/stack-2": globals(
 					str("stack_path", "/stacks/stack-2"),
+					str("stack_name", "stack-2"),
 					str("stack_description", "someDescriptionStack2"),
 				),
 			},
@@ -290,13 +292,13 @@ func TestLoadGlobals(t *testing.T) {
 				{
 					path: "/stacks/stack-1",
 					add: globals(
-						expr("interpolated", `"prefix-${tm_replace(terramate.path, "/", "@")}-suffix"`),
+						expr("interpolated", `"prefix-${tm_replace(terramate.stack.path, "/", "@")}-suffix"`),
 					),
 				},
 				{
 					path: "/stacks/stack-2",
 					add: globals(
-						expr("stack_path", `tm_replace(terramate.path, "/", "-")`),
+						expr("stack_path", `tm_replace(terramate.stack.path, "/", "-")`),
 					),
 				},
 			},
@@ -315,7 +317,7 @@ func TestLoadGlobals(t *testing.T) {
 					path: "/stack",
 					add: globals(
 						str("field", "some-string"),
-						expr("stack_path", "terramate.path"),
+						expr("stack_path", "terramate.stack.path"),
 						expr("ref_field", "global.field"),
 						expr("ref_stack_path", "global.stack_path"),
 						expr("interpolation", `"${global.ref_stack_path}-${global.ref_field}"`),
@@ -343,7 +345,7 @@ func TestLoadGlobals(t *testing.T) {
 					filename: "globals_1.tm.hcl",
 					add: globals(
 						str("field", "some-string"),
-						expr("stack_path", "terramate.path"),
+						expr("stack_path", "terramate.stack.path"),
 					),
 				},
 				{
@@ -386,7 +388,7 @@ func TestLoadGlobals(t *testing.T) {
 					filename: "globals_1.tm.hcl",
 					add: globals(
 						str("field", "some-string"),
-						expr("stack_path", "terramate.path"),
+						expr("stack_path", "terramate.stack.path"),
 					),
 				},
 				{
@@ -441,7 +443,7 @@ func TestLoadGlobals(t *testing.T) {
 				{
 					path: "/envs",
 					add: globals(
-						expr("env_metadata", "terramate.path"),
+						expr("env_metadata", "terramate.stack.path"),
 						expr("env_root_ref", "global.root_field"),
 					),
 				},
@@ -452,7 +454,7 @@ func TestLoadGlobals(t *testing.T) {
 				{
 					path: "/envs/prod/stacks",
 					add: globals(
-						expr("stacks_field", `"${terramate.name}-${global.env}"`),
+						expr("stacks_field", `"${terramate.stack.name}-${global.env}"`),
 					),
 				},
 				{


### PR DESCRIPTION
Moving stack metadata to "terramate.stack". The old metadata is being kept for now to avoid breaking anything. New metadata:

* terramate.name -> terramate.stack.name
* terramate.description -> terramate.stack.description
* terramate.path -> terramate.stack.path.absolute

New metadata will be added on a future PR.