### PR TITLE
feat: add stack.watch attribute

### DIFF
--- a/cmd/terramate/e2etests/list_watch_test.go
+++ b/cmd/terramate/e2etests/list_watch_test.go
@@ -1,0 +1,50 @@
+// Copyright 2022 Mineiros GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2etest
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/mineiros-io/terramate/test/sandbox"
+)
+
+func TestListWatchFile(t *testing.T) {
+	s := sandbox.New(t)
+
+	extDir := s.RootEntry().CreateDir("external")
+	extFile := extDir.CreateFile("file.txt", "anything")
+
+	s.BuildTree([]string{
+		`s:stack:watch=["/external/file.txt"]`,
+	})
+
+	stack := s.LoadStack(filepath.Join(s.RootDir(), "stack"))
+
+	cli := newCLI(t, s.RootDir())
+
+	git := s.Git()
+	git.CommitAll("all")
+	git.Push("main")
+	git.CheckoutNew("change-the-external")
+
+	extFile.Write("changed")
+	git.CommitAll("external file changed")
+
+	want := runExpected{
+		Stdout: stack.RelPath() + "\n",
+	}
+	assertRunResult(t, cli.listChangedStacks(), want)
+}

--- a/hcl/hcl.go
+++ b/hcl/hcl.go
@@ -107,6 +107,9 @@ type Stack struct {
 	// Wants is a list of non-duplicated stack entries that must be selected
 	// whenever the current stack is selected.
 	Wants []string
+
+	// Watch is a list of files to be watched for changes.
+	Watch []string
 }
 
 // GenHCLBlock represents a parsed generate_hcl block.
@@ -953,6 +956,9 @@ func parseStack(stack *Stack, stackblock *ast.Block) error {
 
 		case "wants":
 			errs.Append(assignSet(attr.Name, &stack.Wants, attrVal))
+
+		case "watch":
+			errs.Append(assignSet(attr.Name, &stack.Watch, attrVal))
 
 		case "description":
 			logger.Trace().Msg("parsing stack description.")

--- a/hcl/hcl_test.go
+++ b/hcl/hcl_test.go
@@ -596,6 +596,7 @@ func TestHCLParserTerramateBlocksMerging(t *testing.T) {
 							after = ["after"]
 							before = ["before"]
 							wants = ["wants"]
+							watch = ["watch"]
 						}
 					`,
 				},
@@ -616,6 +617,7 @@ func TestHCLParserTerramateBlocksMerging(t *testing.T) {
 						After:       []string{"after"},
 						Before:      []string{"before"},
 						Wants:       []string{"wants"},
+						Watch:       []string{"watch"},
 					},
 				},
 			},

--- a/hcl/printer.go
+++ b/hcl/printer.go
@@ -66,6 +66,10 @@ func PrintConfig(w io.Writer, cfg Config) error {
 			stackBody.SetAttributeValue("wants", cty.SetVal(listToValue(stack.Wants)))
 		}
 
+		if len(stack.Watch) > 0 {
+			stackBody.SetAttributeValue("watch", cty.SetVal(listToValue(stack.Watch)))
+		}
+
 		if stack.Description != "" {
 			stackBody.SetAttributeValue("description", cty.StringVal(stack.Description))
 		}

--- a/stack/stack.go
+++ b/stack/stack.go
@@ -58,6 +58,9 @@ type (
 		// is selected.
 		wants []string
 
+		// watch is the list of files to be watched for changes.
+		watch []string
+
 		// changed tells if this is a changed stack.
 		changed bool
 	}
@@ -111,6 +114,7 @@ func New(root string, cfg hcl.Config) S {
 		after:         cfg.Stack.After,
 		before:        cfg.Stack.Before,
 		wants:         cfg.Stack.Wants,
+		watch:         toProjectPaths(root, cfg.AbsDir(), cfg.Stack.Watch),
 		hostpath:      cfg.AbsDir(),
 		path:          project.PrjAbsPath(root, cfg.AbsDir()),
 		relPathToRoot: rel,
@@ -142,6 +146,9 @@ func (s S) Before() []string { return s.before }
 // Wants specifies the list of wanted stacks.
 func (s S) Wants() []string { return s.wants }
 
+// Watch returns the list of watched files.
+func (s S) Watch() []string { return s.watch }
+
 // IsChanged tells if the stack is marked as changed.
 func (s S) IsChanged() bool { return s.changed }
 
@@ -170,6 +177,17 @@ func (s S) HostPath() string { return s.hostpath }
 func IsLeaf(root, dir string) (bool, error) {
 	l := NewLoader(root)
 	return l.IsLeafStack(dir)
+}
+
+func toProjectPaths(rootdir string, stackpath string, paths []string) []string {
+	var projectPaths []string
+	for _, path := range paths {
+		if !filepath.IsAbs(path) {
+			path = filepath.Join(stackpath, path)
+		}
+		projectPaths = append(projectPaths, project.PrjAbsPath(rootdir, path))
+	}
+	return projectPaths
 }
 
 // LookupParent checks parent stack of given dir.

--- a/test/sandbox/sandbox.go
+++ b/test/sandbox/sandbox.go
@@ -522,6 +522,8 @@ func buildTree(t *testing.T, rootdir string, layout []string) {
 				cfg.Stack.Before = parseListSpec(t, name, value)
 			case "wants":
 				cfg.Stack.Wants = parseListSpec(t, name, value)
+			case "watch":
+				cfg.Stack.Watch = parseListSpec(t, name, value)
 			case "description":
 				cfg.Stack.Description = value
 			default:


### PR DESCRIPTION
This PR introduces the `stack.watch` attribute which allows the user to specify a list of files that will mark the stack as changed if modified.