### PR TITLE
fix: handle interruption signals when on run

### DIFF
--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -936,8 +936,7 @@ func (c *cli) runOnStacks() {
 
 	err = run.Exec(
 		orderedStacks,
-		c.parsedArgs.Run.Command[0],
-		c.parsedArgs.Run.Command[1:],
+		c.parsedArgs.Run.Command,
 		c.stdin,
 		c.stdout,
 		c.stderr,
@@ -945,9 +944,17 @@ func (c *cli) runOnStacks() {
 	)
 
 	if err != nil {
-		logger.Warn().
-			Err(err).
-			Msg("failed to execute commands")
+
+		logger.Warn().Msg("one or more commands failed")
+
+		var errs *errors.List
+		if errors.As(err, &errs) {
+			for _, err := range errs.Errors() {
+				logger.Warn().Err(err)
+			}
+		} else {
+			logger.Warn().Err(err)
+		}
 
 		os.Exit(1)
 	}

--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -950,10 +950,10 @@ func (c *cli) runOnStacks() {
 		var errs *errors.List
 		if errors.As(err, &errs) {
 			for _, err := range errs.Errors() {
-				logger.Warn().Err(err)
+				logger.Warn().Err(err).Send()
 			}
 		} else {
-			logger.Warn().Err(err)
+			logger.Warn().Err(err).Send()
 		}
 
 		os.Exit(1)

--- a/run/exec.go
+++ b/run/exec.go
@@ -1,0 +1,83 @@
+// Copyright 2022 Mineiros GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package run
+
+import (
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/mineiros-io/terramate/errors"
+	"github.com/mineiros-io/terramate/stack"
+	"github.com/rs/zerolog/log"
+)
+
+// Exec will execute the given command on the given stack list
+// During the execution of this function the default behavior
+// for signal handling will be changed. The behavior implemented is:
+//
+// 1 x CTRL-C -> graceful shutdown, current stack executes but no other stack is executed.
+// No signal is forwarded to the sub process.
+// 2 x CTRL-C -> forward CTRL-C to running sub process
+// 3 x CTRL-C -> forward CTRL-C to running sub process 2nd time
+// 4 x CTRL-C -> kill running sub process with SIGKILL
+//
+// If continue on error is true this function will continue to execute
+// commands on stacks even in face of failures, returning an error.L of errors.
+// If continue on error is false it will return as soon as it finds an error,
+// returning a list with a single error inside.
+func Exec(
+	stacks []stack.S,
+	cmd string,
+	args []string,
+	stdin io.Reader,
+	stdout io.Writer,
+	stderr io.Writer,
+	continueOnError bool,
+) error {
+
+	logger := log.With().
+		Str("action", "run.Exec()").
+		Str("cmd", strings.Join(append([]string{cmd}, args...), " ")).
+		Logger()
+
+	errs := errors.L()
+
+	for _, stack := range stacks {
+		cmd := exec.Command(cmd, args...)
+		cmd.Dir = stack.HostPath()
+		cmd.Env = os.Environ()
+		cmd.Stdin = stdin
+		cmd.Stdout = stdout
+		cmd.Stderr = stderr
+
+		logger := logger.With().
+			Stringer("stack", stack).
+			Logger()
+
+		logger.Info().Msg("Running")
+
+		err := cmd.Run()
+		errs.Append(err)
+		if err != nil {
+			if !continueOnError {
+				return errs.AsError()
+			}
+		}
+	}
+
+	return errs.AsError()
+}

--- a/run/exec.go
+++ b/run/exec.go
@@ -92,7 +92,7 @@ func Exec(
 		}
 
 		if err := cmd.Start(); err != nil {
-			errs.Append(errors.E(stack, err, "starting %s", cmd))
+			errs.Append(errors.E(stack, err, "running %s", cmd))
 			if continueOnError {
 				continue
 			}

--- a/run/exec.go
+++ b/run/exec.go
@@ -49,7 +49,6 @@ func Exec(
 	stderr io.Writer,
 	continueOnError bool,
 ) error {
-
 	logger := log.With().
 		Str("action", "run.Exec()").
 		Str("cmd", strings.Join(cmd, " ")).

--- a/run/exec.go
+++ b/run/exec.go
@@ -86,7 +86,8 @@ func Exec(
 
 		logger.Info().Msg("Running")
 
-		// The child process should not get signals directly
+		// The child process should not get signals directly since
+		// we want to handle first interrupt differently.
 		cmd.SysProcAttr = &syscall.SysProcAttr{
 			Setpgid: true,
 		}

--- a/run/exec.go
+++ b/run/exec.go
@@ -92,7 +92,7 @@ func Exec(
 		}
 
 		if err := cmd.Start(); err != nil {
-			errs.Append(errors.E(stack, err, "running %s", cmd))
+			errs.Append(errors.E(stack, err, "starting %s", cmd))
 			if continueOnError {
 				continue
 			}
@@ -115,9 +115,14 @@ func Exec(
 					logger.Info().Msg("interruption, no more stacks will be run")
 				case 2, 3:
 					logger.Info().Msg("interrupted more than once, sending signal to child process")
+					if err := cmd.Process.Signal(sig); err != nil {
+						logger.Debug().Err(err).Msg("unable to send signal to child process")
+					}
 				case 4:
 					logger.Info().Msg("interrupted 4x times, killing child process")
-
+					if err := cmd.Process.Kill(); err != nil {
+						logger.Debug().Err(err).Msg("unable to send kill signal to child process")
+					}
 				}
 			case err := <-results:
 				logger.Trace().Msg("got command result")

--- a/run/exec.go
+++ b/run/exec.go
@@ -71,7 +71,14 @@ func Exec(
 
 		logger.Info().Msg("Running")
 
-		cmd.Start()
+		if err := cmd.Start(); err != nil {
+			errs.Append(errors.E(stack, err, "running %s", cmd))
+			if continueOnError {
+				continue
+			}
+			return errs.AsError()
+		}
+
 		cmds <- cmd
 
 		err := <-results

--- a/run/exec.go
+++ b/run/exec.go
@@ -29,14 +29,14 @@ import (
 // During the execution of this function the default behavior
 // for signal handling will be changed. The behavior implemented is:
 //
-// 1 x CTRL-C -> graceful shutdown, current stack executes but no other stack is executed.
-// No signal is forwarded to the sub process.
-// 2 x CTRL-C -> forward CTRL-C to running sub process
-// 3 x CTRL-C -> forward CTRL-C to running sub process 2nd time
-// 4 x CTRL-C -> kill running sub process with SIGKILL
+// - 1 x CTRL-C -> graceful shutdown, current stack executes but no other stack is executed.
+//   No signal is forwarded to the sub process.
+// - 2 x CTRL-C -> forward CTRL-C to running sub process
+// - 3 x CTRL-C -> forward CTRL-C to running sub process 2nd time
+// - 4 x CTRL-C -> kill running sub process with SIGKILL
 //
 // If continue on error is true this function will continue to execute
-// commands on stacks even in face of failures, returning an error.L of errors.
+// commands on stacks even in face of failures, returning an error.L with all errors.
 // If continue on error is false it will return as soon as it finds an error,
 // returning a list with a single error inside.
 func Exec(

--- a/run/exec.go
+++ b/run/exec.go
@@ -94,7 +94,7 @@ func Exec(
 		for cmdIsRunning {
 			select {
 			case sig := <-signals:
-				logger.Trace().
+				logger.Info().
 					Str("signal", sig.String()).
 					Msg("received signal")
 


### PR DESCRIPTION
Currently Terramate will exit as soon as it gets an interruption signal, not waiting for the child process to exit. This PR introduces waiting for the child process to finish before exiting Terramate + It will force kill the child process after receiving 3 interruption signals.

Closes #412 