### PR TITLE
feat: add env support on terramate run

### DIFF
--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -935,6 +935,7 @@ func (c *cli) runOnStacks() {
 	logger.Info().Msg("Running on selected stacks")
 
 	err = run.Exec(
+		c.root(),
 		orderedStacks,
 		c.parsedArgs.Run.Command,
 		c.stdin,

--- a/cmd/terramate/e2etests/cmd/test/test.go
+++ b/cmd/terramate/e2etests/cmd/test/test.go
@@ -32,6 +32,8 @@ func main() {
 	switch os.Args[1] {
 	case "hang":
 		hang()
+	case "env":
+		env()
 	default:
 		log.Fatalf("unknown command %s", os.Args[1])
 	}
@@ -49,5 +51,12 @@ func hang() {
 
 	for s := range signals {
 		fmt.Println(s)
+	}
+}
+
+// env sends os.Environ() on stdout and exits.
+func env() {
+	for _, env := range os.Environ() {
+		fmt.Println(env)
 	}
 }

--- a/cmd/terramate/e2etests/cmd/test/test.go
+++ b/cmd/terramate/e2etests/cmd/test/test.go
@@ -1,0 +1,53 @@
+// Copyright 2022 Mineiros GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// test is a test command that implements behaviors that are
+// useful when testing terramate run features in a way that reduces
+// dependencies on the environment to run the tests.
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"os/signal"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		log.Fatal("test requires at least one subcommand argument")
+	}
+
+	switch os.Args[1] {
+	case "hang":
+		hang()
+	default:
+		log.Fatalf("unknown command %s", os.Args[1])
+	}
+}
+
+// hang will hang the process forever, ignoring any signals.
+// It is useful to validate forced kill behavior.
+// It will print "ready" when it starts to receive the signals.
+// It will print the name of the received signals, which may also be useful in testing.
+func hang() {
+	signals := make(chan os.Signal, 10)
+	signal.Notify(signals)
+
+	fmt.Println("ready")
+
+	for s := range signals {
+		fmt.Println(s)
+	}
+}

--- a/cmd/terramate/e2etests/exp_globals_test.go
+++ b/cmd/terramate/e2etests/exp_globals_test.go
@@ -18,7 +18,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/mineiros-io/terramate/config"
 	"github.com/mineiros-io/terramate/project"
 	"github.com/mineiros-io/terramate/test"
 	"github.com/mineiros-io/terramate/test/hclwrite"
@@ -39,13 +38,6 @@ func TestStacksGlobals(t *testing.T) {
 			want    runExpected
 		}
 	)
-
-	globals := func(builders ...hclwrite.BlockBuilder) *hclwrite.Block {
-		return hclwrite.BuildBlock("globals", builders...)
-	}
-	str := hclwrite.String
-	number := hclwrite.NumberInt
-	boolean := hclwrite.Boolean
 
 	tcases := []testcase{
 		{
@@ -239,7 +231,7 @@ stack "/stacks/stack-2":
 
 				for _, globalBlock := range tcase.globals {
 					path := filepath.Join(s.RootDir(), globalBlock.path)
-					test.AppendFile(t, path, config.DefaultFilename,
+					test.AppendFile(t, path, "globals.tm",
 						globalBlock.add.String())
 				}
 

--- a/cmd/terramate/e2etests/hclwrite_utils.go
+++ b/cmd/terramate/e2etests/hclwrite_utils.go
@@ -1,0 +1,31 @@
+package e2etest
+
+import "github.com/mineiros-io/terramate/test/hclwrite"
+
+var (
+	str     = hclwrite.String
+	number  = hclwrite.NumberInt
+	boolean = hclwrite.Boolean
+	labels  = hclwrite.Labels
+	expr    = hclwrite.Expression
+)
+
+func terramate(builders ...hclwrite.BlockBuilder) *hclwrite.Block {
+	return hclwrite.BuildBlock("terramate", builders...)
+}
+
+func config(builders ...hclwrite.BlockBuilder) *hclwrite.Block {
+	return hclwrite.BuildBlock("config", builders...)
+}
+
+func generateHCL(builders ...hclwrite.BlockBuilder) *hclwrite.Block {
+	return hclwrite.BuildBlock("generate_hcl", builders...)
+}
+
+func content(builders ...hclwrite.BlockBuilder) *hclwrite.Block {
+	return hclwrite.BuildBlock("content", builders...)
+}
+
+func globals(builders ...hclwrite.BlockBuilder) *hclwrite.Block {
+	return hclwrite.BuildBlock("globals", builders...)
+}

--- a/cmd/terramate/e2etests/hclwrite_utils.go
+++ b/cmd/terramate/e2etests/hclwrite_utils.go
@@ -1,3 +1,17 @@
+// Copyright 2022 Mineiros GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package e2etest
 
 import "github.com/mineiros-io/terramate/test/hclwrite"

--- a/cmd/terramate/e2etests/list_git_test.go
+++ b/cmd/terramate/e2etests/list_git_test.go
@@ -18,7 +18,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/mineiros-io/terramate/config"
 	"github.com/mineiros-io/terramate/test"
 	"github.com/mineiros-io/terramate/test/sandbox"
 )
@@ -67,7 +66,7 @@ func TestListDetectChangesInSubDirOfStackWithOtherConfigs(t *testing.T) {
 	subsubdir := subdir.CreateDir("dir")
 	subsubfile := subsubdir.CreateFile("something.sh", "# nothing")
 
-	subdir.CreateFile(config.DefaultFilename, `
+	subdir.CreateFile("config.tm", `
 terramate {
 	
 }	

--- a/cmd/terramate/e2etests/main_test.go
+++ b/cmd/terramate/e2etests/main_test.go
@@ -24,7 +24,11 @@ import (
 	"testing"
 )
 
+// terramateTestBin is the path to the terramate binary we compiled for test purposes
 var terramateTestBin string
+
+// testHelperBin is the path to the test binary we compiled for test purposes
+var testHelperBin string
 
 // The TestMain function creates a terramate binary for testing purposes and
 // deletes it after the tests have been run.
@@ -66,10 +70,33 @@ func setupAndRunTests(m *testing.M) (status int) {
 		return 1
 	}
 
+	testCmdPath := filepath.Join(packageDir, "cmd", "test")
+	testHelperBin, err = buildTestHelper(goBin, testCmdPath, binTmpDir)
+	if err != nil {
+		log.Printf("failed to setup e2e tests: %v", err)
+		return 1
+	}
+
 	return m.Run()
 }
 
-func buildTerramate(goBin string, projectRoot string, binDir string) (string, error) {
+func buildTestHelper(goBin, testCmdPath, binDir string) (string, error) {
+	outBinPath := filepath.Join(binDir, "test"+platExeSuffix())
+	cmd := exec.Command(
+		goBin,
+		"build",
+		"-o",
+		outBinPath,
+		testCmdPath,
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("failed to build test helper: %v (output: %s)", err, string(out))
+	}
+	return outBinPath, nil
+}
+
+func buildTerramate(goBin, projectRoot, binDir string) (string, error) {
 	// We need to build the same way it is built on our Makefile + release process
 	// Invoking make here would assume that someone running go test ./... have
 	// make installed, so we are keeping the duplication to reduce deps when running tests.

--- a/cmd/terramate/e2etests/run_test.go
+++ b/cmd/terramate/e2etests/run_test.go
@@ -1361,4 +1361,17 @@ func TestRunWitCustomizedEnv(t *testing.T) {
 	sort.Strings(wantenv)
 
 	test.AssertDiff(t, gotenv, wantenv)
+
+	t.Run("ExperimentalRunEnv", func(t *testing.T) {
+		want := fmt.Sprintf(`
+stack "/stack":
+	FROM_ENV=%s
+	FROM_GLOBAL=%s
+	FROM_META=%s
+	TERRAMATE_OVERRIDDEN=%s
+`, exportedTerramateTest, stackGlobal, stackName, newTerramateOverriden)
+
+		assertRunResult(t, tm.run("experimental", "run-env"), runExpected{
+			Stdout: want})
+	})
 }

--- a/cmd/terramate/e2etests/run_test.go
+++ b/cmd/terramate/e2etests/run_test.go
@@ -1317,7 +1317,7 @@ func TestRunWitCustomizedEnv(t *testing.T) {
 						expr("FROM_META", "terramate.stack.name"),
 						expr("FROM_GLOBAL", "global.env"),
 						expr("FROM_ENV", "env.TERRAMATE_TEST"),
-						str("TERRAMATE_OVERRIDEN", newTerramateOverriden),
+						str("TERRAMATE_OVERRIDDEN", newTerramateOverriden),
 					),
 				),
 			),
@@ -1333,7 +1333,7 @@ func TestRunWitCustomizedEnv(t *testing.T) {
 
 	hostenv := os.Environ()
 	clienv := append(hostenv,
-		"TERRAMATE_OVERRIDEN=oldValue",
+		"TERRAMATE_OVERRIDDEN=oldValue",
 		fmt.Sprintf("TERRAMATE_TEST=%s", exportedTerramateTest),
 	)
 
@@ -1353,7 +1353,7 @@ func TestRunWitCustomizedEnv(t *testing.T) {
 		fmt.Sprintf("FROM_GLOBAL=%s", stackGlobal),
 		fmt.Sprintf("FROM_ENV=%s", exportedTerramateTest),
 		fmt.Sprintf("TERRAMATE_TEST=%s", exportedTerramateTest),
-		fmt.Sprintf("TERRAMATE_OVERRIDEN=%s", newTerramateOverriden),
+		fmt.Sprintf("TERRAMATE_OVERRIDDEN=%s", newTerramateOverriden),
 	)
 	gotenv := strings.Split(strings.Trim(res.Stdout, "\n"), "\n")
 

--- a/cmd/terramate/e2etests/runner_test.go
+++ b/cmd/terramate/e2etests/runner_test.go
@@ -30,6 +30,7 @@ type tmcli struct {
 	t        *testing.T
 	chdir    string
 	loglevel string
+	env      []string
 }
 
 type runResult struct {
@@ -96,6 +97,7 @@ func (tm tmcli) run(args ...string) runResult {
 	cmd.Stdout = stdout
 	cmd.Stderr = stderr
 	cmd.Stdin = stdin
+	cmd.Env = tm.env
 
 	_ = cmd.Run()
 

--- a/cmd/terramate/e2etests/version_check_test.go
+++ b/cmd/terramate/e2etests/version_check_test.go
@@ -21,7 +21,7 @@ import (
 
 	tfversion "github.com/hashicorp/go-version"
 	"github.com/madlambda/spells/assert"
-	"github.com/mineiros-io/terramate"
+	tm "github.com/mineiros-io/terramate"
 	"github.com/mineiros-io/terramate/test/sandbox"
 )
 
@@ -67,7 +67,7 @@ func TestVersionCheck(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			assertRunResult(t, run(t, checkedCmd, invalidVersion), runExpected{
 				Status:      1,
-				StderrRegex: string(terramate.ErrVersion),
+				StderrRegex: string(tm.ErrVersion),
 			})
 		})
 	}
@@ -85,7 +85,7 @@ func TestVersionCheck(t *testing.T) {
 	for _, cmd := range cmds {
 		name := fmt.Sprintf("%s works with valid version", cmd)
 		t.Run(name, func(t *testing.T) {
-			assertRunResult(t, run(t, cmd, terramate.Version()), runExpected{
+			assertRunResult(t, run(t, cmd, tm.Version()), runExpected{
 				Status:       0,
 				IgnoreStdout: true,
 			})
@@ -96,7 +96,7 @@ func TestVersionCheck(t *testing.T) {
 func TestProvidesCorrectVersion(t *testing.T) {
 	s := sandbox.New(t)
 	cli := newCLI(t, s.RootDir())
-	want := terramate.Version() + "\n"
+	want := tm.Version() + "\n"
 
 	assertRunResult(t, cli.run("version"), runExpected{
 		Status: 0,
@@ -109,6 +109,6 @@ func TestProvidesCorrectVersion(t *testing.T) {
 }
 
 func TestTerramateHasValidSemver(t *testing.T) {
-	_, err := tfversion.NewSemver(terramate.Version())
+	_, err := tfversion.NewSemver(tm.Version())
 	assert.NoError(t, err, "terramate VERSION file has invalid version")
 }

--- a/run/env.go
+++ b/run/env.go
@@ -46,10 +46,10 @@ const (
 // on os.Environ and can be used to set env on exec.Cmd.
 type EnvVars []string
 
-// Env will load environment variables to be exported when running any command
+// LoadEnv will load environment variables to be exported when running any command
 // inside the given stack. The order of the env vars is guaranteed to be the same
 // and is ordered lexicographically.
-func Env(rootdir string, st stack.S) (EnvVars, error) {
+func LoadEnv(rootdir string, st stack.S) (EnvVars, error) {
 	logger := log.With().
 		Str("action", "run.Env()").
 		Str("root", rootdir).

--- a/run/env_test.go
+++ b/run/env_test.go
@@ -256,7 +256,7 @@ func TestLoadRunEnv(t *testing.T) {
 
 			for stackRelPath, wantres := range tcase.want {
 				stack := s.LoadStack(filepath.Join(s.RootDir(), stackRelPath))
-				gotvars, err := run.Env(s.RootDir(), stack)
+				gotvars, err := run.LoadEnv(s.RootDir(), stack)
 
 				errorstest.Assert(t, err, wantres.err)
 				test.AssertDiff(t, gotvars, wantres.env)

--- a/run/exec.go
+++ b/run/exec.go
@@ -57,7 +57,7 @@ func Exec(
 	logger.Trace().Msg("loading stacks run environment variables")
 
 	for _, stack := range stacks {
-		env, err := Env(rootdir, stack)
+		env, err := LoadEnv(rootdir, stack)
 		errs.Append(err)
 		stackEnvs[stack.Path()] = env
 	}


### PR DESCRIPTION
Introduces support to manipulating the environment variables when running commands with `terramate run` as specified [here](https://github.com/mineiros-io/terramate/blob/main/docs/project-config.md#terramateconfigrunenv). 

It also introduces a `terramate experimental run-env` that should help debugging env definitions for stacks (only shows env manipulated directly, not like `env`).

Example:

```sh
#!/bin/bash

set -o errexit
set -o pipefail
set -o nounset

workdir=$(mktemp -d)
cd "${workdir}"

echo "workdir: ${workdir}"

cat >terramate.tm <<EOL
terramate {
    config {
      run {
        env {
          NEW_ENV_VAR="test"
          HOME="newhome"
        }
      }
    }
}
EOL

mkdir stack
terramate experimental init-stack stack
echo
terramate experimental run-env
echo
terramate run -- env
```