### PR TITLE
fix: infinite loop in generate if the stack is in /

### DIFF
--- a/generate/genfile/genfile.go
+++ b/generate/genfile/genfile.go
@@ -239,7 +239,12 @@ func loadGenFileBlocks(rootdir string, cfgdir string) ([]genFileBlock, error) {
 		}
 	}
 
-	parentRes, err := loadGenFileBlocks(rootdir, filepath.Dir(cfgdir))
+	parentCfgDir := filepath.Dir(cfgdir)
+	if parentCfgDir == cfgdir {
+		return res, nil
+	}
+
+	parentRes, err := loadGenFileBlocks(rootdir, parentCfgDir)
 	if err != nil {
 		return nil, err
 	}

--- a/generate/genhcl/genhcl.go
+++ b/generate/genhcl/genhcl.go
@@ -244,7 +244,12 @@ func loadGenHCLBlocks(rootdir string, cfgdir string) ([]loadedHCL, error) {
 		}
 	}
 
-	parentRes, err := loadGenHCLBlocks(rootdir, filepath.Dir(cfgdir))
+	parentCfgDir := filepath.Dir(cfgdir)
+	if parentCfgDir == cfgdir {
+		return res, nil
+	}
+
+	parentRes, err := loadGenHCLBlocks(rootdir, parentCfgDir)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
# Reason for This Change

If the stack is in the filesystem / then the generation loops indefinitely.
Got this while testing terramate in the browser using an in-memory file system.

## Description of Changes

Do not recurse if `filepath.Dir(path)` yields the same `path`.