### PR TITLE
chore: add run.Env that loads a stack run environment

### DIFF
--- a/generate/genfile/genfile.go
+++ b/generate/genfile/genfile.go
@@ -102,20 +102,19 @@ func (f File) String() string {
 //
 // The rootdir MUST be an absolute path.
 func Load(rootdir string, sm stack.Metadata, globals stack.Globals) ([]File, error) {
-	stackpath := filepath.Join(rootdir, sm.Path())
 	logger := log.With().
 		Str("action", "genfile.Load()").
-		Str("path", stackpath).
+		Str("path", sm.HostPath()).
 		Logger()
 
 	logger.Trace().Msg("loading generate_file blocks")
 
-	genFileBlocks, err := loadGenFileBlocks(rootdir, stackpath)
+	genFileBlocks, err := loadGenFileBlocks(rootdir, sm.HostPath())
 	if err != nil {
 		return nil, errors.E("loading generate_file", err)
 	}
 
-	evalctx := stack.NewEvalCtx(stackpath, sm, globals)
+	evalctx := stack.NewEvalCtx(sm, globals)
 
 	logger.Trace().Msg("generating files")
 

--- a/generate/genhcl/genhcl.go
+++ b/generate/genhcl/genhcl.go
@@ -111,20 +111,19 @@ func (h HCL) String() string {
 //
 // The rootdir MUST be an absolute path.
 func Load(rootdir string, sm stack.Metadata, globals stack.Globals) ([]HCL, error) {
-	stackpath := filepath.Join(rootdir, sm.Path())
 	logger := log.With().
 		Str("action", "genhcl.Load()").
-		Str("path", stackpath).
+		Str("path", sm.HostPath()).
 		Logger()
 
 	logger.Trace().Msg("loading generate_hcl blocks.")
 
-	loadedHCLs, err := loadGenHCLBlocks(rootdir, stackpath)
+	loadedHCLs, err := loadGenHCLBlocks(rootdir, sm.HostPath())
 	if err != nil {
 		return nil, errors.E("loading generate_hcl", err)
 	}
 
-	evalctx := stack.NewEvalCtx(stackpath, sm, globals)
+	evalctx := stack.NewEvalCtx(sm, globals)
 
 	logger.Trace().Msg("generating HCL code.")
 

--- a/hcl/hcl.go
+++ b/hcl/hcl.go
@@ -255,6 +255,14 @@ func NewConfig(dir string) (Config, error) {
 	}, nil
 }
 
+// HasRunEnv returns true if the config has a terramate.config.run.env block defined
+func (c Config) HasRunEnv() bool {
+	return c.Terramate != nil &&
+		c.Terramate.Config != nil &&
+		c.Terramate.Config.Run != nil &&
+		c.Terramate.Config.Run.Env != nil
+}
+
 // AbsDir returns the absolute path of the configuration directory.
 func (c Config) AbsDir() string { return c.absdir }
 

--- a/run/env.go
+++ b/run/env.go
@@ -27,7 +27,7 @@ import (
 
 const (
 	// ErrParsingCfg indicates that an error happened while parsing configuration.
-	ErrParsingCfg errors.Kind = "parsing run env cfg"
+	ErrParsingCfg errors.Kind = "parsing terramate.config.run.env configuration"
 
 	// ErrLoadingGlobals indicates that an error happened while loading globals.
 	ErrLoadingGlobals errors.Kind = "loading globals to evaluate run env cfg"

--- a/run/env.go
+++ b/run/env.go
@@ -30,7 +30,7 @@ const (
 	ErrParsingCfg errors.Kind = "parsing terramate.config.run.env configuration"
 
 	// ErrLoadingGlobals indicates that an error happened while loading globals.
-	ErrLoadingGlobals errors.Kind = "loading globals to evaluate run env cfg"
+	ErrLoadingGlobals errors.Kind = "loading globals to evaluate terramate.config.run.env configuration"
 
 	// ErrEval indicates that an error happened while evaluating one of the
 	// terramate.config.run.env attributes.

--- a/run/env.go
+++ b/run/env.go
@@ -25,6 +25,9 @@ import (
 )
 
 const (
+	// ErrParsingCfg indicates that an error happened while parsing configuration.
+	ErrParsingCfg errors.Kind = "parsing configuration"
+
 	// ErrInvalidEnvVarType indicates the env var attribute
 	// has an invalid type.
 	ErrInvalidEnvVarType errors.Kind = "invalid env var type"
@@ -42,12 +45,18 @@ func Env(rootdir string, st stack.S) (EnvVars, error) {
 		Str("root", rootdir).
 		Stringer("stack", st).
 		Logger()
-	// TODO(katcipis): test parse error handling
+
 	logger.Trace().Msg("parsing configuration")
 
-	cfg, _ := hcl.ParseDir(rootdir)
+	cfg, err := hcl.ParseDir(rootdir)
+	if err != nil {
+		return nil, errors.E(ErrParsingCfg, err)
+	}
+
+	logger.Trace().Msg("checking if we have run env config")
 
 	if !cfg.HasRunEnv() {
+		logger.Trace().Msg("no run env config found, nothing to do")
 		return nil, nil
 	}
 

--- a/run/env.go
+++ b/run/env.go
@@ -38,7 +38,7 @@ const (
 
 	// ErrInvalidEnvVarType indicates the env var attribute
 	// has an invalid type.
-	ErrInvalidEnvVarType errors.Kind = "invalid env var type"
+	ErrInvalidEnvVarType errors.Kind = "invalid environment variable type"
 )
 
 // EnvVars represents a set of environment variables to be used

--- a/run/env.go
+++ b/run/env.go
@@ -24,6 +24,6 @@ type EnvVars map[string]string
 
 // Env will load environment variables to be exported when running any command
 // inside the given stack.
-func Env(rootdir string, stack stack.S) EnvVars {
-	return nil
+func Env(rootdir string, stack stack.S) (EnvVars, error) {
+	return nil, nil
 }

--- a/run/env.go
+++ b/run/env.go
@@ -83,7 +83,6 @@ func Env(rootdir string, st stack.S) (EnvVars, error) {
 			return nil, errors.E(ErrEval, err)
 		}
 
-		// TODO(katcipis): test eval failure wrong type
 		if val.Type() != cty.String {
 			return nil, errors.E(
 				ErrInvalidEnvVarType,

--- a/run/env.go
+++ b/run/env.go
@@ -24,6 +24,15 @@ type EnvVars map[string]string
 
 // Env will load environment variables to be exported when running any command
 // inside the given stack.
-func Env(rootdir string, stack stack.S) (EnvVars, error) {
+func Env(rootdir string, st stack.S) (EnvVars, error) {
+	//parser := hcl.NewTerramateParser(rootdir)
+	//// TODO(katcipis): test parse error handling
+	//cfg, _ := parser.Parse()
+
+	//// TODO(katcipis): test global load error handling
+	//globals, _ := stack.LoadGlobals(root, st)
+
+	//evalctx := stack.NewEvalCtx(stackpath, sm, globals)
+
 	return nil, nil
 }

--- a/run/env.go
+++ b/run/env.go
@@ -78,7 +78,7 @@ func Env(rootdir string, st stack.S) (EnvVars, error) {
 	}
 
 	evalctx := stack.NewEvalCtx(st, globals)
-	evalctx.SetEval(os.Environ())
+	evalctx.SetEnv(os.Environ())
 
 	envVars := EnvVars{}
 

--- a/run/env.go
+++ b/run/env.go
@@ -1,0 +1,29 @@
+// Copyright 2022 Mineiros GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package run
+
+import (
+	"github.com/mineiros-io/terramate/stack"
+)
+
+// EnvVars represents a set of environment variables to be used
+// when running commands
+type EnvVars map[string]string
+
+// Env will load environment variables to be exported when running any command
+// inside the given stack.
+func Env(rootdir string, stack stack.S) EnvVars {
+	return nil
+}

--- a/run/env_test.go
+++ b/run/env_test.go
@@ -160,6 +160,50 @@ func TestLoadRunEnv(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "fails on globals loading failure",
+			layout: []string{
+				"s:stack",
+			},
+			configs: []hclconfig{
+				{
+					path: "/",
+					add: runEnvCfg(
+						expr("env", "global.a"),
+					),
+				},
+				{
+					path: "/stack",
+					add: globals(
+						expr("a", "undefined"),
+					),
+				},
+			},
+			want: map[string]result{
+				"stack": {
+					err: errors.E(run.ErrLoadingGlobals),
+				},
+			},
+		},
+		{
+			name: "fails evaluating undefined attribute",
+			layout: []string{
+				"s:stack",
+			},
+			configs: []hclconfig{
+				{
+					path: "/",
+					add: runEnvCfg(
+						expr("env", "something.undefined"),
+					),
+				},
+			},
+			want: map[string]result{
+				"stack": {
+					err: errors.E(run.ErrEval),
+				},
+			},
+		},
 	}
 
 	for _, tcase := range tcases {

--- a/run/env_test.go
+++ b/run/env_test.go
@@ -1,0 +1,105 @@
+package run_test
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/mineiros-io/terramate/run"
+	"github.com/mineiros-io/terramate/test"
+	"github.com/mineiros-io/terramate/test/errors"
+	"github.com/mineiros-io/terramate/test/hclwrite"
+	"github.com/mineiros-io/terramate/test/sandbox"
+	"github.com/rs/zerolog"
+)
+
+func TestLoadRunEnv(t *testing.T) {
+
+	type (
+		hclconfig struct {
+			path string
+			add  fmt.Stringer
+		}
+		result struct {
+			env run.EnvVars
+			err error
+		}
+		testcase struct {
+			name    string
+			hostenv run.EnvVars
+			layout  []string
+			configs []hclconfig
+			want    map[string]result
+			wantErr error
+		}
+	)
+
+	expr := hclwrite.Expression
+	terramate := func(builders ...hclwrite.BlockBuilder) *hclwrite.Block {
+		return hclwrite.BuildBlock("terramate", builders...)
+	}
+	config := func(builders ...hclwrite.BlockBuilder) *hclwrite.Block {
+		return hclwrite.BuildBlock("config", builders...)
+	}
+	runblock := func(builders ...hclwrite.BlockBuilder) *hclwrite.Block {
+		return hclwrite.BuildBlock("run", builders...)
+	}
+	env := func(builders ...hclwrite.BlockBuilder) *hclwrite.Block {
+		return hclwrite.BuildBlock("env", builders...)
+	}
+	runEnvCfg := func(builders ...hclwrite.BlockBuilder) *hclwrite.Block {
+		return terramate(config(runblock(env(builders...))))
+	}
+
+	tcases := []testcase{
+		{
+			name: "single stack with env loaded from host env",
+			hostenv: run.EnvVars{
+				"TESTING_RUN_ENV_VAR": "666",
+			},
+			layout: []string{
+				"s:stack",
+			},
+			configs: []hclconfig{
+				{
+					path: "/",
+					add: runEnvCfg(
+						expr("test", "env.TESTING_RUN_ENV_VAR"),
+					),
+				},
+			},
+			want: map[string]result{
+				"stack": {
+					env: run.EnvVars{
+						"test": "666",
+					},
+				},
+			},
+		},
+	}
+
+	for _, tcase := range tcases {
+
+		t.Run(tcase.name, func(t *testing.T) {
+			s := sandbox.New(t)
+			s.BuildTree(tcase.layout)
+
+			for _, cfg := range tcase.configs {
+				path := filepath.Join(s.RootDir(), cfg.path)
+				test.AppendFile(t, path, "run_env_test_cfg.hcl", cfg.add.String())
+			}
+
+			for stackRelPath, wantres := range tcase.want {
+				stack := s.LoadStack(filepath.Join(s.RootDir(), stackRelPath))
+				gotvars, err := run.Env(s.RootDir(), stack)
+
+				errors.Assert(t, err, wantres.err)
+				test.AssertDiff(t, gotvars, wantres.env)
+			}
+		})
+	}
+}
+
+func init() {
+	zerolog.SetGlobalLevel(zerolog.Disabled)
+}

--- a/run/env_test.go
+++ b/run/env_test.go
@@ -1,3 +1,17 @@
+// Copyright 2022 Mineiros GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package run_test
 
 import (

--- a/run/env_test.go
+++ b/run/env_test.go
@@ -204,6 +204,25 @@ func TestLoadRunEnv(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "fails if attribute is not string",
+			layout: []string{
+				"s:stack",
+			},
+			configs: []hclconfig{
+				{
+					path: "/",
+					add: runEnvCfg(
+						expr("env", "[]"),
+					),
+				},
+			},
+			want: map[string]result{
+				"stack": {
+					err: errors.E(run.ErrInvalidEnvVarType),
+				},
+			},
+		},
 	}
 
 	for _, tcase := range tcases {

--- a/run/env_test.go
+++ b/run/env_test.go
@@ -40,7 +40,7 @@ func TestLoadRunEnv(t *testing.T) {
 		}
 		testcase struct {
 			name    string
-			hostenv run.EnvVars
+			hostenv map[string]string
 			layout  []string
 			configs []hclconfig
 			want    map[string]result
@@ -82,7 +82,7 @@ func TestLoadRunEnv(t *testing.T) {
 		},
 		{
 			name: "stacks with env loaded from host env and literals",
-			hostenv: run.EnvVars{
+			hostenv: map[string]string{
 				"TESTING_RUN_ENV_VAR": "666",
 			},
 			layout: []string{
@@ -101,14 +101,14 @@ func TestLoadRunEnv(t *testing.T) {
 			want: map[string]result{
 				"stacks/stack-1": {
 					env: run.EnvVars{
-						"testenv": "666",
-						"teststr": "plain string",
+						"testenv=666",
+						"teststr=plain string",
 					},
 				},
 				"stacks/stack-2": {
 					env: run.EnvVars{
-						"testenv": "666",
-						"teststr": "plain string",
+						"testenv=666",
+						"teststr=plain string",
 					},
 				},
 			},
@@ -143,14 +143,14 @@ func TestLoadRunEnv(t *testing.T) {
 			want: map[string]result{
 				"stacks/stack-1": {
 					env: run.EnvVars{
-						"env1": "stack-1 global",
-						"env2": "stack-1",
+						"env1=stack-1 global",
+						"env2=stack-1",
 					},
 				},
 				"stacks/stack-2": {
 					env: run.EnvVars{
-						"env1": "stack-2 global",
-						"env2": "stack-2",
+						"env1=stack-2 global",
+						"env2=stack-2",
 					},
 				},
 			},

--- a/run/env_test.go
+++ b/run/env_test.go
@@ -33,8 +33,6 @@ func TestLoadRunEnv(t *testing.T) {
 		}
 	)
 
-	t.Skip()
-
 	expr := hclwrite.Expression
 	str := hclwrite.String
 	terramate := func(builders ...hclwrite.BlockBuilder) *hclwrite.Block {
@@ -114,13 +112,13 @@ func TestLoadRunEnv(t *testing.T) {
 					),
 				},
 				{
-					path: "/stack-1",
+					path: "/stacks/stack-1",
 					add: globals(
 						str("env", "stack-1 global"),
 					),
 				},
 				{
-					path: "/stack-2",
+					path: "/stacks/stack-2",
 					add: globals(
 						str("env", "stack-2 global"),
 					),
@@ -151,7 +149,7 @@ func TestLoadRunEnv(t *testing.T) {
 
 			for _, cfg := range tcase.configs {
 				path := filepath.Join(s.RootDir(), cfg.path)
-				test.AppendFile(t, path, "run_env_test_cfg.hcl", cfg.add.String())
+				test.AppendFile(t, path, "run_env_test_cfg.tm", cfg.add.String())
 			}
 
 			for name, value := range tcase.hostenv {

--- a/stack/eval.go
+++ b/stack/eval.go
@@ -15,6 +15,8 @@
 package stack
 
 import (
+	"strings"
+
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/mineiros-io/terramate/hcl/eval"
@@ -42,6 +44,17 @@ func (e *EvalCtx) SetGlobals(g Globals) {
 // SetMetadata sets the given metadata on the stack evaluation context.
 func (e *EvalCtx) SetMetadata(sm Metadata) {
 	e.evalctx.SetNamespace("terramate", metaToCtyMap(sm))
+}
+
+// SetEval sets the given environment on the env namespace of the evaluation context.
+// environ must be on the same format as os.Environ().
+func (e *EvalCtx) SetEval(environ []string) {
+	env := map[string]cty.Value{}
+	for _, v := range environ {
+		parsed := strings.Split(v, "=")
+		env[parsed[0]] = cty.StringVal(parsed[1])
+	}
+	e.evalctx.SetNamespace("env", env)
 }
 
 // Eval will evaluate an expression given its context.

--- a/stack/eval.go
+++ b/stack/eval.go
@@ -46,9 +46,9 @@ func (e *EvalCtx) SetMetadata(sm Metadata) {
 	e.evalctx.SetNamespace("terramate", metaToCtyMap(sm))
 }
 
-// SetEval sets the given environment on the env namespace of the evaluation context.
+// SetEnv sets the given environment on the env namespace of the evaluation context.
 // environ must be on the same format as os.Environ().
-func (e *EvalCtx) SetEval(environ []string) {
+func (e *EvalCtx) SetEnv(environ []string) {
 	env := map[string]cty.Value{}
 	for _, v := range environ {
 		parsed := strings.Split(v, "=")

--- a/stack/eval.go
+++ b/stack/eval.go
@@ -27,8 +27,8 @@ type EvalCtx struct {
 }
 
 // NewEvalCtx creates a new stack evaluation context.
-func NewEvalCtx(stackpath string, sm Metadata, globals Globals) *EvalCtx {
-	evalctx := &EvalCtx{evalctx: eval.NewContext(stackpath)}
+func NewEvalCtx(sm Metadata, globals Globals) *EvalCtx {
+	evalctx := &EvalCtx{evalctx: eval.NewContext(sm.HostPath())}
 	evalctx.SetMetadata(sm)
 	evalctx.SetGlobals(globals)
 	return evalctx

--- a/stack/globals.go
+++ b/stack/globals.go
@@ -123,7 +123,7 @@ func (ge *globalsExpr) eval(rootdir string, meta Metadata) (Globals, error) {
 		attributes: map[string]cty.Value{},
 	}
 
-	evalctx := NewEvalCtx(filepath.Join(rootdir, meta.Path()), meta, globals)
+	evalctx := NewEvalCtx(meta, globals)
 
 	pendingExprsErrs := map[string]error{}
 	pendingExprs := ge.expressions

--- a/stack/stack.go
+++ b/stack/stack.go
@@ -62,6 +62,8 @@ type (
 	Metadata interface {
 		// Name of the stack.
 		Name() string
+		// HostPath is the absolute path of the stack on the host file system.
+		HostPath() string
 		// Path is the absolute path of the stack (relative to project root).
 		Path() string
 		// RelPath is the relative path of the from root.

--- a/test/sandbox/sandbox.go
+++ b/test/sandbox/sandbox.go
@@ -175,6 +175,16 @@ func (s S) Generate() generate.Report {
 	return report
 }
 
+// LoadStack load the stack given its relative path.
+func (s S) LoadStack(relpath string) stack.S {
+	s.t.Helper()
+
+	st, err := stack.Load(s.rootdir, relpath)
+	assert.NoError(s.t, err)
+
+	return st
+}
+
 // LoadStacks load all stacks from sandbox rootdir.
 func (s S) LoadStacks() []stack.S {
 	s.t.Helper()


### PR DESCRIPTION
This will be used on the next PR to implement the run with env feature. When we are iterating the ordered stacks this function will be used to load the stack env so we can pass it to the created command.