### PR TITLE
chore: add initial spec for terramate.config.run.env

### DIFF
--- a/docs/orchestration.md
+++ b/docs/orchestration.md
@@ -282,7 +282,7 @@ Even though **stack-c** defined that it needs to be run after **stack-b**, since
 The environment in which stacks are going to be executed can be configured
 using the `terramate.config.run.env` block. This block has no labels and
 accepts arbitrary attributes where each attribute represents an environment
-variable that will be exported when executing the stack.
+variable that will be evaluated and exported when executing the stack.
 The attributes must always evaluate to strings.
 
 Example:

--- a/docs/orchestration.md
+++ b/docs/orchestration.md
@@ -280,40 +280,52 @@ Even though **stack-c** defined that it needs to be run after **stack-b**, since
 ## Execution Environment
 
 The environment in which stacks are going to be executed can be configured
-using the `export_env` block. This block has no labels and accepts arbitrary
-attributes where each attribute represents an environment variable that will
-be exported when executing the stack. The attributes must always evaluate to
-strings.
+using the `terramate.config.run.env` block. This block has no labels and
+accepts arbitrary attributes where each attribute represents an environment
+variable that will be exported when executing the stack.
+The attributes must always evaluate to strings.
 
 Example:
 
 ```hcl
-export_env {
-  TF_PLUGIN_CACHE_DIR = "/some/path/etc"
+terramate {
+  config {
+    run {
+      env {
+        TF_PLUGIN_CACHE_DIR = "/some/path/etc"
+      }
+    }
+  }
 }
 ```
 
 Will export the environment variable `TF_PLUGIN_CACHE_DIR` on the stack
 execution environment with the value `/some/path/etc`.
 
-Inside the `export_env` block the `env` namespace will be available including
-environment variables exported from the host:
+Inside the `terramate.config.run.env` block the `env` namespace will be
+available including environment variables exported from the host:
 
 ```hcl
-export_env {
-  TF_PLUGIN_CACHE_DIR = "${env.HOME}/.terraform-cache-dir"
+terramate {
+  config {
+    run {
+      env {
+        TF_PLUGIN_CACHE_DIR = "${env.HOME}/.terraform-cache-dir"
+      }
+    }
+  }
 }
 ```
 
 The `env` namespace is read-only and is only available when evaluating
-`export_env` blocks.
+`terramate.config.run.env` blocks.
 
-The `export_env` blocks have the same hierarchical behavior as other features
-on Terramate, so an `export_env` defined on the project root is inherited by
-all stacks in the project.
+The `terramate.config.run.env` blocks have the same hierarchical behavior
+as other features on Terramate, so an `terramate.config.run.env` defined on
+the project root is inherited by all stacks in the project.
 
-All `export_env` blocks are merged, so different variables defined on different
-blocks will all be exported on the stack execution environment.
+All `terramate.config.run.env` blocks are merged, so different variables
+defined on different blocks will all be exported on the stack execution environment.
 
 Regarding variables redefinitions:
 

--- a/docs/orchestration.md
+++ b/docs/orchestration.md
@@ -317,8 +317,25 @@ terramate {
 }
 ```
 
-The `env` namespace is read-only and is only available when evaluating
-`terramate.config.run.env` blocks.
+Globals and Metadata can also be referenced:
+
+```hcl
+terramate {
+  config {
+    run {
+      env {
+        TF_PLUGIN_CACHE_DIR = "${terramate.stack.path.absolute}/${global.cache_dir}"
+      }
+    }
+  }
+}
+```
+
+The `env` namespace is meant to give access to the host environment variables,
+it is read-only, and is only available when evaluating
+`terramate.config.run.env` blocks. This means that any attributes defined
+on `terramate.config.run.env` blocks won't affect the `env` namespace,
+they only affect the stack execution environment.
 
 The `terramate.config.run.env` blocks have the same hierarchical behavior
 as other features on Terramate, so an `terramate.config.run.env` defined on

--- a/docs/orchestration.md
+++ b/docs/orchestration.md
@@ -219,7 +219,6 @@ This will run **terraform** plan on all stacks, but respecting ordering:
 terramate run terraform plan
 ```
 
-
 ### Change Detection And Ordering
 
 When using any terramate command with support to change detection,
@@ -277,6 +276,46 @@ Even though **stack-c** defined that it needs to be run after **stack-b**, since
 **stack-b** has no changes on it, it will be ignored when defining the
 **runtime** order.
 
+
+## Execution Environment
+
+The environment in which stacks are going to be executed can be configured
+using the `export_env` block. This block has no labels and accepts arbitrary
+attributes where each attribute represents an environment variable that will
+be exported when executing the stack. The attributes must always evaluate to
+strings.
+
+Example:
+
+```hcl
+export_env {
+  TF_PLUGIN_CACHE_DIR = "/some/path/etc"
+}
+```
+
+Will export the environment variable `TF_PLUGIN_CACHE_DIR` on the stack
+execution environment with the value `/some/path/etc`.
+
+Inside the `export_env` block the `env` namespace will be available including
+environment variables exported from the host:
+
+```hcl
+export_env {
+  TF_PLUGIN_CACHE_DIR = "${env.HOME}/.terraform-cache-dir"
+}
+```
+
+The `env` namespace is read-only and is only available when evaluating
+`export_env` blocks.
+
+The `export_env` blocks have the same hierarchical behavior as other features
+on Terramate, so an `export_env` defined on the project root is inherited by
+all stacks in the project.
+
+Regarding redefinitions:
+
+* Redefinition on same level is disallowed
+* Redefinition on different levels: more specific definition (closer to stack) is used
 
 ## Failure Modes
 

--- a/docs/orchestration.md
+++ b/docs/orchestration.md
@@ -312,7 +312,10 @@ The `export_env` blocks have the same hierarchical behavior as other features
 on Terramate, so an `export_env` defined on the project root is inherited by
 all stacks in the project.
 
-Regarding redefinitions:
+All `export_env` blocks are merged, so different variables defined on different
+blocks will all be exported on the stack execution environment.
+
+Regarding variables redefinitions:
 
 * Redefinition on same level is disallowed
 * Redefinition on different levels: more specific definition (closer to stack) is used


### PR DESCRIPTION
Initial spec for the `export_env` feature. We could use different names, maybe `run_env` or `exec_env` would be more explicit ? Go crazy on name suggestions =P