### PR TITLE
feat: add git checks config through cfg and env

### DIFF
--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -939,6 +939,14 @@ func (c *cli) checkGenCode() bool {
 		}
 	}
 
+	cfg := c.prj.rootcfg
+
+	if cfg.Terramate != nil &&
+		cfg.Terramate.Config != nil &&
+		cfg.Terramate.Config.Run != nil {
+		return cfg.Terramate.Config.Run.CheckGenCode
+	}
+
 	return true
 }
 

--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -405,6 +405,19 @@ func (c *cli) generate() {
 	}
 }
 
+func (c *cli) checkGitUntracked() bool {
+	if c.parsedArgs.DisableCheckGitUntracked {
+		return false
+	}
+
+	if disableCheck, ok := os.LookupEnv("TM_DISABLE_CHECK_GIT_UNTRACKED"); ok {
+		if disableCheck != "0" && disableCheck != "false" {
+			return false
+		}
+	}
+	return true
+}
+
 func (c *cli) gitSafeguards(checks terramate.RepoChecks, shouldAbort bool) {
 	logger := log.With().
 		Str("action", "gitSafeguards()").
@@ -414,7 +427,7 @@ func (c *cli) gitSafeguards(checks terramate.RepoChecks, shouldAbort bool) {
 		return
 	}
 
-	if !c.parsedArgs.DisableCheckGitUntracked && len(checks.UntrackedFiles) > 0 {
+	if c.checkGitUntracked() && len(checks.UntrackedFiles) > 0 {
 		if shouldAbort {
 			logger.Fatal().
 				Strs("files", checks.UntrackedFiles).

--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -997,13 +997,35 @@ func (c *cli) checkOutdatedGeneratedCode(stacks []stack.S) {
 	}
 }
 
+func (c *cli) checkGitRemote() bool {
+	if c.parsedArgs.Run.DisableCheckGitRemote {
+		return false
+	}
+
+	if disableCheck, ok := os.LookupEnv("TM_DISABLE_CHECK_GIT_REMOTE"); ok {
+		if envVarIsSet(disableCheck) {
+			return false
+		}
+	}
+
+	cfg := c.prj.rootcfg
+
+	if cfg.Terramate != nil &&
+		cfg.Terramate.Config != nil &&
+		cfg.Terramate.Config.Git != nil {
+		return cfg.Terramate.Config.Git.CheckRemote
+	}
+
+	return true
+}
+
 func (c *cli) runOnStacks() {
 	logger := log.With().
 		Str("action", "runOnStacks()").
 		Str("workingDir", c.wd()).
 		Logger()
 
-	if !c.parsedArgs.Run.DisableCheckGitRemote {
+	if c.checkGitRemote() {
 		c.checkGit()
 	}
 

--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -411,7 +411,7 @@ func (c *cli) checkGitUntracked() bool {
 	}
 
 	if disableCheck, ok := os.LookupEnv("TM_DISABLE_CHECK_GIT_UNTRACKED"); ok {
-		if disableCheck != "0" && disableCheck != "false" {
+		if envVarIsSet(disableCheck) {
 			return false
 		}
 	}
@@ -433,7 +433,7 @@ func (c *cli) checkGitUncommited() bool {
 	}
 
 	if disableCheck, ok := os.LookupEnv("TM_DISABLE_CHECK_GIT_UNCOMMITTED"); ok {
-		if disableCheck != "0" && disableCheck != "false" {
+		if envVarIsSet(disableCheck) {
 			return false
 		}
 	}
@@ -934,12 +934,16 @@ func (c *cli) checkGenCode() bool {
 	}
 
 	if disableCheck, ok := os.LookupEnv("TM_DISABLE_CHECK_GEN_CODE"); ok {
-		if disableCheck != "0" && disableCheck != "false" {
+		if envVarIsSet(disableCheck) {
 			return false
 		}
 	}
 
 	return true
+}
+
+func envVarIsSet(val string) bool {
+	return val != "0" && val != "false"
 }
 
 func (c *cli) checkOutdatedGeneratedCode(stacks []stack.S) {

--- a/cmd/terramate/cli/project.go
+++ b/cmd/terramate/cli/project.go
@@ -153,8 +153,13 @@ func (p *project) setDefaults(parsedArgs *cliSpec) error {
 	if cfg.Terramate.Config == nil {
 		p.rootcfg.Terramate.Config = &hcl.RootConfig{}
 	}
+	// Now some defaults are defined on the NewGitConfig but others here.
+	// To define all defaults here we would need boolean pointers to
+	// check if the config is defined or not, the zero value for booleans
+	// is valid (simpler with strings). Maybe we could move all defaults
+	// to NewGitConfig.
 	if cfg.Terramate.Config.Git == nil {
-		cfg.Terramate.Config.Git = &hcl.GitConfig{}
+		cfg.Terramate.Config.Git = hcl.NewGitConfig()
 	}
 
 	gitOpt := cfg.Terramate.Config.Git

--- a/cmd/terramate/e2etests/run_test.go
+++ b/cmd/terramate/e2etests/run_test.go
@@ -1063,7 +1063,27 @@ func TestRunFailIfGeneratedCodeIsOutdated(t *testing.T) {
 	})
 
 	t.Run("disable check using hcl config", func(t *testing.T) {
-		t.Skip("TODO:KATCIPIS")
+		const rootConfig = "terramate.tm.hcl"
+
+		s.RootEntry().CreateFile(rootConfig, `
+			terramate {
+			  config {
+			    run {
+			      check_gen_code = false
+			    }
+			  }
+			}
+		`)
+
+		git.Add(rootConfig)
+		git.Commit("commit root config")
+
+		assertRunResult(t, tmcli.run("run", "--changed", cat, generateFile), runExpected{
+			Stdout: generateFileBody,
+		})
+		assertRunResult(t, tmcli.run("run", cat, generateFile), runExpected{
+			Stdout: generateFileBody,
+		})
 	})
 
 }

--- a/cmd/terramate/e2etests/run_test.go
+++ b/cmd/terramate/e2etests/run_test.go
@@ -906,21 +906,45 @@ func TestRunFailIfGitSafeguardUntracked(t *testing.T) {
 	})
 
 	// disabling the check must work for both with and without --changed
-	assertRun(t, cli.run(
-		"run",
-		"--changed",
-		"--disable-check-git-untracked",
-		cat,
-		mainTfFileName,
-	))
 
-	assertRunResult(t, cli.run(
-		"run",
-		"--disable-check-git-untracked",
-		cat,
-		mainTfFileName,
-	), runExpected{
-		Stdout: mainTfContents,
+	t.Run("disable untracked using cmd args", func(t *testing.T) {
+		assertRun(t, cli.run(
+			"run",
+			"--changed",
+			"--disable-check-git-untracked",
+			cat,
+			mainTfFileName,
+		))
+
+		assertRunResult(t, cli.run(
+			"run",
+			"--disable-check-git-untracked",
+			cat,
+			mainTfFileName,
+		), runExpected{
+			Stdout: mainTfContents,
+		})
+	})
+
+	t.Run("disable untracked using env vars", func(t *testing.T) {
+		cli := newCLI(t, s.RootDir())
+		cli.env = append([]string{
+			"TM_DISABLE_CHECK_GIT_UNTRACKED=true",
+		}, os.Environ()...)
+		assertRun(t, cli.run(
+			"run",
+			"--changed",
+			cat,
+			mainTfFileName,
+		))
+
+		assertRunResult(t, cli.run(
+			"run",
+			cat,
+			mainTfFileName,
+		), runExpected{
+			Stdout: mainTfContents,
+		})
 	})
 }
 

--- a/cmd/terramate/e2etests/run_test.go
+++ b/cmd/terramate/e2etests/run_test.go
@@ -1049,7 +1049,17 @@ func TestRunFailIfGeneratedCodeIsOutdated(t *testing.T) {
 	})
 
 	t.Run("disable check using env vars", func(t *testing.T) {
-		t.Skip("TODO:KATCIPIS")
+		tmcli := newCLI(t, s.RootDir())
+		tmcli.env = append([]string{
+			"TM_DISABLE_CHECK_GEN_CODE=true",
+		}, os.Environ()...)
+
+		assertRunResult(t, tmcli.run("run", "--changed", cat, generateFile), runExpected{
+			Stdout: generateFileBody,
+		})
+		assertRunResult(t, tmcli.run("run", cat, generateFile), runExpected{
+			Stdout: generateFileBody,
+		})
 	})
 
 	t.Run("disable check using hcl config", func(t *testing.T) {

--- a/cmd/terramate/e2etests/run_test.go
+++ b/cmd/terramate/e2etests/run_test.go
@@ -946,6 +946,35 @@ func TestRunFailIfGitSafeguardUntracked(t *testing.T) {
 			Stdout: mainTfContents,
 		})
 	})
+
+	t.Run("disable untracked using hcl config", func(t *testing.T) {
+		cli := newCLI(t, s.RootDir())
+		s.RootEntry().CreateConfig(`
+			terramate {
+			  config {
+			    git {
+			      check_untracked = false
+			    }
+			  }
+			}
+		`)
+		defer s.RootEntry().DeleteConfig()
+
+		assertRun(t, cli.run(
+			"run",
+			"--changed",
+			cat,
+			mainTfFileName,
+		))
+
+		assertRunResult(t, cli.run(
+			"run",
+			cat,
+			mainTfFileName,
+		), runExpected{
+			Stdout: mainTfContents,
+		})
+	})
 }
 
 func TestRunFailIfGeneratedCodeIsOutdated(t *testing.T) {

--- a/hcl/hcl.go
+++ b/hcl/hcl.go
@@ -208,6 +208,15 @@ func (s StackID) Value() (string, bool) {
 	return *s.id, true
 }
 
+// NewGitConfig creates a git configuration with proper default values.
+func NewGitConfig() *GitConfig {
+	return &GitConfig{
+		CheckUntracked:   true,
+		CheckUncommitted: true,
+		CheckRemote:      true,
+	}
+}
+
 // parsedFile tells the origin and kind of the parsedFile.
 // The kind can be either internal or external, meaning the file was parsed
 // by this parser or by another parser instance, respectively.
@@ -1050,11 +1059,7 @@ func parseRootConfig(cfg *RootConfig, block *ast.MergedBlock) error {
 	if ok {
 		logger.Trace().Msg("Type is 'git'")
 
-		cfg.Git = &GitConfig{
-			CheckUntracked:   true,
-			CheckUncommitted: true,
-			CheckRemote:      true,
-		}
+		cfg.Git = NewGitConfig()
 
 		logger.Trace().Msg("Parse git config.")
 

--- a/hcl/hcl.go
+++ b/hcl/hcl.go
@@ -1098,7 +1098,7 @@ func parseRunConfig(runCfg *RunConfig, runBlock *ast.MergedBlock) error {
 		switch attr.Name {
 		case "check_gen_code":
 			if value.Type() != cty.Bool {
-				errs.Append(errors.E(attr.Expr.Range(),
+				errs.Append(attrEvalErr(attr,
 					"terramate.config.run.check_gen_code is not a bool but %q",
 					value.Type().FriendlyName(),
 				))


### PR DESCRIPTION
Just as we can pass flags:

- `--disable-check-git-untracked`
- `--disable-check-git-uncommitted`
- `--disable-check-git-remote`
- `--disable-check-gen-code`

We now can have them as project configs:

```hcl
terramate {
  config {
    git {
      check_untracked   = true
      check_uncommitted = true
      check_remote      = true
    }
    run {
      check_gen_code = true
    }
  }
}
```

And environment variables:

- `TM_DISABLE_CHECK_GIT_UNTRACKED`
- `TM_DISABLE_CHECK_GIT_UNCOMITTED`
- `TM_DISABLE_CHECK_GIT_REMOTE`
- `TM_DISABLE_CHECK_GEN_CODE`

A env variable is considered `true` if set and not `0` nor `false`.

Precedence:
- command line
- ENV (needs to be actually set to be considered) 
- config
- built-in default

Docs will be added on a following PR.