### PR TITLE
fix: checkGit() called for non-git repos

### DIFF
--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -358,6 +358,10 @@ func (c *cli) checkGit() {
 		Str("action", "checkGit()").
 		Logger()
 
+	if !c.prj.isRepo {
+		return
+	}
+
 	logger.Trace().Msg("Check git default remote.")
 
 	if err := c.prj.checkDefaultRemote(); err != nil {

--- a/cmd/terramate/e2etests/list_git_test.go
+++ b/cmd/terramate/e2etests/list_git_test.go
@@ -1,0 +1,193 @@
+package e2etest
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/mineiros-io/terramate/config"
+	"github.com/mineiros-io/terramate/test"
+	"github.com/mineiros-io/terramate/test/sandbox"
+)
+
+func TestE2EListWithGit(t *testing.T) {
+	for _, tc := range listTestcases() {
+		t.Run(tc.name, func(t *testing.T) {
+			s := sandbox.New(t)
+			s.BuildTree(tc.layout)
+
+			cli := newCLI(t, s.RootDir())
+			assertRunResult(t, cli.listStacks(), tc.want)
+		})
+	}
+}
+
+func TestListDetectChangesInSubDirOfStack(t *testing.T) {
+	s := sandbox.New(t)
+
+	stack := s.CreateStack("stack")
+	subdir := stack.CreateDir("sub/dir")
+	subfile := subdir.CreateFile("something.sh", "# nothing")
+
+	cli := newCLI(t, s.RootDir())
+
+	git := s.Git()
+	git.CommitAll("all")
+	git.Push("main")
+	git.CheckoutNew("change-the-stack")
+
+	subfile.Write("# changed")
+	git.Add(stack.Path())
+	git.Commit("stack changed")
+
+	want := runExpected{
+		Stdout: stack.RelPath() + "\n",
+	}
+	assertRunResult(t, cli.listChangedStacks(), want)
+}
+
+func TestListDetectChangesInSubDirOfStackWithOtherConfigs(t *testing.T) {
+	s := sandbox.New(t)
+
+	stack := s.CreateStack("stack")
+	subdir := stack.CreateDir("sub")
+	subsubdir := subdir.CreateDir("dir")
+	subsubfile := subsubdir.CreateFile("something.sh", "# nothing")
+
+	subdir.CreateFile(config.DefaultFilename, `
+terramate {
+	
+}	
+`)
+
+	cli := newCLI(t, s.RootDir())
+
+	git := s.Git()
+	git.CommitAll("all")
+	git.Push("main")
+	git.CheckoutNew("change-the-stack")
+
+	subsubfile.Write("# changed")
+	git.Add(stack.Path())
+	git.Commit("stack changed")
+
+	want := runExpected{
+		Stdout: stack.RelPath() + "\n",
+	}
+	assertRunResult(t, cli.listChangedStacks(), want)
+}
+
+func TestListChangedIgnoreDeletedStackDirectory(t *testing.T) {
+	s := sandbox.New(t)
+
+	stack := s.CreateStack("stack-old")
+	cli := newCLI(t, s.RootDir())
+
+	git := s.Git()
+	git.CommitAll("all")
+	git.Push("main")
+	git.CheckoutNew("deleted-stack")
+
+	test.RemoveAll(t, stack.Path())
+
+	git.CommitAll("removed stack")
+
+	assertRun(t, cli.listChangedStacks())
+}
+
+func TestListChangedIgnoreDeletedNonStackDirectory(t *testing.T) {
+	s := sandbox.New(t)
+
+	s.CreateStack("stack")
+	toBeDeletedDir := filepath.Join(s.RootDir(), "to-be-deleted")
+	test.MkdirAll(t, toBeDeletedDir)
+	test.WriteFile(t, toBeDeletedDir, "test.txt", "")
+	cli := newCLI(t, s.RootDir())
+
+	git := s.Git()
+	git.CommitAll("all")
+	git.Push("main")
+
+	git.CheckoutNew("deleted-diretory")
+
+	test.RemoveAll(t, toBeDeletedDir)
+	git.CommitAll("removed directory")
+
+	assertRun(t, cli.listChangedStacks())
+}
+
+func TestListChangedDontIgnoreStackDeletedFiles(t *testing.T) {
+	s := sandbox.New(t)
+
+	stack := s.CreateStack("stack")
+	testDir := stack.CreateDir("test")
+	file := testDir.CreateFile("testfile", "")
+	cli := newCLI(t, s.RootDir())
+
+	git := s.Git()
+	git.CommitAll("all")
+	git.Push("main")
+	git.CheckoutNew("deleted-file")
+
+	test.RemoveAll(t, file.Path())
+
+	git.CommitAll("removed file")
+
+	assertRunResult(t, cli.listChangedStacks(), runExpected{
+		Stdout: stack.RelPath() + "\n",
+	})
+}
+
+func TestListChangedDontIgnoreStackDeletedDirectories(t *testing.T) {
+	s := sandbox.New(t)
+
+	stack := s.CreateStack("stack")
+	testDir := stack.CreateDir("test")
+	testDir.CreateFile("testfile1", "")
+	testDir.CreateFile("testfile2", "")
+	cli := newCLI(t, s.RootDir())
+
+	git := s.Git()
+	git.CommitAll("all")
+	git.Push("main")
+	git.CheckoutNew("deleted-dir")
+
+	test.RemoveAll(t, testDir.Path())
+
+	git.CommitAll("removed directory")
+
+	assertRunResult(t, cli.listChangedStacks(), runExpected{
+		Stdout: stack.RelPath() + "\n",
+	})
+}
+
+func TestListTwiceBug(t *testing.T) {
+	const (
+		mainTfFileName = "main.tf"
+		modname        = "modA"
+	)
+
+	s := sandbox.New(t)
+
+	stack := s.CreateStack("stack")
+	mod1 := s.CreateModule(modname)
+	mod1MainTf := mod1.CreateFile(mainTfFileName, "# module A")
+
+	stack.CreateFile("main.tf", `
+module "mod1" {
+source = "%s"
+}`, stack.ModSource(mod1))
+
+	git := s.Git()
+	git.CommitAll("first commit")
+	git.Push("main")
+	git.CheckoutNew("change-stack")
+
+	mod1MainTf.Write("# something else")
+	stack.CreateFile("test.txt", "something else")
+	git.CommitAll("stack and module changed")
+
+	cli := newCLI(t, s.RootDir())
+
+	wantList := stack.RelPath() + "\n"
+	assertRunResult(t, cli.listChangedStacks(), runExpected{Stdout: wantList})
+}

--- a/cmd/terramate/e2etests/list_git_test.go
+++ b/cmd/terramate/e2etests/list_git_test.go
@@ -1,3 +1,17 @@
+// Copyright 2022 Mineiros GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package e2etest
 
 import (

--- a/cmd/terramate/e2etests/list_nongit_test.go
+++ b/cmd/terramate/e2etests/list_nongit_test.go
@@ -1,0 +1,22 @@
+package e2etest
+
+import (
+	"testing"
+
+	"github.com/mineiros-io/terramate/test"
+	"github.com/mineiros-io/terramate/test/sandbox"
+)
+
+func TestE2EListNonGit(t *testing.T) {
+	for _, tc := range listTestcases() {
+		t.Run(tc.name, func(t *testing.T) {
+			s := sandbox.NoGit(t)
+			s.BuildTree(tc.layout)
+
+			test.WriteRootConfig(t, s.RootDir())
+
+			cli := newCLI(t, s.RootDir())
+			assertRunResult(t, cli.listStacks(), tc.want)
+		})
+	}
+}

--- a/cmd/terramate/e2etests/list_nongit_test.go
+++ b/cmd/terramate/e2etests/list_nongit_test.go
@@ -1,3 +1,17 @@
+// Copyright 2022 Mineiros GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package e2etest
 
 import (

--- a/cmd/terramate/e2etests/list_test.go
+++ b/cmd/terramate/e2etests/list_test.go
@@ -15,23 +15,21 @@
 package e2etest
 
 import (
-	"path/filepath"
 	"testing"
 
-	"github.com/mineiros-io/terramate/config"
 	"github.com/mineiros-io/terramate/hcl"
 	"github.com/mineiros-io/terramate/test"
 	"github.com/mineiros-io/terramate/test/sandbox"
 )
 
-func TestCLIList(t *testing.T) {
-	type testcase struct {
-		name   string
-		layout []string
-		want   runExpected
-	}
+type testcase struct {
+	name   string
+	layout []string
+	want   runExpected
+}
 
-	for _, tc := range []testcase{
+func listTestcases() []testcase {
+	return []testcase{
 		{
 			name: "no stack",
 		},
@@ -118,14 +116,6 @@ z/a
 `,
 			},
 		},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			s := sandbox.New(t)
-			s.BuildTree(tc.layout)
-
-			cli := newCLI(t, s.RootDir())
-			assertRunResult(t, cli.listStacks(), tc.want)
-		})
 	}
 }
 
@@ -159,175 +149,4 @@ func TestListNoSuchFile(t *testing.T) {
 		Status:      1,
 		StderrRegex: "no such file or directory",
 	})
-}
-
-func TestListDetectChangesInSubDirOfStack(t *testing.T) {
-	s := sandbox.New(t)
-
-	stack := s.CreateStack("stack")
-	subdir := stack.CreateDir("sub/dir")
-	subfile := subdir.CreateFile("something.sh", "# nothing")
-
-	cli := newCLI(t, s.RootDir())
-
-	git := s.Git()
-	git.CommitAll("all")
-	git.Push("main")
-	git.CheckoutNew("change-the-stack")
-
-	subfile.Write("# changed")
-	git.Add(stack.Path())
-	git.Commit("stack changed")
-
-	want := runExpected{
-		Stdout: stack.RelPath() + "\n",
-	}
-	assertRunResult(t, cli.listChangedStacks(), want)
-}
-
-func TestListDetectChangesInSubDirOfStackWithOtherConfigs(t *testing.T) {
-	s := sandbox.New(t)
-
-	stack := s.CreateStack("stack")
-	subdir := stack.CreateDir("sub")
-	subsubdir := subdir.CreateDir("dir")
-	subsubfile := subsubdir.CreateFile("something.sh", "# nothing")
-
-	subdir.CreateFile(config.DefaultFilename, `
-terramate {
-	
-}	
-`)
-
-	cli := newCLI(t, s.RootDir())
-
-	git := s.Git()
-	git.CommitAll("all")
-	git.Push("main")
-	git.CheckoutNew("change-the-stack")
-
-	subsubfile.Write("# changed")
-	git.Add(stack.Path())
-	git.Commit("stack changed")
-
-	want := runExpected{
-		Stdout: stack.RelPath() + "\n",
-	}
-	assertRunResult(t, cli.listChangedStacks(), want)
-}
-
-func TestListChangedIgnoreDeletedStackDirectory(t *testing.T) {
-	s := sandbox.New(t)
-
-	stack := s.CreateStack("stack-old")
-	cli := newCLI(t, s.RootDir())
-
-	git := s.Git()
-	git.CommitAll("all")
-	git.Push("main")
-	git.CheckoutNew("deleted-stack")
-
-	test.RemoveAll(t, stack.Path())
-
-	git.CommitAll("removed stack")
-
-	assertRun(t, cli.listChangedStacks())
-}
-
-func TestListChangedIgnoreDeletedNonStackDirectory(t *testing.T) {
-	s := sandbox.New(t)
-
-	s.CreateStack("stack")
-	toBeDeletedDir := filepath.Join(s.RootDir(), "to-be-deleted")
-	test.MkdirAll(t, toBeDeletedDir)
-	test.WriteFile(t, toBeDeletedDir, "test.txt", "")
-	cli := newCLI(t, s.RootDir())
-
-	git := s.Git()
-	git.CommitAll("all")
-	git.Push("main")
-
-	git.CheckoutNew("deleted-diretory")
-
-	test.RemoveAll(t, toBeDeletedDir)
-	git.CommitAll("removed directory")
-
-	assertRun(t, cli.listChangedStacks())
-}
-
-func TestListChangedDontIgnoreStackDeletedFiles(t *testing.T) {
-	s := sandbox.New(t)
-
-	stack := s.CreateStack("stack")
-	testDir := stack.CreateDir("test")
-	file := testDir.CreateFile("testfile", "")
-	cli := newCLI(t, s.RootDir())
-
-	git := s.Git()
-	git.CommitAll("all")
-	git.Push("main")
-	git.CheckoutNew("deleted-file")
-
-	test.RemoveAll(t, file.Path())
-
-	git.CommitAll("removed file")
-
-	assertRunResult(t, cli.listChangedStacks(), runExpected{
-		Stdout: stack.RelPath() + "\n",
-	})
-}
-
-func TestListChangedDontIgnoreStackDeletedDirectories(t *testing.T) {
-	s := sandbox.New(t)
-
-	stack := s.CreateStack("stack")
-	testDir := stack.CreateDir("test")
-	testDir.CreateFile("testfile1", "")
-	testDir.CreateFile("testfile2", "")
-	cli := newCLI(t, s.RootDir())
-
-	git := s.Git()
-	git.CommitAll("all")
-	git.Push("main")
-	git.CheckoutNew("deleted-dir")
-
-	test.RemoveAll(t, testDir.Path())
-
-	git.CommitAll("removed directory")
-
-	assertRunResult(t, cli.listChangedStacks(), runExpected{
-		Stdout: stack.RelPath() + "\n",
-	})
-}
-
-func TestListTwiceBug(t *testing.T) {
-	const (
-		mainTfFileName = "main.tf"
-		modname        = "modA"
-	)
-
-	s := sandbox.New(t)
-
-	stack := s.CreateStack("stack")
-	mod1 := s.CreateModule(modname)
-	mod1MainTf := mod1.CreateFile(mainTfFileName, "# module A")
-
-	stack.CreateFile("main.tf", `
-module "mod1" {
-source = "%s"
-}`, stack.ModSource(mod1))
-
-	git := s.Git()
-	git.CommitAll("first commit")
-	git.Push("main")
-	git.CheckoutNew("change-stack")
-
-	mod1MainTf.Write("# something else")
-	stack.CreateFile("test.txt", "something else")
-	git.CommitAll("stack and module changed")
-
-	cli := newCLI(t, s.RootDir())
-
-	wantList := stack.RelPath() + "\n"
-	assertRunResult(t, cli.listChangedStacks(), runExpected{Stdout: wantList})
 }

--- a/test/hcl.go
+++ b/test/hcl.go
@@ -93,3 +93,14 @@ func assertStackBlock(t *testing.T, got, want *hcl.Stack) {
 		assert.EqualStrings(t, w, got.After[i], "stack after mismatch")
 	}
 }
+
+// WriteRootConfig writes a basic terramate root config.
+func WriteRootConfig(t *testing.T, rootdir string) {
+	WriteFile(t, rootdir, "root.config.tm", `
+terramate {
+	config {
+
+	}
+}
+			`)
+}


### PR DESCRIPTION
# Reason for This Change

The checks for git were running for non-git environments.

## Description of Changes

A guard was added to checkGit() and the tests were reused for git/nongit envs so we catch those related issues.

Closes #402 
