### PR TITLE
refactor: renaming and adding new test on hcl parser

### DIFF
--- a/stack/globals.go
+++ b/stack/globals.go
@@ -237,7 +237,7 @@ func loadStackGlobalsExprs(rootdir string, cfgdir string) (*globalsExpr, error) 
 		return nil, errors.E("adding dir to parser", err)
 	}
 
-	err = p.MinimalParse()
+	err = p.Parse()
 	if err != nil {
 		return nil, errors.E("parsing config", err)
 	}

--- a/test/stack.go
+++ b/test/stack.go
@@ -34,7 +34,7 @@ func AssertStackImports(t *testing.T, rootdir string, got stack.S, want []string
 	err = parser.AddDir(got.HostPath())
 	assert.NoError(t, err)
 
-	err = parser.MinimalParse()
+	err = parser.Parse()
 	assert.NoError(t, err)
 
 	imports, err := parser.Imports()


### PR DESCRIPTION
# Reason for This Change

As I searched for something that would help me implement the stack clone feature I found some opportunities to make things clearer, at least to me (always debatable if it is better of course).

## Description of Changes

Renamed a few methods to make things more clear. I think it makes sense that a Parse method only parses the HCL itself, without any Terramate specific schema validations, and then a ParseConfig one is a more specific version that will do schema validation and return a more high level Terramate configuration (minimal parse was confusing to me, but that is debatable).

Also make a few other fields more explicit on their names and added a test for the ParseBodies method, I think it will be quite useful on the stack clone so I just double checked it does what I need.
