### PR TITLE
fix: avoid checking the schema in case of syntax errors

### DIFF
--- a/hcl/hcl_test.go
+++ b/hcl/hcl_test.go
@@ -802,6 +802,7 @@ func TestHCLParserStack(t *testing.T) {
 						}
 						stack {
 							wants =
+							unrecognized = "test"
 						}
 					`,
 				},

--- a/hcl/hcl_test.go
+++ b/hcl/hcl_test.go
@@ -792,6 +792,27 @@ func TestHCLParserStack(t *testing.T) {
 			},
 		},
 		{
+			name: "schema not checked for files with syntax errors",
+			input: []cfgfile{
+				{
+					filename: "stack.tm",
+					body: `
+						terramate {
+							required_version = ""
+						}
+						stack {
+							wants =
+						}
+					`,
+				},
+			},
+			want: want{
+				errs: []error{
+					errors.E(hcl.ErrHCLSyntax),
+				},
+			},
+		},
+		{
 			name: "after: empty set works",
 			input: []cfgfile{
 				{
@@ -1046,8 +1067,6 @@ func TestHCLParserMultipleErrors(t *testing.T) {
 			},
 			want: want{
 				errs: []error{
-					errors.E(hcl.ErrTerramateSchema,
-						mkrange("file.tm", start(1, 1, 0), end(1, 2, 1))),
 					errors.E(hcl.ErrHCLSyntax,
 						mkrange("file.tm", start(2, 1, 4), end(2, 2, 5))),
 					errors.E(hcl.ErrHCLSyntax,
@@ -1069,14 +1088,10 @@ func TestHCLParserMultipleErrors(t *testing.T) {
 			},
 			want: want{
 				errs: []error{
-					errors.E(hcl.ErrTerramateSchema,
-						mkrange("file1.tm", start(1, 1, 0), end(1, 2, 1))),
 					errors.E(hcl.ErrHCLSyntax,
 						mkrange("file1.tm", start(2, 1, 4), end(2, 2, 5))),
 					errors.E(hcl.ErrHCLSyntax,
 						mkrange("file1.tm", start(3, 1, 8), end(3, 2, 9))),
-					errors.E(hcl.ErrTerramateSchema,
-						mkrange("file2.tm", start(1, 1, 0), end(1, 2, 1))),
 					errors.E(hcl.ErrHCLSyntax,
 						mkrange("file2.tm", start(2, 1, 4), end(2, 2, 5))),
 					errors.E(hcl.ErrHCLSyntax,


### PR DESCRIPTION
The invalid config below:

```
stack {
    wants = 
}
```

generates an error when calling the hashicorp parse.ParseHCL() function but it populate its `parse.Files()` with an invalid data structure for the file's body... for the case above, it creates an attribute with name "wants" and value of type cty.DynamicValue that's not even nullable (attrVar.IsNull() returns `false`)...

So we cannot have syntax error + schema errors because they do not provide partial correct nodes.

The fix was making terramate check the schema only for the files successfully parsed (valid HCL).

I got this issue while experimenting with the VSCode extension. The Language Server crashed with log below:

```
attribute=wants stack=
2022-06-14T13:09:43+01:00 TRC Iterate over values. action=assignSet()
panic: can't use ElementIterator on unknown value

goroutine 22 [running]:
github.com/zclconf/go-cty/cty.Value.ElementIterator({{{0x7776c8?, 0x953768?}}, {0x6b9120?, 0x9534a0?}})
	/home/i4k/go/pkg/mod/github.com/zclconf/go-cty@v1.8.3/cty/value_ops.go:1118 +0xd8
github.com/mineiros-io/terramate/hcl.assignSet({0xc000258744, 0x5}, 0xc0001431d0, {{{0x7776c8?, 0x953768?}}, {0x6b9120?, 0x9534a0?}})
	/home/i4k/go/pkg/mod/github.com/mineiros-io/terramate@v0.1.5/hcl/hcl.go:652 +0x37c
github.com/mineiros-io/terramate/hcl.parseStack(0xc000143180, 0xc000245200)
	/home/i4k/go/pkg/mod/github.com/mineiros-io/terramate@v0.1.5/hcl/hcl.go:739 +0x919
github.com/mineiros-io/terramate/hcl.(*TerramateParser).parseTerramateSchema(0xc00028f950)
	/home/i4k/go/pkg/mod/github.com/mineiros-io/terramate@v0.1.5/hcl/hcl.go:1142 +0xb2f
github.com/mineiros-io/terramate/hcl.(*TerramateParser).Parse(0xc00028f950)
	/home/i4k/go/pkg/mod/github.com/mineiros-io/terramate@v0.1.5/hcl/hcl.go:207 +0x72
github.com/mineiros-io/terramate-ls.checkFiles({0xc00014bb40, 0x2, 0x2?}, {0xc0001f0237, 0x61}, {0xc000130c60, 0x146})
	/home/i4k/src/mineiros/terramate-ls/ls.go:401 +0x128
github.com/mineiros-io/terramate-ls.(*Server).checkAndReply(0xc0001f0230?, {0x777658, 0xc00012fc80}, 0xc00014ba60, {0xc0001f0237, 0x61}, {0xc000130c60, 0x146})
	/home/i4k/src/mineiros/terramate-ls/ls.go:328 +0x156
github.com/mineiros-io/terramate-ls.(*Server).handleDocumentOpen(0x2aa?, {0x777658, 0xc00012fc80}, 0xc00014f7b8?, {0x7fee44fc1f18, 0xc00025a420}, {{0x776d10, 0xc0001d84d0}, 0xff, {0x0, ...}, ...})
	/home/i4k/src/mineiros/terramate-ls/ls.go:188 +0x11f
github.com/mineiros-io/terramate-ls.(*Server).Handler(0xc000132510, {0x777658, 0xc00012fc80}, 0xc00014ba60, {0x7fee44fc1f18?, 0xc00025a420?})
	/home/i4k/src/mineiros/terramate-ls/ls.go:93 +0x4ff
go.lsp.dev/jsonrpc2.(*conn).run(0xc000100c80, {0x777658, 0xc00012fc80}, 0xc0001d8790)
	/home/i4k/go/pkg/mod/go.lsp.dev/jsonrpc2@v0.10.0/conn.go:206 +0x24b
created by go.lsp.dev/jsonrpc2.(*conn).Go
	/home/i4k/go/pkg/mod/go.lsp.dev/jsonrpc2@v0.10.0/conn.go:189 +0xb0
[Error - 1:09:43 PM] Connection to server got closed. Server will not be restarted.
```