### PR TITLE
feat: add support for directories in the stack order

### DIFF
--- a/cmd/terramate/e2etests/run_test.go
+++ b/cmd/terramate/e2etests/run_test.go
@@ -66,6 +66,15 @@ func TestCLIRunOrder(t *testing.T) {
 			},
 		},
 		{
+			name: "after regular file",
+			layout: []string{
+				fmt.Sprintf("s:stack:after=[%q]", test.WriteFile(t, "", "test.txt", `bleh`)),
+			},
+			want: runExpected{
+				Stdout: listStacks(`stack`),
+			},
+		},
+		{
 			name: "independent stacks, consistent ordering (lexicographic)",
 			layout: []string{
 				"s:batatinha",

--- a/cmd/terramate/e2etests/run_test.go
+++ b/cmd/terramate/e2etests/run_test.go
@@ -57,6 +57,15 @@ func TestCLIRunOrder(t *testing.T) {
 			},
 		},
 		{
+			name: "after non-existent path",
+			layout: []string{
+				fmt.Sprintf("s:stack:after=[%q]", test.NonExistingDir(t)),
+			},
+			want: runExpected{
+				Stdout: listStacks(`stack`),
+			},
+		},
+		{
 			name: "independent stacks, consistent ordering (lexicographic)",
 			layout: []string{
 				"s:batatinha",
@@ -541,7 +550,7 @@ func TestCLIRunOrder(t *testing.T) {
 			},
 		},
 		{
-			name: "before directory containing no stacks",
+			name: "before directory containing no stacks does nothing",
 			layout: []string{
 				`d:dir`,
 				`d:dir/dir2`,
@@ -553,7 +562,7 @@ func TestCLIRunOrder(t *testing.T) {
 			},
 		},
 		{
-			name: "after directory containing no stacks",
+			name: "after directory containing no stacks does nothing",
 			layout: []string{
 				`d:dir`,
 				`d:dir/dir2`,

--- a/cmd/terramate/e2etests/run_test.go
+++ b/cmd/terramate/e2etests/run_test.go
@@ -535,6 +535,32 @@ func TestCLIRunOrder(t *testing.T) {
 			},
 		},
 		{
+			name: "after stack containing sub-stacks",
+			layout: []string{
+				`s:parent`,
+				`s:parent/s1`,
+				`s:parent/s2`,
+				`s:parent/s3`,
+				`s:stack:after=["/parent"]`,
+			},
+			want: runExpected{
+				Stdout: listStacks("parent", "s1", "s2", "s3", "stack"),
+			},
+		},
+		{
+			name: "after sub-stack of parent",
+			layout: []string{
+				`s:parent`,
+				`s:parent/s1`,
+				`s:parent/s2`,
+				`s:parent/s3`,
+				`s:stack:after=["/parent/s2"]`,
+			},
+			want: runExpected{
+				Stdout: listStacks("parent", "s1", "s2", "s3", "stack"),
+			},
+		},
+		{
 			name: "before directory containing stacks",
 			layout: []string{
 				`d:dir`,

--- a/cmd/terramate/e2etests/run_test.go
+++ b/cmd/terramate/e2etests/run_test.go
@@ -530,11 +530,11 @@ func TestCLIRunOrder(t *testing.T) {
 			},
 		},
 		{
-			name: "before directory containing stacks in deep directories",
+			name: "after directory containing stacks in deep directories",
 			layout: []string{
 				`d:dir`,
-				`s:dir/A/B/C/D/A-stack`,
-				`s:Z-stack:before=["/dir"]`,
+				`s:dir/A/B/C/D/Z-stack`,
+				`s:A-stack:after=["/dir"]`,
 			},
 			want: runExpected{
 				Stdout: listStacks("Z-stack", "A-stack"),

--- a/cmd/terramate/e2etests/run_test.go
+++ b/cmd/terramate/e2etests/run_test.go
@@ -471,13 +471,14 @@ func TestCLIRunOrder(t *testing.T) {
 			},
 		},
 		{
-			name: "child stack can have explicit after clause to parent",
+			name: "child stack CANNOT have explicit after clause to parent",
 			layout: []string{
 				`s:stacks`,
 				`s:stacks/child:after=["/stacks"]`,
 			},
 			want: runExpected{
-				Stdout: listStacks("stacks", "child"),
+				Status:      defaultErrExitStatus,
+				StderrRegex: string(dag.ErrCycleDetected),
 			},
 		},
 		{
@@ -500,6 +501,32 @@ func TestCLIRunOrder(t *testing.T) {
 			want: runExpected{
 				Status:      defaultErrExitStatus,
 				StderrRegex: string(dag.ErrCycleDetected),
+			},
+		},
+		{
+			name: "after directory containing stacks",
+			layout: []string{
+				`d:dir`,
+				`s:dir/s1`,
+				`s:dir/s2`,
+				`s:dir/s3`,
+				`s:stack:after=["/dir"]`,
+			},
+			want: runExpected{
+				Stdout: listStacks("s1", "s2", "s3", "stack"),
+			},
+		},
+		{
+			name: "before directory containing stacks",
+			layout: []string{
+				`d:dir`,
+				`s:dir/s1`,
+				`s:dir/s2`,
+				`s:dir/s3`,
+				`s:stack:before=["/dir"]`,
+			},
+			want: runExpected{
+				Stdout: listStacks("stack", "s1", "s2", "s3"),
 			},
 		},
 	} {

--- a/cmd/terramate/e2etests/run_test.go
+++ b/cmd/terramate/e2etests/run_test.go
@@ -529,6 +529,41 @@ func TestCLIRunOrder(t *testing.T) {
 				Stdout: listStacks("stack", "s1", "s2", "s3"),
 			},
 		},
+		{
+			name: "before directory containing stacks in deep directories",
+			layout: []string{
+				`d:dir`,
+				`s:dir/A/B/C/D/A-stack`,
+				`s:Z-stack:before=["/dir"]`,
+			},
+			want: runExpected{
+				Stdout: listStacks("Z-stack", "A-stack"),
+			},
+		},
+		{
+			name: "before directory containing no stacks",
+			layout: []string{
+				`d:dir`,
+				`d:dir/dir2`,
+				`s:stack:before=["/dir"]`,
+				`s:stack2`,
+			},
+			want: runExpected{
+				Stdout: listStacks("stack", "stack2"),
+			},
+		},
+		{
+			name: "after directory containing no stacks",
+			layout: []string{
+				`d:dir`,
+				`d:dir/dir2`,
+				`s:stack:after=["/dir"]`,
+				`s:stack2`,
+			},
+			want: runExpected{
+				Stdout: listStacks("stack", "stack2"),
+			},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			sandboxes := []sandbox.S{

--- a/docs/orchestration.md
+++ b/docs/orchestration.md
@@ -104,7 +104,7 @@ stacks contained in the directory paths. As the stack you are saying:
 
 **after** ensures the opposite, that the stacks contained in the provided 
 directories are executed before the current stack. As the stack, you are saying:
-"I execute after these stacks".
+"I execute after all stacks inside these directories".
 
 For example, let's assume we have a project organized like this:
 

--- a/docs/orchestration.md
+++ b/docs/orchestration.md
@@ -99,8 +99,8 @@ Or they can be relative to the project root, starting with "/":
 ```
 
 **before** ensures that the configured stack is executed before the
-stacks contained in the directory entries. As the stack you are saying: 
-"I execute before these stacks".
+stacks contained in the directory paths. As the stack you are saying: 
+"I execute before all stacks inside these directories".
 
 **after** ensures the opposite, that the stacks contained in the provided 
 directories are executed before the current stack. As the stack, you are saying:

--- a/docs/orchestration.md
+++ b/docs/orchestration.md
@@ -78,8 +78,8 @@ just for cosmetic purposes can potentially change the execution order and break 
 Order of execution can be explicitly declared inside the **stack** block using
 the fields **before** and **after**. 
 
-Each field is a set of string paths (**set(string)**), where each string is a 
-reference to another directory, which can be a stack or contain stacks inside.
+Each field is a set of string (**set(string)**), where each string is a path that
+references another directory, which can be a stack or contain stacks inside.
 
 The explicit order can be used in conjunction with the implicit filesystem order
 but have in mind that a parent stack in the filesystem can never execute after a

--- a/docs/orchestration.md
+++ b/docs/orchestration.md
@@ -78,31 +78,33 @@ just for cosmetic purposes can potentially change the execution order and break 
 Order of execution can be explicitly declared inside the **stack** block using
 the fields **before** and **after**. 
 
-Each field is a set of strings (**set(string)**), where each string is a 
-reference to another stack.
+Each field is a set of string paths (**set(string)**), where each string is a 
+reference to another directory, which can be a stack or contain stacks inside.
 
 The explicit order can be used in conjunction with the implicit filesystem order
 but have in mind that a parent stack in the filesystem can never execute after a
 child one, and trying to make this using explicit **before** and **after** clauses
 will lead to a cycle error.
 
-References to stacks can be relative to the stack being configured in the form:
+References to directories can be relative to the stack being configured in the form:
 
 ```
-../../stack
+../../dir
 ```
 
 Or they can be relative to the project root, starting with "/":
 
 ```
-/path/relative/to/project/root/stack
+/path/relative/to/project/root/dir
 ```
 
 **before** ensures that the configured stack is executed before the
-listed stacks, as the stack you are saying "I execute before these stacks".
+stacks contained in the directory entries. As the stack you are saying: 
+"I execute before these stacks".
 
-**after** ensures the opposite, that the listed stacks are executed before
-the configured stack, you are saying "I execute after these stacks".
+**after** ensures the opposite, that the stacks contained in the provided 
+directories are executed before the current stack. As the stack, you are saying:
+"I execute after these stacks".
 
 For example, let's assume we have a project organized like this:
 

--- a/run/order.go
+++ b/run/order.go
@@ -146,8 +146,8 @@ func BuildDAG(
 
 	visited[s.Path()] = struct{}{}
 
-	checkOrderPaths := func(fieldname string, paths []string) []string {
-		newpaths := []string{}
+	cleanOrderPaths := func(fieldname string, paths []string) []string {
+		cleanpaths := []string{}
 		for _, path := range paths {
 			var abspath string
 			if filepath.IsAbs(path) {
@@ -159,16 +159,16 @@ func BuildDAG(
 			if err != nil {
 				logger.Warn().
 					Err(err).
-					Msgf(`failed to stat "%s" path %q`, fieldname, abspath)
+					Msgf(`failed to stat "%s" path %q - ignoring`, fieldname, abspath)
 			} else {
-				newpaths = append(newpaths, path)
+				cleanpaths = append(cleanpaths, path)
 			}
 		}
-		return newpaths
+		return cleanpaths
 	}
 
-	afterPaths := checkOrderPaths("after", s.After())
-	beforePaths := checkOrderPaths("before", s.Before())
+	afterPaths := cleanOrderPaths("after", s.After())
+	beforePaths := cleanOrderPaths("before", s.Before())
 
 	logger.Trace().Msg("Load all stacks in dir after current stack.")
 
@@ -184,8 +184,8 @@ func BuildDAG(
 		return fmt.Errorf("stack %q: failed to load the \"before\" stacks: %w", s, err)
 	}
 
-	logger.Debug().
-		Msg("Add new node to DAG.")
+	logger.Debug().Msg("Add new node to DAG.")
+
 	err = d.AddNode(dag.ID(s.Path()), s, toids(beforeStacks), toids(afterStacks))
 	if err != nil {
 		return fmt.Errorf("stack %q: failed to build DAG: %w", s, err)
@@ -195,8 +195,8 @@ func BuildDAG(
 	stacks = append(stacks, afterStacks...)
 	stacks = append(stacks, beforeStacks...)
 
-	logger.Trace().
-		Msg("Range over stacks.")
+	logger.Trace().Msg("Range over stacks.")
+
 	for _, s := range stacks {
 		logger = log.With().
 			Str("action", "BuildDAG()").
@@ -208,8 +208,8 @@ func BuildDAG(
 			continue
 		}
 
-		logger.Trace().
-			Msg("Build DAG.")
+		logger.Trace().Msg("Build DAG.")
+
 		err = BuildDAG(d, root, s, loader, visited)
 		if err != nil {
 			return fmt.Errorf("stack %q: failed to build DAG: %w", s, err)

--- a/run/order.go
+++ b/run/order.go
@@ -155,11 +155,15 @@ func BuildDAG(
 			} else {
 				abspath = filepath.Join(s.HostPath(), path)
 			}
-			_, err := os.Stat(abspath)
+			st, err := os.Stat(abspath)
 			if err != nil {
 				logger.Warn().
 					Err(err).
-					Msgf(`failed to stat "%s" path %q - ignoring`, fieldname, abspath)
+					Msgf("failed to stat %q path %q - ignoring", fieldname, abspath)
+			} else if !st.IsDir() {
+				logger.Warn().
+					Msgf("stack.%s path %q is not a directory - ignoring",
+						fieldname, path)
 			} else {
 				cleanpaths = append(cleanpaths, path)
 			}

--- a/run/order.go
+++ b/run/order.go
@@ -174,7 +174,7 @@ func BuildDAG(
 	afterPaths := removeWrongPaths("after", s.After())
 	beforePaths := removeWrongPaths("before", s.Before())
 
-	logger.Trace().Msg("Load all stacks in dir after current stack.")
+	logger.Trace().Msg("load all stacks in dir after current stack")
 
 	afterStacks, err := loader.LoadAll(root, s.HostPath(), afterPaths...)
 	if err != nil {

--- a/run/order.go
+++ b/run/order.go
@@ -146,7 +146,7 @@ func BuildDAG(
 
 	visited[s.Path()] = struct{}{}
 
-	cleanOrderPaths := func(fieldname string, paths []string) []string {
+	removeWrongPaths := func(fieldname string, paths []string) []string {
 		cleanpaths := []string{}
 		for _, path := range paths {
 			var abspath string
@@ -171,8 +171,8 @@ func BuildDAG(
 		return cleanpaths
 	}
 
-	afterPaths := cleanOrderPaths("after", s.After())
-	beforePaths := cleanOrderPaths("before", s.Before())
+	afterPaths := removeWrongPaths("after", s.After())
+	beforePaths := removeWrongPaths("before", s.Before())
 
 	logger.Trace().Msg("Load all stacks in dir after current stack.")
 


### PR DESCRIPTION
This PR adds support for using directories in the after/before clauses of the stack block.
This allows for a more flexible mechanism for defining stack ordering because this way users can organize similar stacks inside a common directory and use this directory as a reference in the order.