### PR TITLE
refactor: move stack create default handling to cli pkg

### DIFF
--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/mineiros-io/terramate/errors"
 	"github.com/mineiros-io/terramate/generate"
 	prj "github.com/mineiros-io/terramate/project"
@@ -499,11 +500,34 @@ func (c *cli) createStack() {
 	logger.Trace().Msg("creating stack")
 
 	stackDir := filepath.Join(c.wd(), c.parsedArgs.Create.Path)
+
+	stackID := c.parsedArgs.Create.ID
+	if stackID == "" {
+
+		logger.Trace().Msg("no ID provided, generating one")
+
+		id, err := uuid.NewRandom()
+		if err != nil {
+			logger.Fatal().Err(err)
+		}
+		stackID = id.String()
+	}
+
+	stackName := c.parsedArgs.Create.Name
+	if stackName == "" {
+		stackName = filepath.Base(stackDir)
+	}
+
+	stackDescription := c.parsedArgs.Create.Description
+	if stackDescription == "" {
+		stackDescription = stackName
+	}
+
 	err := stack.Create(c.root(), stack.CreateCfg{
 		Dir:         stackDir,
-		ID:          c.parsedArgs.Create.ID,
-		Name:        c.parsedArgs.Create.Name,
-		Description: c.parsedArgs.Create.Description,
+		ID:          stackID,
+		Name:        stackName,
+		Description: stackDescription,
 		Imports:     c.parsedArgs.Create.Import,
 	})
 

--- a/cmd/terramate/e2etests/create_test.go
+++ b/cmd/terramate/e2etests/create_test.go
@@ -19,6 +19,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/madlambda/spells/assert"
 	"github.com/mineiros-io/terramate/test"
 	"github.com/mineiros-io/terramate/test/sandbox"
@@ -84,6 +85,11 @@ func TestCreateStackDefaults(t *testing.T) {
 
 	assert.EqualStrings(t, "stack", got.Name(), "checking stack name")
 	assert.EqualStrings(t, "stack", got.Desc(), "checking stack description")
+
+	// By default the CLI generates an id with an UUID
+	gotID, _ := got.ID()
+	_, err := uuid.Parse(gotID)
+	assert.NoError(t, err, "validating default UUID")
 
 	test.AssertStackImports(t, s.RootDir(), got, []string{})
 }

--- a/stack/create.go
+++ b/stack/create.go
@@ -20,7 +20,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/google/uuid"
 	"github.com/mineiros-io/terramate/errors"
 	"github.com/mineiros-io/terramate/hcl"
 	"github.com/rs/zerolog/log"
@@ -107,39 +106,30 @@ func Create(rootdir string, cfg CreateCfg) (err error) {
 		return errors.E(ErrStackAlreadyExists, "name %q", parsedCfg.Stack.Name)
 	}
 
+	stackCfg := hcl.Stack{}
+
+	if cfg.Name != "" {
+		stackCfg.Name = cfg.Name
+	}
+
+	if cfg.Description != "" {
+		stackCfg.Description = cfg.Description
+	}
+
+	if cfg.ID != "" {
+		stackID, err := hcl.NewStackID(cfg.ID)
+		if err != nil {
+			return errors.E(ErrInvalidStackID, err)
+		}
+		stackCfg.ID = stackID
+	}
+
 	tmCfg, err := hcl.NewConfig(cfg.Dir)
 	if err != nil {
 		return errors.E(err, "failed to create new stack config")
 	}
 
-	if cfg.ID == "" {
-		logger.Trace().Msg("no ID provided, generating one")
-
-		id, err := uuid.NewRandom()
-		if err != nil {
-			return errors.E(err, "failed to create stack UUID")
-		}
-		cfg.ID = id.String()
-	}
-
-	if cfg.Name == "" {
-		cfg.Name = filepath.Base(cfg.Dir)
-	}
-
-	if cfg.Description == "" {
-		cfg.Description = cfg.Name
-	}
-
-	stackID, err := hcl.NewStackID(cfg.ID)
-	if err != nil {
-		return errors.E(ErrInvalidStackID, err)
-	}
-
-	tmCfg.Stack = &hcl.Stack{
-		ID:          stackID,
-		Name:        cfg.Name,
-		Description: cfg.Description,
-	}
+	tmCfg.Stack = &stackCfg
 
 	logger.Trace().Msg("creating stack file")
 

--- a/stack/create_test.go
+++ b/stack/create_test.go
@@ -18,7 +18,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/google/uuid"
 	"github.com/madlambda/spells/assert"
 	"github.com/mineiros-io/terramate/errors"
 	"github.com/mineiros-io/terramate/hcl"
@@ -58,10 +57,7 @@ func TestStackCreation(t *testing.T) {
 				Dir: "stack",
 			},
 			want: want{
-				stack: wantedStack{
-					name: "stack",
-					desc: "stack",
-				},
+				stack: wantedStack{name: "stack"},
 			},
 		},
 		{
@@ -70,10 +66,7 @@ func TestStackCreation(t *testing.T) {
 				Dir: "dir1/dir2/dir3/stack",
 			},
 			want: want{
-				stack: wantedStack{
-					name: "stack",
-					desc: "stack",
-				},
+				stack: wantedStack{name: "stack"},
 			},
 		},
 		{
@@ -83,10 +76,7 @@ func TestStackCreation(t *testing.T) {
 				Dir: "stack",
 			},
 			want: want{
-				stack: wantedStack{
-					name: "stack",
-					desc: "stack",
-				},
+				stack: wantedStack{name: "stack"},
 			},
 		},
 		{
@@ -96,10 +86,7 @@ func TestStackCreation(t *testing.T) {
 				Dir: "stack",
 			},
 			want: want{
-				stack: wantedStack{
-					name: "stack",
-					desc: "stack",
-				},
+				stack: wantedStack{name: "stack"},
 			},
 		},
 		{
@@ -111,7 +98,6 @@ func TestStackCreation(t *testing.T) {
 			want: want{
 				stack: wantedStack{
 					name: "The Name Of The Stack",
-					desc: "The Name Of The Stack",
 				},
 			},
 		},
@@ -153,7 +139,6 @@ func TestStackCreation(t *testing.T) {
 			want: want{
 				stack: wantedStack{
 					name:    "stack-imports",
-					desc:    "stack-imports",
 					imports: []string{"/common/something.tm.hcl"},
 				},
 			},
@@ -168,7 +153,6 @@ func TestStackCreation(t *testing.T) {
 			want: want{
 				stack: wantedStack{
 					name: "stack-imports",
-					desc: "stack-imports",
 					imports: []string{
 						"/common/1.tm.hcl",
 						"/common/2.tm.hcl",
@@ -201,7 +185,7 @@ func TestStackCreation(t *testing.T) {
 			want:   want{err: errors.E(stack.ErrStackAlreadyExists)},
 		},
 		{
-			name:   "fails if stack already exists and there is a stack.tm.hcl file",
+			name:   "fails if there is a stack.tm.hcl file on dir",
 			layout: []string{"f:stack/stack.tm.hcl"},
 			create: stack.CreateCfg{Dir: "stack"},
 			want:   want{err: errors.E(stack.ErrStackAlreadyExists)},
@@ -226,12 +210,14 @@ func TestStackCreation(t *testing.T) {
 			want := tc.want.stack
 			got := s.LoadStack(stackPath)
 
-			gotID, _ := got.ID()
 			if wantID, ok := want.id.Value(); ok {
+				gotID, _ := got.ID()
 				assert.EqualStrings(t, wantID, gotID)
 			} else {
-				_, err := uuid.Parse(gotID)
-				assert.NoError(t, err)
+				gotID, ok := got.ID()
+				if ok {
+					t.Fatalf("got unwanted ID %q", gotID)
+				}
 			}
 			assert.EqualStrings(t, want.name, got.Name(), "checking stack name")
 			assert.EqualStrings(t, want.desc, got.Desc(), "checking stack description")


### PR DESCRIPTION
This will make it easier to use the new stack.Create function on tests instead of the old Init one, since for a lot of scenarios the default definitions are unexpected. Since these particular defaults seems to be CLI specific I moved them there.