### PR TITLE
chore: build terramate statically whenever possible

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,8 +97,4 @@ jobs:
           go-version: "1.17"
 
       - name: release dry run
-        uses: goreleaser/goreleaser-action@v2
-        with:
-          distribution: goreleaser
-          version: v1.2.5
-          args: release --snapshot --rm-dist
+        run: make release/dry-run

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,10 +37,6 @@ jobs:
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v2
-        with:
-          distribution: goreleaser
-          version: v1.2.5
-          args: release --rm-dist
+        run: make release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -16,11 +16,12 @@ builds:
   - main: ./cmd/terramate
     env:
       - CGO_ENABLED=0
+    ldflags:
+      - -extldflags "-static"
     goos:
       - linux
       - darwin
       # - windows (when we add win support)
-      #
 archives:
   - replacements:
       darwin: darwin

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ SHELL := /bin/bash -o pipefail -o errexit -o nounset
 COVERAGE_REPORT ?= coverage.txt
 
 addlicense=go run github.com/google/addlicense@v1.0.0 -ignore **/*.yml
+buildflags=--ldflags '-extldflags "-static"'
 
 .PHONY: default
 default: help
@@ -71,12 +72,12 @@ test/fuzz/fmt:
 ## Build terramate into bin directory
 .PHONY: build
 build:
-	CGO_ENABLED=0 go build --ldflags '-extldflags "-static"' -o bin/terramate ./cmd/terramate
+	CGO_ENABLED=0 go build $(buildflags) -o bin/terramate ./cmd/terramate
 
 ## Install terramate on the host
 .PHONY: install
 install:
-	go install ./cmd/terramate
+	CGO_ENABLED=0 go install $(buildflags) ./cmd/terramate
 
 ## remove build artifacts
 .PHONY: clean

--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ test/fuzz/fmt:
 ## Build terramate into bin directory
 .PHONY: build
 build:
-	go build -o bin/terramate ./cmd/terramate
+	CGO_ENABLED=0 go build --ldflags '-extldflags "-static"' -o bin/terramate ./cmd/terramate
 
 ## Install terramate on the host
 .PHONY: install

--- a/cmd/terramate/e2etests/main_test.go
+++ b/cmd/terramate/e2etests/main_test.go
@@ -71,6 +71,8 @@ func setupAndRunTests(m *testing.M) (status int) {
 
 func buildTerramate(goBin string, projectRoot string, binDir string) (string, error) {
 	// We need to build the same way it is built on our Makefile + release process
+	// Invoking make here would assume that someone running go test ./... have
+	// make installed, so we are keeping the duplication to reduce deps when running tests.
 	outBinPath := filepath.Join(binDir, "terramate"+platExeSuffix())
 	cmd := exec.Command(
 		goBin,

--- a/cmd/terramate/e2etests/main_test.go
+++ b/cmd/terramate/e2etests/main_test.go
@@ -70,14 +70,18 @@ func setupAndRunTests(m *testing.M) (status int) {
 }
 
 func buildTerramate(goBin string, projectRoot string, binDir string) (string, error) {
+	// We need to build the same way it is built on our Makefile + release process
 	outBinPath := filepath.Join(binDir, "terramate"+platExeSuffix())
 	cmd := exec.Command(
 		goBin,
 		"build",
+		"--ldflags",
+		`-extldflags "-static"`,
 		"-o",
 		outBinPath,
 		filepath.Join(projectRoot, "cmd/terramate"),
 	)
+	cmd.Env = append(os.Environ(), "CGO_ENABLED=0")
 
 	out, err := cmd.CombinedOutput()
 	if err != nil {


### PR DESCRIPTION
Not all targets targets support static binaries (like macos), but for linux now we have a static build, both on make + release + e2e testing.

To check the release binaries you can run:

```
make release/dry-run
```

And check inside the dist dir:

```
file dist/terramate_*/terramate
dist/terramate_darwin_amd64/terramate: Mach-O 64-bit x86_64 executable
dist/terramate_darwin_arm64/terramate: Mach-O 64-bit arm64 executable, flags:<|DYLDLINK|PIE>
dist/terramate_linux_386/terramate:    ELF 32-bit LSB executable, Intel 80386, version 1 (SYSV), statically linked, Go BuildID=Z0uQDQNinOYf7RfT23LA/6FMEyC8F2_39TyAJx8rp/Hzi3ovxvism8APu_csVO/V_GfsOkddGoQSay72BYt, not stripped
dist/terramate_linux_amd64/terramate:  ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, Go BuildID=p_lac1sQB1eDcJloaogQ/o7V0Kf1ihJLTDY5NDJw7/CUhlwVzU0Q5pX9y00NhB/86hIfr1jW26fBhsYYmSL, not stripped
dist/terramate_linux_arm64/terramate:  ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, Go BuildID=CguNnxFygOUHY-eAEDtO/PFFdtAYvH19ZYHSnhu16/ZcAT_rYOwzJgL4Ys44b3/2UtxG4gNwESxaoxYt3aR, not stripped
```