### PR TITLE
Add Logic For Git Base Ref Edge Case

### DIFF
--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -1058,8 +1058,17 @@ func (c *cli) runOnStacks() {
 		Str("workingDir", c.wd()).
 		Logger()
 
+	// Default the project's base reference to the git change base argument.
+	c.prj.baseRef = c.parsedArgs.GitChangeBase
+
 	if c.checkGitRemote() {
 		c.checkGit()
+	}
+
+	// If the Terramate configuration for the repository don't allow for determining a git base reference and the user
+	// has specified to automatically detect changes then report a fatal error back to the user.
+	if c.prj.baseRef == "" && c.parsedArgs.Changed {
+		log.Fatal().Msg("could not determine git base ref for automatic change detection")
 	}
 
 	if len(c.parsedArgs.Run.Command) == 0 {

--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -1065,7 +1065,7 @@ func (c *cli) runOnStacks() {
 		c.checkGit()
 	}
 
-	// If the Terramate configuration for the repository don't allow for determining a git base reference and the user
+	// If the Terramate configuration for the repository doesn't allow for determining a git base reference and the user
 	// has specified to automatically detect changes then report a fatal error back to the user.
 	if c.prj.baseRef == "" && c.parsedArgs.Changed {
 		log.Fatal().Msg("could not determine git base ref for automatic change detection")


### PR DESCRIPTION
# Reason for This Change

Closes #496

## Description of Changes

Adds some additional checks and logic related to determining what git change base ref to utilize when automatic change detection is specified by the user; as well as a fatal error message when automatic change detection is desired but the Terramate configuration does not allow for it to properly do so.
