### PR TITLE
fix: handle explicitly complex stack ID expressions

### DIFF
--- a/stack/clone.go
+++ b/stack/clone.go
@@ -32,6 +32,10 @@ const (
 	// ErrCloneDestDirExists indicates that the dest dir on a clone
 	// operation already exists.
 	ErrCloneDestDirExists errors.Kind = "clone dest dir exists"
+
+	// ErrCloneSrcStackIDNotSupported indicates that the source stack ID
+	// is not supported by clone.
+	ErrCloneSrcStackIDNotSupported errors.Kind = "src stack ID not supported"
 )
 
 // Clone will clone the stack at srcdir into destdir.
@@ -207,6 +211,13 @@ func updateStackID(stackdir string) error {
 	// Id's are very constrained and are always strings, so we expect
 	// the tokens: TokenOQuote + TokenQuotedLit + TokenCQuote
 	idQuotedLiteral := tokens[blockStart+idAttributeOffset+1]
+	if idQuotedLiteral.Type != hclsyntax.TokenQuotedLit {
+		// Ideally we should support anything that evaluates to a string
+		// on HCL, but for now to avoid too much parsing effort we assume
+		// simple plain strings like "id".
+		return errors.E(ErrCloneSrcStackIDNotSupported, "ID must be a simple string literal")
+	}
+
 	id, err := uuid.NewRandom()
 	if err != nil {
 		return errors.E(err, "creating new ID for cloned stack")

--- a/stack/clone_test.go
+++ b/stack/clone_test.go
@@ -89,6 +89,17 @@ func TestStackClone(t *testing.T) {
 			dest:    "/cloned-stack",
 			wantErr: errors.E(stack.ErrCloneDestDirExists),
 		},
+		{
+			name: "src stack ID must be a string literal",
+			layout: []string{
+				`f:/stack/stack.tm.hcl:stack {
+				  id = ("id")
+				}`,
+			},
+			src:     "/stack",
+			dest:    "/cloned-stack",
+			wantErr: errors.E(stack.ErrCloneSrcStackIDNotSupported),
+		},
 	}
 
 	for _, tc := range testcases {


### PR DESCRIPTION
The stack ID can be defined with expressions like `("id")` which evaluates to a valid stack ID but right now we don't handle parsing when cloning since parsing all possibilities would be quite some work, since we can't manipulate expressions properly using the HCL library and need to reimplement parsing using tokens. Here we just check that the ID is not a simple "id" and if it is not we fail explicitely, since the current behavior is to generate an invalid stack definition.

An expression not recognized by the clone will result in an error like:

```
2022-07-18T17:10:49+02:00 FTL cloning stack error="src stack ID not supported: ID must be a simple string literal" action=cli.cloneStack() dest=stacks/cloned-stack src=stacks/stack workingDir=/tmp/tmp.EARBTYTXtX
```

Ideally we should support any expression that is valid, this is just a way to fail fast/gracefully, in the future we may just properly update any valid stack IDs.