### PR TITLE
chore: remove mac 10.15 from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,7 @@ jobs:
       - name: make build
         run: make build
 
+
   gh_integration_test:
     name: GHA Integration Test
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-20.04", "macos-11"] # maybe in the future: windows-2019, windows-2022
+        # removed "macos-10.15" because of failures on GHA
+        # maybe in the future: windows-2019, windows-2022
+        os: ["ubuntu-20.04", "macos-11"] 
         go: ["1.17", "1.18"]
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-20.04", "macos-10.15", "macos-11"] # maybe in the future: windows-2019, windows-2022
+        os: ["ubuntu-20.04", "macos-11"] # maybe in the future: windows-2019, windows-2022
         go: ["1.17", "1.18"]
 
     steps:
@@ -62,7 +62,6 @@ jobs:
 
       - name: make build
         run: make build
-
 
   gh_integration_test:
     name: GHA Integration Test


### PR DESCRIPTION
Remove "macos-10.15" from the CI, it started to get cancelled all the time by GHA, maybe they dropped support to it or they are going through some issues with it. We could add it back if it starts working again.