### PR TITLE
refactor: remove error on stack eval ctx creation

### DIFF
--- a/generate/genfile/genfile.go
+++ b/generate/genfile/genfile.go
@@ -118,10 +118,7 @@ func Load(rootdir string, sm stack.Metadata, globals stack.Globals) (StackFiles,
 		return StackFiles{}, errors.E("loading generate_file", err)
 	}
 
-	evalctx, err := stack.NewEvalCtx(stackpath, sm, globals)
-	if err != nil {
-		return StackFiles{}, errors.E(err, "creating eval context")
-	}
+	evalctx := stack.NewEvalCtx(stackpath, sm, globals)
 
 	logger.Trace().Msg("generating files")
 

--- a/generate/genhcl/genhcl.go
+++ b/generate/genhcl/genhcl.go
@@ -132,10 +132,7 @@ func Load(rootdir string, sm stack.Metadata, globals stack.Globals) (StackHCLs, 
 		return StackHCLs{}, errors.E("loading generate_hcl", err)
 	}
 
-	evalctx, err := stack.NewEvalCtx(stackpath, sm, globals)
-	if err != nil {
-		return StackHCLs{}, errors.E(err, "creating eval context")
-	}
+	evalctx := stack.NewEvalCtx(stackpath, sm, globals)
 
 	logger.Trace().Msg("generating HCL code.")
 

--- a/stack/eval.go
+++ b/stack/eval.go
@@ -27,11 +27,11 @@ type EvalCtx struct {
 }
 
 // NewEvalCtx creates a new stack evaluation context.
-func NewEvalCtx(stackpath string, sm Metadata, globals Globals) (*EvalCtx, error) {
+func NewEvalCtx(stackpath string, sm Metadata, globals Globals) *EvalCtx {
 	evalctx := &EvalCtx{evalctx: eval.NewContext(stackpath)}
 	evalctx.SetMetadata(sm)
 	evalctx.SetGlobals(globals)
-	return evalctx, nil
+	return evalctx
 }
 
 // SetGlobals sets the given globals on the stack evaluation context.

--- a/stack/globals.go
+++ b/stack/globals.go
@@ -123,10 +123,7 @@ func (ge *globalsExpr) eval(rootdir string, meta Metadata) (Globals, error) {
 		attributes: map[string]cty.Value{},
 	}
 
-	evalctx, err := NewEvalCtx(filepath.Join(rootdir, meta.Path()), meta, globals)
-	if err != nil {
-		return Globals{}, err
-	}
+	evalctx := NewEvalCtx(filepath.Join(rootdir, meta.Path()), meta, globals)
 
 	pendingExprsErrs := map[string]error{}
 	pendingExprs := ge.expressions


### PR DESCRIPTION
The stack eval creation doesn't need to return an error anymore, it is a leftover from a previous refactor I did, sorry I missed this.