### PR TITLE
feat: add terramate create <path>

### DIFF
--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -74,6 +74,7 @@ type cliSpec struct {
 	DisableCheckGitUncommitted bool `optional:"true" default:"false" help:"Disable git check for uncommitted files"`
 
 	Create struct {
+		Path        string   `arg:"" name:"path" passthrough:"" help:"Path of the new stack"`
 		ID          string   `help:"ID of the stack, defaults to UUID"`
 		Name        string   `help:"Name of the stack, defaults to stack dir base name"`
 		Description string   `help:"Description of the stack, defaults to the stack name"`
@@ -337,7 +338,7 @@ func (c *cli) run() {
 	switch c.ctx.Command() {
 	case "fmt":
 		c.format()
-	case "create":
+	case "create <path>":
 		c.createStack()
 	case "list":
 		c.printStacks()
@@ -496,7 +497,19 @@ func (c *cli) createStack() {
 		Logger()
 
 	logger.Trace().Msg("creating stack")
-	// TODO(katcipis): implement stack creation
+
+	stackDir := filepath.Join(c.wd(), c.parsedArgs.Create.Path)
+	err := stack.Create(c.root(), stack.CreateCfg{
+		Dir:         stackDir,
+		ID:          c.parsedArgs.Create.ID,
+		Name:        c.parsedArgs.Create.Name,
+		Description: c.parsedArgs.Create.Description,
+		Imports:     c.parsedArgs.Create.Import,
+	})
+
+	if err != nil {
+		logger.Fatal().Err(err).Msg("creating stack")
+	}
 }
 
 func (c *cli) format() {

--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -510,6 +510,8 @@ func (c *cli) createStack() {
 	if err != nil {
 		logger.Fatal().Err(err).Msg("creating stack")
 	}
+
+	c.log("Created stack %s with success", c.parsedArgs.Create.Path)
 }
 
 func (c *cli) format() {

--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -496,6 +496,7 @@ func (c *cli) createStack() {
 		Logger()
 
 	logger.Trace().Msg("creating stack")
+	// TODO(katcipis): implement stack creation
 }
 
 func (c *cli) format() {

--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -73,6 +73,13 @@ type cliSpec struct {
 	DisableCheckGitUntracked   bool `optional:"true" default:"false" help:"Disable git check for untracked files"`
 	DisableCheckGitUncommitted bool `optional:"true" default:"false" help:"Disable git check for uncommitted files"`
 
+	Create struct {
+		ID          string   `help:"ID of the stack, defaults to UUID"`
+		Name        string   `help:"Name of the stack, defaults to stack dir base name"`
+		Description string   `help:"Description of the stack, defaults to the stack name"`
+		Import      []string `help:"Add import block for the given path on the stack"`
+	} `cmd:"" help:"Creates a stack"`
+
 	Fmt struct {
 		Check bool `help:"Lists unformatted files, exit with 0 if all is formatted, 1 otherwise"`
 	} `cmd:"" help:"Format all files inside dir recursively"`
@@ -330,6 +337,8 @@ func (c *cli) run() {
 	switch c.ctx.Command() {
 	case "fmt":
 		c.format()
+	case "create":
+		c.createStack()
 	case "list":
 		c.printStacks()
 	case "run":
@@ -477,6 +486,16 @@ func (c *cli) listStacks(mgr *terramate.Manager, isChanged bool) (*terramate.Sta
 		return mgr.ListChanged()
 	}
 	return mgr.List()
+}
+
+func (c *cli) createStack() {
+	logger := log.With().
+		Str("workingDir", c.wd()).
+		Str("action", "cli.createStack()").
+		Str("imports", fmt.Sprint(c.parsedArgs.Create.Import)).
+		Logger()
+
+	logger.Trace().Msg("creating stack")
 }
 
 func (c *cli) format() {

--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -74,7 +74,7 @@ type cliSpec struct {
 	DisableCheckGitUncommitted bool `optional:"true" default:"false" help:"Disable git check for uncommitted files"`
 
 	Create struct {
-		Path        string   `arg:"" name:"path" passthrough:"" help:"Path of the new stack"`
+		Path        string   `arg:"" name:"path" help:"Path of the new stack"`
 		ID          string   `help:"ID of the stack, defaults to UUID"`
 		Name        string   `help:"Name of the stack, defaults to stack dir base name"`
 		Description string   `help:"Description of the stack, defaults to the stack name"`

--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -74,7 +74,7 @@ type cliSpec struct {
 	DisableCheckGitUncommitted bool `optional:"true" default:"false" help:"Disable git check for uncommitted files"`
 
 	Create struct {
-		Path        string   `arg:"" name:"path" help:"Path of the new stack"`
+		Path        string   `arg:"" name:"path" help:"Path of the new stack relative to the working dir"`
 		ID          string   `help:"ID of the stack, defaults to UUID"`
 		Name        string   `help:"Name of the stack, defaults to stack dir base name"`
 		Description string   `help:"Description of the stack, defaults to the stack name"`

--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -79,7 +79,7 @@ type cliSpec struct {
 		Name        string   `help:"Name of the stack, defaults to stack dir base name"`
 		Description string   `help:"Description of the stack, defaults to the stack name"`
 		Import      []string `help:"Add import block for the given path on the stack"`
-	} `cmd:"" help:"Creates a stack"`
+	} `cmd:"" help:"Creates a stack on the project"`
 
 	Fmt struct {
 		Check bool `help:"Lists unformatted files, exit with 0 if all is formatted, 1 otherwise"`

--- a/cmd/terramate/e2etests/create_test.go
+++ b/cmd/terramate/e2etests/create_test.go
@@ -54,13 +54,15 @@ func TestCreateStack(t *testing.T) {
 	}
 
 	for _, stackPath := range stackPaths {
-		cli.run("create", stackPath,
+		res := cli.run("create", stackPath,
 			"--id", stackID,
 			"--name", stackName,
 			"--description", stackDescription,
 			"--import", stackImport1,
 			"--import", stackImport2,
 		)
+
+		assertRun(t, res)
 
 		got := s.LoadStack(stackPath)
 

--- a/cmd/terramate/e2etests/create_test.go
+++ b/cmd/terramate/e2etests/create_test.go
@@ -19,9 +19,6 @@ import (
 	"testing"
 
 	"github.com/madlambda/spells/assert"
-	"github.com/mineiros-io/terramate/hcl"
-	"github.com/mineiros-io/terramate/hcl/ast"
-	"github.com/mineiros-io/terramate/stack"
 	"github.com/mineiros-io/terramate/test"
 	"github.com/mineiros-io/terramate/test/sandbox"
 )
@@ -71,8 +68,7 @@ func TestCreateStack(t *testing.T) {
 		assert.EqualStrings(t, stackName, got.Name(), "checking stack name")
 		assert.EqualStrings(t, stackDescription, got.Desc(), "checking stack description")
 
-		// TODO(katcipis): extract this to avoid duplication with stack.Create tests
-		assertStackImports(t, s.RootDir(), got, []string{stackImport1, stackImport2})
+		test.AssertStackImports(t, s.RootDir(), got, []string{stackImport1, stackImport2})
 	}
 }
 
@@ -86,43 +82,5 @@ func TestCreateStackDefaults(t *testing.T) {
 	assert.EqualStrings(t, "stack", got.Name(), "checking stack name")
 	assert.EqualStrings(t, "stack", got.Desc(), "checking stack description")
 
-	// TODO(katcipis): extract this to avoid duplication with stack.Create tests
-	assertStackImports(t, s.RootDir(), got, []string{})
-}
-
-func assertStackImports(t *testing.T, rootdir string, got stack.S, want []string) {
-	// TODO(katcipis): extract this to avoid duplication with stack.Create tests
-	t.Helper()
-
-	parser, err := hcl.NewTerramateParser(rootdir, got.HostPath())
-	assert.NoError(t, err)
-
-	err = parser.AddDir(got.HostPath())
-	assert.NoError(t, err)
-
-	err = parser.MinimalParse()
-	assert.NoError(t, err)
-
-	// TODO(katcipis): extract this to avoid duplication with stack.Create tests
-	imports := ast.Blocks{}
-	//imports, err := parser.Imports()
-	//assert.NoError(t, err)
-
-	if len(imports) != len(want) {
-		t.Fatalf("got %d imports, wanted %v", len(imports), want)
-	}
-
-checkImports:
-	for _, wantImport := range want {
-		for _, gotImportBlock := range imports {
-			sourceVal, diags := gotImportBlock.Attributes["source"].Expr.Value(nil)
-			if diags.HasErrors() {
-				t.Fatalf("error %v evaluating import source attribute", diags)
-			}
-			if sourceVal.AsString() == wantImport {
-				continue checkImports
-			}
-		}
-		t.Errorf("wanted import %s not found", wantImport)
-	}
+	test.AssertStackImports(t, s.RootDir(), got, []string{})
 }

--- a/cmd/terramate/e2etests/create_test.go
+++ b/cmd/terramate/e2etests/create_test.go
@@ -31,7 +31,6 @@ func TestCreateStack(t *testing.T) {
 	cli := newCLI(t, s.RootDir())
 
 	const (
-		stackPath        = "stack"
 		stackID          = "stack-id"
 		stackName        = "stack name"
 		stackDescription = "stack description"
@@ -47,23 +46,32 @@ func TestCreateStack(t *testing.T) {
 	createFile(stackImport1)
 	createFile(stackImport2)
 
-	cli.run("create", stackPath,
-		"--id", stackID,
-		"--name", stackName,
-		"--description", stackDescription,
-		"--import", stackImport1,
-		"--import", stackImport2,
-	)
+	stackPaths := []string{
+		"stack-1",
+		"/stack-2",
+		"/stacks/stack-a",
+		"stacks/stack-b",
+	}
 
-	got := s.LoadStack(stackPath)
+	for _, stackPath := range stackPaths {
+		cli.run("create", stackPath,
+			"--id", stackID,
+			"--name", stackName,
+			"--description", stackDescription,
+			"--import", stackImport1,
+			"--import", stackImport2,
+		)
 
-	gotID, _ := got.ID()
-	assert.EqualStrings(t, stackID, gotID)
-	assert.EqualStrings(t, stackName, got.Name(), "checking stack name")
-	assert.EqualStrings(t, stackDescription, got.Desc(), "checking stack description")
+		got := s.LoadStack(stackPath)
 
-	// TODO(katcipis): extract this to avoid duplication with stack.Create tests
-	assertStackImports(t, s.RootDir(), got, []string{stackImport1, stackImport2})
+		gotID, _ := got.ID()
+		assert.EqualStrings(t, stackID, gotID)
+		assert.EqualStrings(t, stackName, got.Name(), "checking stack name")
+		assert.EqualStrings(t, stackDescription, got.Desc(), "checking stack description")
+
+		// TODO(katcipis): extract this to avoid duplication with stack.Create tests
+		assertStackImports(t, s.RootDir(), got, []string{stackImport1, stackImport2})
+	}
 }
 
 func assertStackImports(t *testing.T, rootdir string, got stack.S, want []string) {

--- a/cmd/terramate/e2etests/create_test.go
+++ b/cmd/terramate/e2etests/create_test.go
@@ -1,0 +1,104 @@
+// Copyright 2022 Mineiros GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2etest
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/madlambda/spells/assert"
+	"github.com/mineiros-io/terramate/hcl"
+	"github.com/mineiros-io/terramate/hcl/ast"
+	"github.com/mineiros-io/terramate/stack"
+	"github.com/mineiros-io/terramate/test"
+	"github.com/mineiros-io/terramate/test/sandbox"
+)
+
+func TestCreateStack(t *testing.T) {
+	s := sandbox.New(t)
+	cli := newCLI(t, s.RootDir())
+
+	const (
+		stackPath        = "stack"
+		stackID          = "stack-id"
+		stackName        = "stack name"
+		stackDescription = "stack description"
+		stackImport1     = "/core/file1.tm.hcl"
+		stackImport2     = "/core/file2.tm.hcl"
+	)
+
+	createFile := func(path string) {
+		abspath := filepath.Join(s.RootDir(), path)
+		test.WriteFile(t, filepath.Dir(abspath), filepath.Base(abspath), "")
+	}
+
+	createFile(stackImport1)
+	createFile(stackImport2)
+
+	cli.run("create", stackPath,
+		"--id", stackID,
+		"--name", stackName,
+		"--description", stackDescription,
+		"--import", stackImport1,
+		"--import", stackImport2,
+	)
+
+	got := s.LoadStack(stackPath)
+
+	gotID, _ := got.ID()
+	assert.EqualStrings(t, stackID, gotID)
+	assert.EqualStrings(t, stackName, got.Name(), "checking stack name")
+	assert.EqualStrings(t, stackDescription, got.Desc(), "checking stack description")
+
+	// TODO(katcipis): extract this to avoid duplication with stack.Create tests
+	assertStackImports(t, s.RootDir(), got, []string{stackImport1, stackImport2})
+}
+
+func assertStackImports(t *testing.T, rootdir string, got stack.S, want []string) {
+	// TODO(katcipis): extract this to avoid duplication with stack.Create tests
+	t.Helper()
+
+	parser, err := hcl.NewTerramateParser(rootdir, got.HostPath())
+	assert.NoError(t, err)
+
+	err = parser.AddDir(got.HostPath())
+	assert.NoError(t, err)
+
+	err = parser.MinimalParse()
+	assert.NoError(t, err)
+
+	// TODO(katcipis): extract this to avoid duplication with stack.Create tests
+	imports := ast.Blocks{}
+	//imports, err := parser.Imports()
+	//assert.NoError(t, err)
+
+	if len(imports) != len(want) {
+		t.Fatalf("got %d imports, wanted %v", len(imports), want)
+	}
+
+checkImports:
+	for _, wantImport := range want {
+		for _, gotImportBlock := range imports {
+			sourceVal, diags := gotImportBlock.Attributes["source"].Expr.Value(nil)
+			if diags.HasErrors() {
+				t.Fatalf("error %v evaluating import source attribute", diags)
+			}
+			if sourceVal.AsString() == wantImport {
+				continue checkImports
+			}
+		}
+		t.Errorf("wanted import %s not found", wantImport)
+	}
+}

--- a/cmd/terramate/e2etests/create_test.go
+++ b/cmd/terramate/e2etests/create_test.go
@@ -74,6 +74,20 @@ func TestCreateStack(t *testing.T) {
 	}
 }
 
+func TestCreateStackDefaults(t *testing.T) {
+	s := sandbox.New(t)
+	cli := newCLI(t, s.RootDir())
+	cli.run("create", "stack")
+
+	got := s.LoadStack("stack")
+
+	assert.EqualStrings(t, "stack", got.Name(), "checking stack name")
+	assert.EqualStrings(t, "stack", got.Desc(), "checking stack description")
+
+	// TODO(katcipis): extract this to avoid duplication with stack.Create tests
+	assertStackImports(t, s.RootDir(), got, []string{})
+}
+
 func assertStackImports(t *testing.T, rootdir string, got stack.S, want []string) {
 	// TODO(katcipis): extract this to avoid duplication with stack.Create tests
 	t.Helper()

--- a/cmd/terramate/e2etests/create_test.go
+++ b/cmd/terramate/e2etests/create_test.go
@@ -15,6 +15,7 @@
 package e2etest
 
 import (
+	"fmt"
 	"path/filepath"
 	"testing"
 
@@ -59,7 +60,9 @@ func TestCreateStack(t *testing.T) {
 			"--import", stackImport2,
 		)
 
-		assertRun(t, res)
+		assertRunResult(t, res, runExpected{
+			Stdout: fmt.Sprintf("Created stack %s with success\n", stackPath),
+		})
 
 		got := s.LoadStack(stackPath)
 

--- a/stack/create.go
+++ b/stack/create.go
@@ -158,6 +158,10 @@ func Create(rootdir string, cfg CreateCfg) error {
 		return errors.E(err, "writing stack imports to stack file")
 	}
 
+	if len(cfg.Imports) > 0 {
+		stackFile.Write([]byte("\n"))
+	}
+
 	return hcl.PrintImports(stackFile, cfg.Imports)
 }
 

--- a/stack/create.go
+++ b/stack/create.go
@@ -62,7 +62,7 @@ type CreateCfg struct {
 //
 // If the stack already exists it will return an error and no changes will be
 // made to the stack.
-func Create(rootdir string, cfg CreateCfg) error {
+func Create(rootdir string, cfg CreateCfg) (err error) {
 	const stackFilename = "stack.tm.hcl"
 
 	logger := log.With().
@@ -90,7 +90,7 @@ func Create(rootdir string, cfg CreateCfg) error {
 
 	logger.Trace().Msg("validating create configuration")
 
-	_, err := os.Stat(filepath.Join(cfg.Dir, stackFilename))
+	_, err = os.Stat(filepath.Join(cfg.Dir, stackFilename))
 	if err == nil {
 		// Even if there is no stack inside the file, we can't overwrite
 		// the user file anyway.
@@ -147,10 +147,15 @@ func Create(rootdir string, cfg CreateCfg) error {
 	if err != nil {
 		return errors.E(err, "opening stack file")
 	}
+
 	defer func() {
-		err := stackFile.Close()
-		if err != nil {
-			logger.Error().Err(err).Msg("closing stack file")
+		errClose := stackFile.Close()
+		if errClose != nil {
+			if err != nil {
+				err = errors.L(err, errClose)
+			} else {
+				err = errClose
+			}
 		}
 	}()
 
@@ -159,7 +164,7 @@ func Create(rootdir string, cfg CreateCfg) error {
 	}
 
 	if len(cfg.Imports) > 0 {
-		stackFile.Write([]byte("\n"))
+		fmt.Fprint(stackFile, "\n")
 	}
 
 	return hcl.PrintImports(stackFile, cfg.Imports)

--- a/stack/create_test.go
+++ b/stack/create_test.go
@@ -236,7 +236,7 @@ func TestStackCreation(t *testing.T) {
 			assert.EqualStrings(t, want.name, got.Name(), "checking stack name")
 			assert.EqualStrings(t, want.desc, got.Desc(), "checking stack description")
 
-			assertStackImports(t, s.RootDir(), got, want.imports)
+			test.AssertStackImports(t, s.RootDir(), got, want.imports)
 		})
 	}
 }
@@ -247,40 +247,6 @@ func buildImportedFiles(t *testing.T, rootdir string, imports []string) {
 	for _, importPath := range imports {
 		abspath := filepath.Join(rootdir, importPath)
 		test.WriteFile(t, filepath.Dir(abspath), filepath.Base(abspath), "")
-	}
-}
-
-func assertStackImports(t *testing.T, rootdir string, got stack.S, want []string) {
-	t.Helper()
-
-	parser, err := hcl.NewTerramateParser(rootdir, got.HostPath())
-	assert.NoError(t, err)
-
-	err = parser.AddDir(got.HostPath())
-	assert.NoError(t, err)
-
-	err = parser.MinimalParse()
-	assert.NoError(t, err)
-
-	imports, err := parser.Imports()
-	assert.NoError(t, err)
-
-	if len(imports) != len(want) {
-		t.Fatalf("got %d imports, wanted %v", len(imports), want)
-	}
-
-checkImports:
-	for _, wantImport := range want {
-		for _, gotImportBlock := range imports {
-			sourceVal, diags := gotImportBlock.Attributes["source"].Expr.Value(nil)
-			if diags.HasErrors() {
-				t.Fatalf("error %v evaluating import source attribute", diags)
-			}
-			if sourceVal.AsString() == wantImport {
-				continue checkImports
-			}
-		}
-		t.Errorf("wanted import %s not found", wantImport)
 	}
 }
 

--- a/test/stack.go
+++ b/test/stack.go
@@ -1,0 +1,46 @@
+package test
+
+import (
+	"testing"
+
+	"github.com/madlambda/spells/assert"
+	"github.com/mineiros-io/terramate/hcl"
+	"github.com/mineiros-io/terramate/stack"
+)
+
+// AssertStackImports checks that the given stack has all the wanted import
+// definitions. The wanted imports is a slice of the sources that are imported
+// on each block.
+func AssertStackImports(t *testing.T, rootdir string, got stack.S, want []string) {
+	t.Helper()
+
+	parser, err := hcl.NewTerramateParser(rootdir, got.HostPath())
+	assert.NoError(t, err)
+
+	err = parser.AddDir(got.HostPath())
+	assert.NoError(t, err)
+
+	err = parser.MinimalParse()
+	assert.NoError(t, err)
+
+	imports, err := parser.Imports()
+	assert.NoError(t, err)
+
+	if len(imports) != len(want) {
+		t.Fatalf("got %d imports, wanted %v", len(imports), want)
+	}
+
+checkImports:
+	for _, wantImport := range want {
+		for _, gotImportBlock := range imports {
+			sourceVal, diags := gotImportBlock.Attributes["source"].Expr.Value(nil)
+			if diags.HasErrors() {
+				t.Fatalf("error %v evaluating import source attribute", diags)
+			}
+			if sourceVal.AsString() == wantImport {
+				continue checkImports
+			}
+		}
+		t.Errorf("wanted import %s not found", wantImport)
+	}
+}

--- a/test/stack.go
+++ b/test/stack.go
@@ -1,3 +1,17 @@
+// Copyright 2022 Mineiros GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package test
 
 import (


### PR DESCRIPTION
Introduces the `terramate create` command on the CLI. Example:

```sh
#!/bin/bash

set -o errexit
set -o nounset
set -o pipefail

workdir=$(mktemp -d)
cd "${workdir}" || exit

cat > terramate.tm.hcl <<- EOM
terramate {
  config {
  }
}
EOM

terramate create stack 
cat stack/stack.tm.hcl
echo

mkdir common
touch common/file1.tm.hcl
touch common/file2.tm.hcl

mkdir stacks
cd stacks

terramate create stack-1 \
    --name "stack name" \
    --description "stack description" \
    --id "stack-id" \
    --import "/common/file1.tm.hcl" \
    --import "/common/file2.tm.hcl"

cat stack-1/stack.tm.hcl
echo

cd ..

echo "final structure"
tree
```