### PR TITLE
chore: improve stack clone update

### DIFF
--- a/cmd/terramate/e2etests/exp_clone_test.go
+++ b/cmd/terramate/e2etests/exp_clone_test.go
@@ -44,7 +44,7 @@ generate_hcl "test.hcl" {
 /*
   Commenting is fun
 */
-stack{
+stack {
   // Commenting stack ID
   id = %q // comment after ID expression
   // Commenting stack name

--- a/hcl/lex/lex.go
+++ b/hcl/lex/lex.go
@@ -15,10 +15,8 @@
 package lex
 
 import (
-	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/hashicorp/hcl/v2/hclwrite"
-	"github.com/mineiros-io/terramate/errors"
 )
 
 // StringLiteralTokens creates all tokens to represent the given string as an hcl
@@ -39,22 +37,6 @@ func TokenQuotedLit(name string) *hclwrite.Token {
 	}
 }
 
-// TokenIdent creates a new identifier token
-func TokenIdent(name string) *hclwrite.Token {
-	return &hclwrite.Token{
-		Type:  hclsyntax.TokenIdent,
-		Bytes: []byte(name),
-	}
-}
-
-// TokenOBrace creates a new { token.
-func TokenOBrace() *hclwrite.Token {
-	return &hclwrite.Token{
-		Type:  hclsyntax.TokenOBrace,
-		Bytes: []byte{byte(hclsyntax.TokenOBrace)},
-	}
-}
-
 // TokenOQuote creates a new open quote " token.
 func TokenOQuote() *hclwrite.Token {
 	return &hclwrite.Token{
@@ -67,91 +49,4 @@ func TokenCQuote() *hclwrite.Token {
 	return &hclwrite.Token{
 		Type: hclsyntax.TokenCQuote,
 	}
-}
-
-// TokenEqual creates a new = token.
-func TokenEqual() *hclwrite.Token {
-	return &hclwrite.Token{
-		Type:  hclsyntax.TokenEqual,
-		Bytes: []byte{byte(hclsyntax.TokenEqual)},
-	}
-}
-
-// TokenEquals compare if two tokens have the same type and bytes.
-func TokenEquals(token1, token2 *hclwrite.Token) bool {
-	return token1.Type == token2.Type &&
-		string(token1.Bytes) == string(token2.Bytes)
-}
-
-// FindTokenSequence finds the first match of the given token sequence
-// on the given tokens, returning the position of the first token of the
-// matched sequence. The contents of the tokens are also matched, not only their type.
-func FindTokenSequence(tokens hclwrite.Tokens, seq ...*hclwrite.Token) (int, bool) {
-	if len(seq) == 0 {
-		return 0, false
-	}
-searchMatch:
-	for i := 0; i < len(tokens); i++ {
-		for j := 0; j < len(seq); j++ {
-			pos := i + j
-
-			if pos >= len(tokens) {
-				break searchMatch
-			}
-
-			if !TokenEquals(tokens[pos], seq[j]) {
-				continue searchMatch
-			}
-		}
-		return i, true
-	}
-	return 0, false
-}
-
-// Config performs lexical analysis on the given buffer, treating it as a
-// whole HCL config file, and returns the resulting tokens.
-//
-// Only minimal validation is done during lexical analysis, so the returned
-// error may include errors about lexical issues such as bad character
-// encodings or unrecognized characters, but full parsing is required to
-// detect _all_ syntax errors.
-func Config(src []byte, filename string) (hclsyntax.Tokens, error) {
-	tokens, diags := hclsyntax.LexConfig(src, filename, hcl.Pos{Byte: 0, Line: 1, Column: 1})
-	if diags.HasErrors() {
-		return nil, errors.E(diags, "lexing configuration")
-	}
-	return tokens, nil
-}
-
-// WriterTokens takes a sequence of tokens as produced by the hclsyntax
-// package and transforms it into an equivalent sequence of tokens
-// from hclwrite, which then can be properly saved back on a file.
-//
-// The resulting list contains the same number of tokens and uses the same
-// indices as the input, allowing the two sets of tokens to be correlated by index.
-func WriterTokens(nativeTokens hclsyntax.Tokens) hclwrite.Tokens {
-	// This is mostly copied from a private function on hclwrite.
-	tokBuf := make([]hclwrite.Token, len(nativeTokens))
-	var lastByteOffset int
-	for i, mainToken := range nativeTokens {
-		bytes := make([]byte, len(mainToken.Bytes))
-		copy(bytes, mainToken.Bytes)
-
-		tokBuf[i] = hclwrite.Token{
-			Type:  mainToken.Type,
-			Bytes: bytes,
-			// We assume here that spaces are always ASCII spaces, since
-			// that's what the scanner also assumes, and thus the number
-			// of bytes skipped is also the number of space characters.
-			SpacesBefore: mainToken.Range.Start.Byte - lastByteOffset,
-		}
-
-		lastByteOffset = mainToken.Range.End.Byte
-	}
-
-	ret := make(hclwrite.Tokens, len(tokBuf))
-	for i := range ret {
-		ret[i] = &tokBuf[i]
-	}
-	return ret
 }

--- a/hcl/lex/lex.go
+++ b/hcl/lex/lex.go
@@ -21,6 +21,24 @@ import (
 	"github.com/mineiros-io/terramate/errors"
 )
 
+// StringLiteralTokens creates all tokens to represent the given string as an hcl
+// literal string.
+func StringLiteralTokens(literal string) hclwrite.Tokens {
+	return hclwrite.Tokens{
+		TokenOQuote(),
+		TokenQuotedLit(literal),
+		TokenCQuote(),
+	}
+}
+
+// TokenQuotedLit creates a new quoted literal token
+func TokenQuotedLit(name string) *hclwrite.Token {
+	return &hclwrite.Token{
+		Type:  hclsyntax.TokenQuotedLit,
+		Bytes: []byte(`"` + name + `"`),
+	}
+}
+
 // TokenIdent creates a new identifier token
 func TokenIdent(name string) *hclwrite.Token {
 	return &hclwrite.Token{
@@ -34,6 +52,20 @@ func TokenOBrace() *hclwrite.Token {
 	return &hclwrite.Token{
 		Type:  hclsyntax.TokenOBrace,
 		Bytes: []byte{byte(hclsyntax.TokenOBrace)},
+	}
+}
+
+// TokenOQuote creates a new open quote " token.
+func TokenOQuote() *hclwrite.Token {
+	return &hclwrite.Token{
+		Type: hclsyntax.TokenOQuote,
+	}
+}
+
+// TokenCQuote creates a new close quote " token.
+func TokenCQuote() *hclwrite.Token {
+	return &hclwrite.Token{
+		Type: hclsyntax.TokenCQuote,
 	}
 }
 

--- a/stack/clone.go
+++ b/stack/clone.go
@@ -21,7 +21,9 @@ import (
 	"strings"
 
 	"github.com/google/uuid"
+	hhcl "github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/mineiros-io/terramate/errors"
 	"github.com/mineiros-io/terramate/hcl"
 	"github.com/mineiros-io/terramate/hcl/lex"
@@ -32,10 +34,6 @@ const (
 	// ErrCloneDestDirExists indicates that the dest dir on a clone
 	// operation already exists.
 	ErrCloneDestDirExists errors.Kind = "clone dest dir exists"
-
-	// ErrCloneSrcStackIDNotSupported indicates that the source stack ID
-	// is not supported by clone.
-	ErrCloneSrcStackIDNotSupported errors.Kind = "src stack ID not supported"
 )
 
 // Clone will clone the stack at srcdir into destdir.
@@ -175,60 +173,41 @@ func updateStackID(stackdir string) error {
 
 	logger.Trace().Msg("lexing cloned stack file")
 
-	roTokens, err := lex.Config(stackContents, stackFilePath)
-	if err != nil {
-		return errors.E(err, "cloned stack is invalid HCL")
+	parsed, diags := hclwrite.ParseConfig([]byte(stackContents), stackFilePath, hhcl.InitialPos)
+	if diags.HasErrors() {
+		return errors.E(diags, "parsing cloned stack configuration")
 	}
 
-	logger.Trace().Msg("finding stack block on tokens")
+	blocks := parsed.Body().Blocks()
 
-	tokens := lex.WriterTokens(roTokens)
-	blockStart, ok := lex.FindTokenSequence(tokens, lex.TokenIdent(hcl.StackBlockType), lex.TokenOBrace())
-	if !ok {
-		return errors.E(err, "cloned stack doesn't have stack block")
-	}
-	blockStart += 2
+updateStackID:
+	for _, block := range blocks {
+		if block.Type() != hcl.StackBlockType {
+			continue
+		}
 
-	logger.Trace().Msg("finding id attribute")
+		body := block.Body()
+		attrs := body.Attributes()
+		for name := range attrs {
+			if name != hcl.StackIDField {
+				continue
+			}
 
-	// We can assume at this point that the stack has an ID, since previous parsing checked that.
-	// This is not generally safe, if we allow the stack block to have attributes that
-	// have objects as values and those objects can have an "id" field this will fail.
-	// If we allow multiple stack blocks, this will also fail.
-	// For now we are assuming stack blocks are constrained, for something safer we need
-	// a more proper parser instead of YOLO lexing.
+			id, err := uuid.NewRandom()
+			if err != nil {
+				return errors.E(err, "creating new ID for cloned stack")
+			}
 
-	idAttributeOffset, ok := lex.FindTokenSequence(tokens[blockStart:], lex.TokenIdent(hcl.StackIDField), lex.TokenEqual())
-	if !ok {
-		return errors.E(err, "cloned stack doesn't have stack ID")
-	}
-	idAttributeOffset += 2
-
-	logger.Trace().Msg("updating id attribute")
-
-	// Here we assume that stack IDs are also on the form:
-	// id = "id"
-	// Id's are very constrained and are always strings, so we expect
-	// the tokens: TokenOQuote + TokenQuotedLit + TokenCQuote
-	idQuotedLiteral := tokens[blockStart+idAttributeOffset+1]
-	if idQuotedLiteral.Type != hclsyntax.TokenQuotedLit {
-		// Ideally we should support anything that evaluates to a string
-		// on HCL, but for now to avoid too much parsing effort we assume
-		// simple plain strings like "id".
-		return errors.E(ErrCloneSrcStackIDNotSupported, "ID must be a simple string literal")
+			body.SetAttributeRaw(name, lex.StringLiteralTokens(id.String()))
+			break updateStackID
+		}
 	}
 
-	id, err := uuid.NewRandom()
-	if err != nil {
-		return errors.E(err, "creating new ID for cloned stack")
-	}
-	idQuotedLiteral.Bytes = []byte(id.String())
-
-	logger.Trace().Msg("saving updated tokens")
+	logger.Trace().Msg("saving updated file")
 
 	// Since we just created the clones stack files they have the default
 	// permissions given by Go on os.Create, 0666.
-	return os.WriteFile(stackFilePath, tokens.Bytes(), 0666)
+	return os.WriteFile(stackFilePath, parsed.Bytes(), 0666)
 }
 
 func getStackBody(parser *hcl.TerramateParser) (string, *hclsyntax.Body) {

--- a/stack/clone_test.go
+++ b/stack/clone_test.go
@@ -89,17 +89,6 @@ func TestStackClone(t *testing.T) {
 			dest:    "/cloned-stack",
 			wantErr: errors.E(stack.ErrCloneDestDirExists),
 		},
-		{
-			name: "src stack ID must be a string literal",
-			layout: []string{
-				`f:/stack/stack.tm.hcl:stack {
-				  id = ("id")
-				}`,
-			},
-			src:     "/stack",
-			dest:    "/cloned-stack",
-			wantErr: errors.E(stack.ErrCloneSrcStackIDNotSupported),
-		},
 	}
 
 	for _, tc := range testcases {

--- a/stack/clone_test.go
+++ b/stack/clone_test.go
@@ -165,7 +165,7 @@ generate_hcl "test.hcl" {
   Commenting is fun
 */
 
-stack{
+stack {
   // Commenting stack ID
   id = %q // comment after ID expression
   // Commenting stack name


### PR DESCRIPTION
Using hclwrite and some minimal token manipulation there is a much better way to replace the attribute. Sorry for the brainfart on the previous approach, I did something very similar for the formatting on hcl/fmt.go but apparently Im stupid x_x.