### PR TITLE
feat: add terramate.root.path.fs.basename/absolute

### DIFF
--- a/generate/generate_file_test.go
+++ b/generate/generate_file_test.go
@@ -302,7 +302,7 @@ func TestGenerateFileRemoveFilesWhenConditionIsFalse(t *testing.T) {
 	assertFileDontExist(filename)
 }
 
-func TestGenerateFileTerramateMetadata(t *testing.T) {
+func TestGenerateFileTerramateRootMetadata(t *testing.T) {
 	// We need to know the sandbox abspath to test terramate.root properly
 	const generatedFile = "file.hcl"
 
@@ -312,7 +312,7 @@ func TestGenerateFileTerramateMetadata(t *testing.T) {
 		hcldoc(
 			generateFile(
 				labels(generatedFile),
-				expr("content", "terramate.root.path.absolute"),
+				expr("content", `"${terramate.root.path.fs.absolute}-${terramate.root.path.fs.basename}"`),
 			),
 		).String(),
 	)
@@ -327,7 +327,7 @@ func TestGenerateFileTerramateMetadata(t *testing.T) {
 		},
 	})
 
-	want := s.RootDir()
+	want := s.RootDir() + "-" + filepath.Base(s.RootDir())
 	got := stackEntry.ReadFile(generatedFile)
 
 	assert.EqualStrings(t, want, got)

--- a/generate/generate_hcl_test.go
+++ b/generate/generate_hcl_test.go
@@ -874,7 +874,7 @@ func TestGenerateHCLCleanupOldFiles(t *testing.T) {
 	assertEqualStringList(t, got, []string{})
 }
 
-func TestGenerateHCLTerramateMetadata(t *testing.T) {
+func TestGenerateHCLTerramateRootMetadata(t *testing.T) {
 	// We need to know the sandbox abspath to test terramate.root properly
 	const generatedFile = "file.hcl"
 
@@ -885,7 +885,8 @@ func TestGenerateHCLTerramateMetadata(t *testing.T) {
 			generateHCL(
 				labels(generatedFile),
 				content(
-					expr("terramate_root", "terramate.root.path.absolute"),
+					expr("terramate_root_path_abs", "terramate.root.path.fs.absolute"),
+					expr("terramate_root_path_basename", "terramate.root.path.fs.basename"),
 				),
 			),
 		).String(),
@@ -902,7 +903,8 @@ func TestGenerateHCLTerramateMetadata(t *testing.T) {
 	})
 
 	want := hcldoc(
-		str("terramate_root", s.RootDir()),
+		str("terramate_root_path_abs", s.RootDir()),
+		str("terramate_root_path_basename", filepath.Base(s.RootDir())),
 	).String()
 	got := stackEntry.ReadFile(generatedFile)
 

--- a/stack/eval.go
+++ b/stack/eval.go
@@ -15,6 +15,7 @@
 package stack
 
 import (
+	"path/filepath"
 	"strings"
 
 	"github.com/hashicorp/hcl/v2/hclsyntax"
@@ -84,8 +85,12 @@ func metaToCtyMap(rootdir string, m Metadata) map[string]cty.Value {
 		"description": cty.StringVal(m.Desc()),
 		"path":        stackpath,
 	})
-	rootpath := eval.FromMapToObject(map[string]cty.Value{
+	rootfs := eval.FromMapToObject(map[string]cty.Value{
 		"absolute": cty.StringVal(rootdir),
+		"basename": cty.StringVal(filepath.Base(rootdir)),
+	})
+	rootpath := eval.FromMapToObject(map[string]cty.Value{
+		"fs": rootfs,
 	})
 	root := eval.FromMapToObject(map[string]cty.Value{
 		"path": rootpath,


### PR DESCRIPTION
Renames terramate root path metadata + adds basename. In the end we have the following metadata available:

- `terramate.root.path.fs.absolute` : The absolute path of the root of the project.
- `terramate.root.path.fs.basename` : The basename of the root project path, which is the project name.