### PR TITLE
fix: codegen should generate empty files

### DIFF
--- a/generate/generate_file_check_test.go
+++ b/generate/generate_file_check_test.go
@@ -121,9 +121,30 @@ func TestCheckOutdatedDetectsEmptyGenerateFileContent(t *testing.T) {
 	)
 
 	assertOutdatedFiles([]string{"test.txt"})
-
 	s.Generate()
+	assertOutdatedFiles([]string{})
 
+	// Check having generated code and switch to no code
+	stackEntry.CreateConfig(
+		generateFile(
+			labels("test.txt"),
+			str("content", "code"),
+		).String(),
+	)
+
+	assertOutdatedFiles([]string{"test.txt"})
+	s.Generate()
+	assertOutdatedFiles([]string{})
+
+	stackEntry.CreateConfig(
+		generateFile(
+			labels("test.txt"),
+			str("content", ""),
+		).String(),
+	)
+
+	assertOutdatedFiles([]string{"test.txt"})
+	s.Generate()
 	assertOutdatedFiles([]string{})
 }
 

--- a/generate/generate_file_check_test.go
+++ b/generate/generate_file_check_test.go
@@ -98,7 +98,7 @@ func TestCheckReturnsOutdatedStackFilenamesForGeneratedFile(t *testing.T) {
 	assertOutdatedFiles([]string{})
 }
 
-func TestCheckOutdatedIgnoresEmptyGenerateFileContent(t *testing.T) {
+func TestCheckOutdatedDetectsEmptyGenerateFileContent(t *testing.T) {
 	s := sandbox.New(t)
 
 	stackEntry := s.CreateStack("stacks/stack")
@@ -113,29 +113,6 @@ func TestCheckOutdatedIgnoresEmptyGenerateFileContent(t *testing.T) {
 	}
 
 	// Checking detection when the config is empty at first
-	stackEntry.CreateConfig(
-		generateFile(
-			labels("test.txt"),
-			str("content", ""),
-		).String(),
-	)
-
-	assertOutdatedFiles([]string{})
-
-	// Checking detection when the config isnt empty, is generated and then becomes empty
-	stackEntry.CreateConfig(
-		generateFile(
-			labels("test.txt"),
-			str("content", "test"),
-		).String(),
-	)
-
-	assertOutdatedFiles([]string{"test.txt"})
-
-	s.Generate()
-
-	assertOutdatedFiles([]string{})
-
 	stackEntry.CreateConfig(
 		generateFile(
 			labels("test.txt"),

--- a/generate/generate_file_test.go
+++ b/generate/generate_file_test.go
@@ -67,6 +67,18 @@ func TestGenerateFile(t *testing.T) {
 					},
 				},
 			},
+			wantReport: generate.Report{
+				Successes: []generate.Result{
+					{
+						StackPath: "/stacks/stack-1",
+						Created:   []string{"empty"},
+					},
+					{
+						StackPath: "/stacks/stack-2",
+						Created:   []string{"empty"},
+					},
+				},
+			},
 		},
 		{
 			name: "generate_file with false condition generates nothing",

--- a/generate/generate_file_test.go
+++ b/generate/generate_file_test.go
@@ -39,7 +39,7 @@ func TestGenerateFile(t *testing.T) {
 	}
 	testCodeGeneration(t, checkGenFiles, []testcase{
 		{
-			name: "empty generate_file content generates nothing",
+			name: "empty generate_file content generates empty file",
 			layout: []string{
 				"s:stacks/stack-1",
 				"s:stacks/stack-2",
@@ -51,6 +51,20 @@ func TestGenerateFile(t *testing.T) {
 						labels("empty"),
 						str("content", ""),
 					),
+				},
+			},
+			want: []generatedFile{
+				{
+					stack: "/stacks/stack-1",
+					files: map[string]fmt.Stringer{
+						"empty": stringer(""),
+					},
+				},
+				{
+					stack: "/stacks/stack-2",
+					files: map[string]fmt.Stringer{
+						"empty": stringer(""),
+					},
 				},
 			},
 		},

--- a/generate/generate_hcl_check_test.go
+++ b/generate/generate_hcl_check_test.go
@@ -120,7 +120,7 @@ func TestCheckReturnsOutdatedStackFilenamesForGeneratedHCL(t *testing.T) {
 	assertOutdatedFiles([]string{})
 }
 
-func TestCheckOutdatedIgnoresEmptyGenerateHCLBlocks(t *testing.T) {
+func TestCheckOutdatedDetectsEmptyGenerateHCLBlocks(t *testing.T) {
 	s := sandbox.New(t)
 
 	stackEntry := s.CreateStack("stacks/stack")
@@ -133,30 +133,6 @@ func TestCheckOutdatedIgnoresEmptyGenerateHCLBlocks(t *testing.T) {
 		assert.NoError(t, err)
 		assertEqualStringList(t, got, want)
 	}
-
-	// Checking detection when the config is empty at first
-	stackEntry.CreateConfig(
-		generateHCL(
-			labels("test.tf"),
-			content(),
-		).String())
-
-	assertOutdatedFiles([]string{})
-
-	// Checking detection when the config isnt empty, is generated and then becomes empty
-	stackEntry.CreateConfig(
-		generateHCL(
-			labels("test.tf"),
-			content(
-				block("whatever"),
-			),
-		).String())
-
-	assertOutdatedFiles([]string{"test.tf"})
-
-	s.Generate()
-
-	assertOutdatedFiles([]string{})
 
 	stackEntry.CreateConfig(
 		generateHCL(

--- a/generate/generate_hcl_check_test.go
+++ b/generate/generate_hcl_check_test.go
@@ -141,9 +141,30 @@ func TestCheckOutdatedDetectsEmptyGenerateHCLBlocks(t *testing.T) {
 		).String())
 
 	assertOutdatedFiles([]string{"test.tf"})
-
 	s.Generate()
+	assertOutdatedFiles([]string{})
 
+	// Check having generated code and switch to no code
+	stackEntry.CreateConfig(
+		generateHCL(
+			labels("test.tf"),
+			content(
+				str("test", "test"),
+			),
+		).String())
+
+	assertOutdatedFiles([]string{"test.tf"})
+	s.Generate()
+	assertOutdatedFiles([]string{})
+
+	stackEntry.CreateConfig(
+		generateHCL(
+			labels("test.tf"),
+			content(),
+		).String())
+
+	assertOutdatedFiles([]string{"test.tf"})
+	s.Generate()
 	assertOutdatedFiles([]string{})
 }
 

--- a/generate/generate_hcl_test.go
+++ b/generate/generate_hcl_test.go
@@ -50,7 +50,7 @@ func TestGenerateHCL(t *testing.T) {
 			},
 		},
 		{
-			name: "empty generate_hcl block generates nothing",
+			name: "empty generate_hcl block generates empty file",
 			layout: []string{
 				"s:stacks/stack-1",
 				"s:stacks/stack-2",
@@ -62,6 +62,20 @@ func TestGenerateHCL(t *testing.T) {
 						labels("empty"),
 						content(),
 					),
+				},
+			},
+			want: []generatedFile{
+				{
+					stack: "/stacks/stack-1",
+					files: map[string]fmt.Stringer{
+						"empty": hcldoc(),
+					},
+				},
+				{
+					stack: "/stacks/stack-2",
+					files: map[string]fmt.Stringer{
+						"empty": hcldoc(),
+					},
 				},
 			},
 		},

--- a/generate/generate_hcl_test.go
+++ b/generate/generate_hcl_test.go
@@ -78,6 +78,18 @@ func TestGenerateHCL(t *testing.T) {
 					},
 				},
 			},
+			wantReport: generate.Report{
+				Successes: []generate.Result{
+					{
+						StackPath: "/stacks/stack-1",
+						Created:   []string{"empty"},
+					},
+					{
+						StackPath: "/stacks/stack-2",
+						Created:   []string{"empty"},
+					},
+				},
+			},
 		},
 		{
 			name: "generate_hcl with false condition generates nothing",
@@ -1022,11 +1034,12 @@ func TestGenerateHCLCleanupOldFiles(t *testing.T) {
 	got = stackEntry.ListGenFiles()
 	assertEqualStringList(t, got, []string{"file1.tf"})
 
-	// Empty block generates no code, so it gets deleted
+	// condition = false gets deleted
 	rootConfig.Write(
 		hcldoc(
 			generateHCL(
 				labels("file1.tf"),
+				boolean("condition", false),
 				content(),
 			),
 		).String(),


### PR DESCRIPTION
# Reason for This Change

We want both generate_hcl and generate_file to generate empty files when content is empty, instead of the current behavior of not generating any file.

## Description of Changes

Both code generation and outdated code detection are fixed to handle empty files.