### PR TITLE
chore: refactor hcl parser

### DIFF
--- a/generate/genfile/genfile.go
+++ b/generate/genfile/genfile.go
@@ -216,7 +216,7 @@ func loadGenFileBlocks(rootdir string, cfgdir string) ([]genFileBlock, error) {
 		return nil, nil
 	}
 
-	genFileBlocks, err := hcl.ParseGenerateFileBlocks(cfgdir)
+	blocks, err := hcl.ParseGenerateFileBlocks(cfgdir)
 	if err != nil {
 		return nil, errors.E(err, "cfgdir %q", cfgdir)
 	}
@@ -224,18 +224,16 @@ func loadGenFileBlocks(rootdir string, cfgdir string) ([]genFileBlock, error) {
 	logger.Trace().Msg("Parsed generate_file blocks.")
 	res := []genFileBlock{}
 
-	for filename, blocks := range genFileBlocks {
-		for _, block := range blocks {
-			origin := project.PrjAbsPath(rootdir, filename)
+	for _, block := range blocks {
+		origin := project.PrjAbsPath(rootdir, block.Origin)
 
-			res = append(res, genFileBlock{
-				label:  block.Label,
-				origin: origin,
-				block:  block,
-			})
+		res = append(res, genFileBlock{
+			label:  block.Label,
+			origin: origin,
+			block:  block,
+		})
 
-			logger.Trace().Msg("loaded generate_file block.")
-		}
+		logger.Trace().Msg("loaded generate_file block.")
 	}
 
 	parentCfgDir := filepath.Dir(cfgdir)

--- a/generate/genhcl/genhcl.go
+++ b/generate/genhcl/genhcl.go
@@ -219,7 +219,7 @@ func loadGenHCLBlocks(rootdir string, cfgdir string) ([]loadedHCL, error) {
 		return nil, nil
 	}
 
-	hclblocks, err := hcl.ParseGenerateHCLBlocks(cfgdir)
+	blocks, err := hcl.ParseGenerateHCLBlocks(cfgdir)
 	if err != nil {
 		return nil, errors.E(ErrParsing, err, "cfgdir %q", cfgdir)
 	}
@@ -227,20 +227,18 @@ func loadGenHCLBlocks(rootdir string, cfgdir string) ([]loadedHCL, error) {
 	logger.Trace().Msg("Parsed generate_hcl blocks.")
 	res := []loadedHCL{}
 
-	for filename, genhclBlocks := range hclblocks {
-		for _, genhclBlock := range genhclBlocks {
-			name := genhclBlock.Label
-			origin := project.PrjAbsPath(rootdir, filename)
+	for _, genhclBlock := range blocks {
+		name := genhclBlock.Label
+		origin := project.PrjAbsPath(rootdir, genhclBlock.Origin)
 
-			res = append(res, loadedHCL{
-				name:      name,
-				origin:    origin,
-				block:     genhclBlock.Content,
-				condition: genhclBlock.Condition,
-			})
+		res = append(res, loadedHCL{
+			name:      name,
+			origin:    origin,
+			block:     genhclBlock.Content,
+			condition: genhclBlock.Condition,
+		})
 
-			logger.Trace().Msg("loaded generate_hcl block.")
-		}
+		logger.Trace().Msg("loaded generate_hcl block.")
 	}
 
 	parentCfgDir := filepath.Dir(cfgdir)

--- a/hcl/attribute.go
+++ b/hcl/attribute.go
@@ -14,7 +14,11 @@
 
 package hcl
 
-import "github.com/hashicorp/hcl/v2/hclsyntax"
+import (
+	"sort"
+
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+)
 
 // Attribute represents a parsed attribute.
 type Attribute struct {
@@ -24,7 +28,7 @@ type Attribute struct {
 
 // Attributes represents multiple parsed attributes.
 // The attributes can be sorted lexicographically by their name.
-type Attributes []Attribute
+type Attributes map[string]Attribute
 
 // NewAttribute creates a new attribute given a parsed attribute and its origin.
 func NewAttribute(origin string, val *hclsyntax.Attribute) Attribute {
@@ -42,17 +46,28 @@ func (a Attribute) Value() *hclsyntax.Attribute {
 	return a.val
 }
 
+func (a Attributes) SortedList() AttributeSlice {
+	var attrs AttributeSlice
+	for _, val := range a {
+		attrs = append(attrs, val)
+	}
+	sort.Sort(attrs)
+	return attrs
+}
+
+type AttributeSlice []Attribute
+
 // Len returns the size of the attributes slice.
-func (a Attributes) Len() int {
+func (a AttributeSlice) Len() int {
 	return len(a)
 }
 
 // Less returns true if i < j, false otherwise.
-func (a Attributes) Less(i, j int) bool {
+func (a AttributeSlice) Less(i, j int) bool {
 	return a[i].val.Name < a[j].val.Name
 }
 
 // Swap swaps i and j.
-func (a Attributes) Swap(i, j int) {
+func (a AttributeSlice) Swap(i, j int) {
 	a[i], a[j] = a[j], a[i]
 }

--- a/hcl/attribute.go
+++ b/hcl/attribute.go
@@ -23,7 +23,7 @@ import (
 // Attribute represents a parsed attribute.
 type Attribute struct {
 	origin string
-	val    *hclsyntax.Attribute
+	*hclsyntax.Attribute
 }
 
 // Attributes represents multiple parsed attributes.
@@ -32,18 +32,16 @@ type Attributes map[string]Attribute
 
 // NewAttribute creates a new attribute given a parsed attribute and its origin.
 func NewAttribute(origin string, val *hclsyntax.Attribute) Attribute {
-	return Attribute{origin: origin, val: val}
+	return Attribute{
+		origin:    origin,
+		Attribute: val,
+	}
 }
 
 // Origin is the path of the file from where the attribute was parsed
 // It is always an absolute path.
 func (a Attribute) Origin() string {
 	return a.origin
-}
-
-// Value is the actual parsed attribute.
-func (a Attribute) Value() *hclsyntax.Attribute {
-	return a.val
 }
 
 func (a Attributes) SortedList() AttributeSlice {
@@ -64,7 +62,7 @@ func (a AttributeSlice) Len() int {
 
 // Less returns true if i < j, false otherwise.
 func (a AttributeSlice) Less(i, j int) bool {
-	return a[i].val.Name < a[j].val.Name
+	return a[i].Name < a[j].Name
 }
 
 // Swap swaps i and j.

--- a/hcl/block.go
+++ b/hcl/block.go
@@ -1,3 +1,17 @@
+// Copyright 2022 Mineiros GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package hcl
 
 import "github.com/hashicorp/hcl/v2/hclsyntax"

--- a/hcl/block.go
+++ b/hcl/block.go
@@ -1,0 +1,25 @@
+package hcl
+
+import "github.com/hashicorp/hcl/v2/hclsyntax"
+
+type Block struct {
+	Origin     string
+	Attributes Attributes
+	Blocks     []*Block
+
+	*hclsyntax.Block
+}
+
+type Blocks []*Block
+
+func NewBlock(origin string, block *hclsyntax.Block) *Block {
+	attrs := make(Attributes)
+	for name, val := range block.Body.Attributes {
+		attrs[name] = NewAttribute(origin, val)
+	}
+	return &Block{
+		Origin:     origin,
+		Attributes: attrs,
+		Block:      block,
+	}
+}

--- a/hcl/fmt.go
+++ b/hcl/fmt.go
@@ -19,7 +19,7 @@ import (
 	"os"
 	"path/filepath"
 
-	hhcl "github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/mineiros-io/terramate/errors"
@@ -38,7 +38,7 @@ type FormatResult struct {
 //
 // It returns an error if the given source is invalid HCL.
 func FormatMultiline(src, filename string) (string, error) {
-	parsed, diags := hclwrite.ParseConfig([]byte(src), filename, hhcl.InitialPos)
+	parsed, diags := hclwrite.ParseConfig([]byte(src), filename, hcl.InitialPos)
 	if diags.HasErrors() {
 		return "", errors.E(ErrHCLSyntax, diags)
 	}
@@ -49,7 +49,7 @@ func FormatMultiline(src, filename string) (string, error) {
 // Format will format the given source code using hcl.Format.
 // It returns an error if the given source is invalid HCL.
 func Format(src, filename string) (string, error) {
-	parsed, diags := hclwrite.ParseConfig([]byte(src), filename, hhcl.InitialPos)
+	parsed, diags := hclwrite.ParseConfig([]byte(src), filename, hcl.InitialPos)
 	if diags.HasErrors() {
 		return "", errors.E(ErrHCLSyntax, diags)
 	}

--- a/hcl/fmt.go
+++ b/hcl/fmt.go
@@ -19,7 +19,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/hashicorp/hcl/v2"
+	hhcl "github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/mineiros-io/terramate/errors"
@@ -38,7 +38,7 @@ type FormatResult struct {
 //
 // It returns an error if the given source is invalid HCL.
 func FormatMultiline(src, filename string) (string, error) {
-	parsed, diags := hclwrite.ParseConfig([]byte(src), filename, hcl.InitialPos)
+	parsed, diags := hclwrite.ParseConfig([]byte(src), filename, hhcl.InitialPos)
 	if diags.HasErrors() {
 		return "", errors.E(ErrHCLSyntax, diags)
 	}
@@ -49,7 +49,7 @@ func FormatMultiline(src, filename string) (string, error) {
 // Format will format the given source code using hcl.Format.
 // It returns an error if the given source is invalid HCL.
 func Format(src, filename string) (string, error) {
-	parsed, diags := hclwrite.ParseConfig([]byte(src), filename, hcl.InitialPos)
+	parsed, diags := hclwrite.ParseConfig([]byte(src), filename, hhcl.InitialPos)
 	if diags.HasErrors() {
 		return "", errors.E(ErrHCLSyntax, diags)
 	}

--- a/hcl/hcl.go
+++ b/hcl/hcl.go
@@ -1217,13 +1217,7 @@ func parseUnmergedBlocks(dir, blocktype string, validate blockValidator) (Blocks
 		return nil, errors.E("adding files to parser", err)
 	}
 
-	err = parser.parseSyntax()
-	if err != nil {
-		return nil, err
-	}
-
-	// TODO(i4k): improve API
-	err = parser.mergeConfig()
+	err = parser.MinimalParse()
 	if err != nil {
 		return nil, err
 	}
@@ -1231,7 +1225,6 @@ func parseUnmergedBlocks(dir, blocktype string, validate blockValidator) (Blocks
 	logger.Trace().Msg("Validating and filtering blocks")
 
 	blocks := filterBlocksByType(blocktype, parser.Blocks)
-
 	for _, block := range blocks {
 		if err := validate(block); err != nil {
 			return nil, errors.E(err, "validation failed")

--- a/hcl/hcl.go
+++ b/hcl/hcl.go
@@ -20,7 +20,7 @@ import (
 	"sort"
 	"strings"
 
-	hhcl "github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclparse"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/hashicorp/hcl/v2/hclwrite"
@@ -452,7 +452,7 @@ func ParseModules(path string) ([]Module, error) {
 		}
 		if !ok {
 			errs.Append(errors.E(ErrTerraformSchema,
-				hhcl.RangeBetween(block.OpenBraceRange, block.CloseBraceRange),
+				hcl.RangeBetween(block.OpenBraceRange, block.CloseBraceRange),
 				"module must have a \"source\" attribute",
 			))
 		}
@@ -563,14 +563,14 @@ func validateGenerateHCLBlock(block *Block) error {
 			len(block.Body.Blocks)))
 	}
 
-	schema := &hhcl.BodySchema{
-		Attributes: []hhcl.AttributeSchema{
+	schema := &hcl.BodySchema{
+		Attributes: []hcl.AttributeSchema{
 			{
 				Name:     "condition",
 				Required: false,
 			},
 		},
-		Blocks: []hhcl.BlockHeaderSchema{
+		Blocks: []hcl.BlockHeaderSchema{
 			{
 				Type:       "content",
 				LabelNames: []string{},
@@ -596,8 +596,8 @@ func validateGenerateFileBlock(block *Block) error {
 		errs.Append(errors.E(ErrTerramateSchema, block.OpenBraceRange,
 			"generate_file label can't be empty"))
 	}
-	schema := &hhcl.BodySchema{
-		Attributes: []hhcl.AttributeSchema{
+	schema := &hcl.BodySchema{
+		Attributes: []hcl.AttributeSchema{
 			{
 				Name:     "content",
 				Required: true,

--- a/hcl/hcl_cfg_run_test.go
+++ b/hcl/hcl_cfg_run_test.go
@@ -43,10 +43,10 @@ func TestHCLParserConfigRun(t *testing.T) {
 		}
 
 		body := res.Body.(*hclsyntax.Body)
-		attrs := make(hcl.Attributes, 0, len(body.Attributes))
+		attrs := make(hcl.Attributes)
 
-		for _, attr := range body.Attributes {
-			attrs = append(attrs, hcl.NewAttribute(filepath, attr))
+		for name, attr := range body.Attributes {
+			attrs[name] = hcl.NewAttribute(filepath, attr)
 		}
 
 		return hcl.Config{
@@ -437,8 +437,8 @@ func TestHCLParserConfigRun(t *testing.T) {
 				},
 			},
 			want: want{
-				errs: []error{errors.E(hcl.ErrTerramateSchema,
-					mkrange("cfg.tm", start(9, 15, 147), end(9, 31, 163)))},
+				errs: []error{errors.E(hcl.ErrHCLSyntax,
+					mkrange("cfg.tm", start(9, 15, 147), end(9, 21, 153)))},
 			},
 		},
 		{
@@ -489,11 +489,11 @@ func TestHCLParserConfigRun(t *testing.T) {
 			},
 			want: want{
 				errs: []error{
-					errors.E(hcl.ErrTerramateSchema,
-						mkrange("cfg2.tm", start(6, 15, 84), end(6, 31, 100)),
+					errors.E(hcl.ErrHCLSyntax,
+						mkrange("cfg.tm", start(6, 15, 84), end(6, 21, 90)),
 					),
-					errors.E(hcl.ErrTerramateSchema,
-						mkrange("cfg3.tm", start(6, 15, 84), end(6, 31, 100)),
+					errors.E(hcl.ErrHCLSyntax,
+						mkrange("cfg3.tm", start(6, 15, 84), end(6, 21, 90)),
 					),
 				},
 			},

--- a/hcl/hcl_test.go
+++ b/hcl/hcl_test.go
@@ -1177,7 +1177,7 @@ func TestHCLParserMultipleErrors(t *testing.T) {
 					body: `terramate {
 						config {
 							git {
-								default_remote = "test"
+								default_branch = "test"
 							}
 						}
 					}`,
@@ -1186,9 +1186,9 @@ func TestHCLParserMultipleErrors(t *testing.T) {
 			want: want{
 				errs: []error{
 					errors.E(hcl.ErrTerramateSchema,
-						mkrange("cfg2.tm", start(3, 8, 34), end(3, 13, 39))),
-					errors.E(hcl.ErrTerramateSchema,
 						mkrange("cfg1.tm", start(9, 6, 108), end(9, 12, 114))),
+					errors.E(hcl.ErrHCLSyntax,
+						mkrange("cfg2.tm", start(4, 9, 48), end(4, 23, 62))),
 				},
 			},
 		},
@@ -1319,7 +1319,7 @@ func TestHCLParserTerramateBlocksMerging(t *testing.T) {
 			},
 		},
 		{
-			name: "multiple files with terramate.config.git blocks fail",
+			name: "multiple files with conflicting terramate.config.git attributes fail",
 			input: []cfgfile{
 				{
 					filename: "git.tm",
@@ -1339,7 +1339,7 @@ func TestHCLParserTerramateBlocksMerging(t *testing.T) {
 						terramate {
 							config {
 								git {
-									default_remote = "upstream"
+									default_branch = "other"
 								}
 							}
 						}
@@ -1348,7 +1348,7 @@ func TestHCLParserTerramateBlocksMerging(t *testing.T) {
 			},
 			want: want{
 				errs: []error{
-					errors.E(hcl.ErrTerramateSchema),
+					errors.E(hcl.ErrHCLSyntax),
 				},
 			},
 		},

--- a/hcl/merged_block.go
+++ b/hcl/merged_block.go
@@ -1,0 +1,140 @@
+// Copyright 2022 Mineiros GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hcl
+
+import (
+	"sort"
+
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/mineiros-io/terramate/errors"
+)
+
+// MergedBlock represents a block that spans multiple files.
+type MergedBlock struct {
+	Type string
+
+	// Origins is the list of filenames that contributed to this block.
+	Origins []string
+
+	Attributes Attributes
+
+	// Raw is the list of original blocks that contributed to this block.
+	Raw hclsyntax.Blocks
+
+	SubBlocks map[string]*MergedBlock
+
+	// RawSubBlocks keep the original list of sub blocks.
+	RawSubBlocks map[string]hclsyntax.Blocks
+}
+
+type MergedBlocks map[string]*MergedBlock
+
+// NewMergedBlock creates a new MergedBlock of type typ.
+func NewMergedBlock(typ string) *MergedBlock {
+	return &MergedBlock{
+		Type:         typ,
+		Attributes:   make(Attributes),
+		SubBlocks:    make(map[string]*MergedBlock),
+		RawSubBlocks: make(map[string]hclsyntax.Blocks),
+	}
+}
+
+func (mb *MergedBlock) MergeBlock(fname string, other *hclsyntax.Block) error {
+	errs := errors.L()
+
+	// Currently all merged blocks do not support labels.
+	// This should not be handled here if changed in the future.
+	if len(other.Labels) > 0 {
+		errs.Append(errors.E(ErrTerramateSchema, other.LabelRanges,
+			"block type %q does not support labels"))
+	}
+
+	errs.Append(mb.mergeAttrs(fname, other.Body.Attributes))
+	errs.Append(mb.mergeSubBlocks(fname, other.Body.Blocks))
+	err := errs.AsError()
+	if err == nil {
+		mb.Raw = append(mb.Raw, other)
+	}
+	return err
+}
+
+func (mb *MergedBlock) mergeAttrs(origin string, other hclsyntax.Attributes) error {
+	for _, newval := range sortAttributes(other) {
+		if _, ok := mb.Attributes[newval.Name]; ok {
+			return errors.E(ErrHCLSyntax, newval.NameRange,
+				"attribute %q redeclared", newval.Name)
+		}
+		mb.Attributes[newval.Name] = NewAttribute(origin, newval)
+	}
+	return nil
+}
+
+func (mb *MergedBlock) mergeSubBlocks(origin string, other hclsyntax.Blocks) error {
+	errs := errors.L()
+	for _, newblock := range other {
+		var err error
+		if old, ok := mb.SubBlocks[newblock.Type]; ok {
+			err = old.MergeBlock(origin, newblock)
+		} else {
+			b := NewMergedBlock(newblock.Type)
+			err = b.MergeBlock(origin, newblock)
+			if err == nil {
+				mb.SubBlocks[newblock.Type] = b
+			}
+		}
+
+		if err == nil {
+			rawBlocks := mb.RawSubBlocks[newblock.Type]
+			rawBlocks = append(rawBlocks, newblock)
+			mb.RawSubBlocks[newblock.Type] = rawBlocks
+		}
+
+		errs.Append(err)
+	}
+	return errs.AsError()
+}
+
+func (mb *MergedBlock) validateSubBlocks(allowed ...string) error {
+	errs := errors.L()
+
+	var keys []string
+	for key := range mb.RawSubBlocks {
+		keys = append(keys, key)
+	}
+
+	sort.Strings(keys)
+
+	for _, key := range keys {
+		rawBlocks := mb.RawSubBlocks[key]
+
+		for _, rawblock := range rawBlocks {
+			found := false
+
+			for _, check := range allowed {
+				if rawblock.Type == check {
+					found = true
+				}
+			}
+
+			if !found {
+				errs.Append(errors.E(ErrTerramateSchema,
+					rawblock.DefRange(), "unrecognized block %q",
+					rawblock.Type))
+			}
+		}
+	}
+
+	return errs.AsError()
+}

--- a/run/env.go
+++ b/run/env.go
@@ -83,18 +83,17 @@ func LoadEnv(rootdir string, st stack.S) (EnvVars, error) {
 
 	attrs := cfg.Terramate.Config.Run.Env.Attributes.SortedList()
 
-	for _, attribute := range attrs {
-		hclattr := attribute.Value()
+	for _, attr := range attrs {
 		logger = logger.With().
-			Str("attribute", hclattr.Name).
+			Str("attribute", attr.Name).
 			Logger()
 
 		logger.Trace().Msg("evaluating")
 
-		val, err := evalctx.Eval(hclattr.Expr)
+		val, err := evalctx.Eval(attr.Expr)
 		if err != nil {
-			return nil, errors.E(ErrEval, hclattr.NameRange,
-				err, "attribute origin %s", attribute.Origin())
+			return nil, errors.E(ErrEval, attr.NameRange,
+				err, "attribute origin %s", attr.Origin())
 		}
 
 		logger.Trace().Msg("checking evaluated value type")
@@ -102,13 +101,13 @@ func LoadEnv(rootdir string, st stack.S) (EnvVars, error) {
 		if val.Type() != cty.String {
 			return nil, errors.E(
 				ErrInvalidEnvVarType,
-				hclattr.NameRange,
+				attr.NameRange,
 				"attr has type %s but must be string, attribute origin %s",
 				val.Type().FriendlyName(),
-				attribute.Origin(),
+				attr.Origin(),
 			)
 		}
-		envVars = append(envVars, hclattr.Name+"="+val.AsString())
+		envVars = append(envVars, attr.Name+"="+val.AsString())
 
 		logger.Trace().Msg("env var loaded")
 	}

--- a/run/env.go
+++ b/run/env.go
@@ -16,7 +16,6 @@ package run
 
 import (
 	"os"
-	"sort"
 
 	"github.com/mineiros-io/terramate/errors"
 	"github.com/mineiros-io/terramate/hcl"
@@ -82,8 +81,7 @@ func LoadEnv(rootdir string, st stack.S) (EnvVars, error) {
 
 	envVars := EnvVars{}
 
-	attrs := cfg.Terramate.Config.Run.Env.Attributes
-	sort.Stable(attrs)
+	attrs := cfg.Terramate.Config.Run.Env.Attributes.SortedList()
 
 	for _, attribute := range attrs {
 		hclattr := attribute.Value()

--- a/stack/globals.go
+++ b/stack/globals.go
@@ -229,36 +229,34 @@ func loadStackGlobalsExprs(rootdir string, cfgdir string) (*globalsExpr, error) 
 		Str("cfgdir", cfgdir).
 		Logger()
 
-	logger.Debug().Msg("Parse globals blocks.")
-
-	blocks, err := hcl.ParseGlobalsBlocks(filepath.Join(rootdir, cfgdir))
-	if err != nil {
-		return nil, errors.E("parsing globals block", err)
-	}
-
 	globals := newGlobalsExpr()
 
-	logger.Trace().Msg("Range over blocks.")
+	logger.Debug().Msg("Parse globals blocks.")
 
-	for filename, fileblocks := range blocks {
-		logger.Trace().Msg("Range over block attributes.")
+	absdir := filepath.Join(rootdir, cfgdir)
+	p := hcl.NewTerramateParser(absdir)
+	err := p.AddDir(absdir)
+	if err != nil {
+		return nil, errors.E("adding files to parser", err)
+	}
 
-		for _, fileblock := range fileblocks {
-			for name, attr := range fileblock.Body.Attributes {
-				if globals.has(name) {
-					return nil, errors.E(
-						ErrGlobalRedefined,
-						"%q redefined in %q", name, filename,
-					)
-				}
+	err = p.MinimalParse()
+	if err != nil {
+		return nil, errors.E("parsing config", err)
+	}
 
-				logger.Trace().Msg("Add attribute to globals.")
+	globalsBlock, ok := p.MergedBlocks["globals"]
+	if ok {
+		logger.Trace().Msg("Range over attributes.")
 
-				globals.add(name, expression{
-					origin: project.PrjAbsPath(rootdir, filename),
-					value:  attr.Expr,
-				})
-			}
+		for _, attr := range globalsBlock.Attributes.SortedList() {
+			logger.Trace().Msg("Add attribute to globals.")
+
+			attrVal := attr.Value()
+			globals.add(attrVal.Name, expression{
+				origin: project.PrjAbsPath(rootdir, attr.Origin()),
+				value:  attrVal.Expr,
+			})
 		}
 	}
 

--- a/stack/globals.go
+++ b/stack/globals.go
@@ -252,10 +252,9 @@ func loadStackGlobalsExprs(rootdir string, cfgdir string) (*globalsExpr, error) 
 		for _, attr := range globalsBlock.Attributes.SortedList() {
 			logger.Trace().Msg("Add attribute to globals.")
 
-			attrVal := attr.Value()
-			globals.add(attrVal.Name, expression{
+			globals.add(attr.Name, expression{
 				origin: project.PrjAbsPath(rootdir, attr.Origin()),
-				value:  attrVal.Expr,
+				value:  attr.Expr,
 			})
 		}
 	}

--- a/stack/globals_test.go
+++ b/stack/globals_test.go
@@ -1063,7 +1063,7 @@ func TestLoadGlobals(t *testing.T) {
 					add:      globals(str("a", "b")),
 				},
 			},
-			wantErr: errors.E(stack.ErrGlobalRedefined),
+			wantErr: errors.E(hcl.ErrHCLSyntax),
 		},
 	}
 

--- a/test/hcl.go
+++ b/test/hcl.go
@@ -16,7 +16,6 @@ package test
 
 import (
 	"os"
-	"sort"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -137,7 +136,7 @@ func hclFromAttributes(t *testing.T, attrs hcl.Attributes) string {
 	file := hclwrite.NewEmptyFile()
 	body := file.Body()
 
-	sort.Stable(attrs)
+	attrList := attrs.SortedList()
 
 	filesRead := map[string][]byte{}
 	readFile := func(filename string) []byte {
@@ -154,7 +153,7 @@ func hclFromAttributes(t *testing.T, attrs hcl.Attributes) string {
 		return file
 	}
 
-	for _, attr := range attrs {
+	for _, attr := range attrList {
 		tokens, err := eval.GetExpressionTokens(
 			readFile(attr.Origin()),
 			attr.Origin(),

--- a/test/hcl.go
+++ b/test/hcl.go
@@ -157,10 +157,10 @@ func hclFromAttributes(t *testing.T, attrs hcl.Attributes) string {
 		tokens, err := eval.GetExpressionTokens(
 			readFile(attr.Origin()),
 			attr.Origin(),
-			attr.Value().Expr,
+			attr.Expr,
 		)
 		assert.NoError(t, err)
-		body.SetAttributeRaw(attr.Value().Name, tokens)
+		body.SetAttributeRaw(attr.Name, tokens)
 	}
 
 	return string(file.Bytes())


### PR DESCRIPTION
Reuse the code for merging of attrs and blocks in the hcl APIs, so it makes easy to handle `imports` in a single place.