### PR TITLE
fix: warn in case of unexpected terramate block

### DIFF
--- a/cmd/terramate/e2etests/list_test.go
+++ b/cmd/terramate/e2etests/list_test.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/mineiros-io/terramate/hcl"
 	"github.com/mineiros-io/terramate/test"
 	"github.com/mineiros-io/terramate/test/sandbox"
 )
@@ -169,6 +170,21 @@ func TestListStackWithNoTerramateBlock(t *testing.T) {
 	s.BuildTree([]string{"s:stack"})
 	cli := newCLI(t, s.RootDir())
 	assertRunResult(t, cli.listStacks(), runExpected{Stdout: "stack\n"})
+}
+
+func TestListLogsWarningIfConfigHasConflicts(t *testing.T) {
+	s := sandbox.New(t)
+	s.BuildTree([]string{
+		"s:stack",
+		`f:stack/terramate.tm:terramate {}`,
+	})
+
+	tmcli := newCLI(t, s.RootDir())
+	tmcli.loglevel = "warn"
+	assertRunResult(t, tmcli.listStacks(), runExpected{
+		Stdout:      "stack\n",
+		StderrRegex: string(hcl.ErrConfigConflict),
+	})
 }
 
 func TestListNoSuchFile(t *testing.T) {

--- a/cmd/terramate/e2etests/list_test.go
+++ b/cmd/terramate/e2etests/list_test.go
@@ -183,7 +183,7 @@ func TestListLogsWarningIfConfigHasConflicts(t *testing.T) {
 	tmcli.loglevel = "warn"
 	assertRunResult(t, tmcli.listStacks(), runExpected{
 		Stdout:      "stack\n",
-		StderrRegex: string(hcl.ErrConfigConflict),
+		StderrRegex: string(hcl.ErrUnexpectedTerramate),
 	})
 }
 

--- a/hcl/hcl.go
+++ b/hcl/hcl.go
@@ -1448,7 +1448,6 @@ func (p *TerramateParser) checkConflicts(cfg Config) error {
 				"`stack` block conflicts with `terramate` block defined at %s",
 				tmblock.RawOrigins[0].TypeRange.String(),
 			),
-
 			errors.E(ErrConfigConflict, tmblock.RawOrigins[0].TypeRange,
 				"`terramate` block conflicts with `stack` block defined at %s",
 				stackblock.TypeRange.String(),

--- a/hcl/hcl.go
+++ b/hcl/hcl.go
@@ -366,7 +366,7 @@ func (p *TerramateParser) ParseConfig() (Config, error) {
 	errs.Append(err)
 
 	if err == nil {
-		errs.Append(p.checkConflicts(cfg))
+		errs.Append(p.checkConfigSanity(cfg))
 	}
 
 	if err := errs.AsError(); err != nil {
@@ -1423,9 +1423,9 @@ func (p *TerramateParser) parseTerramateSchema() (Config, error) {
 	return config, nil
 }
 
-func (p *TerramateParser) checkConflicts(cfg Config) error {
+func (p *TerramateParser) checkConfigSanity(cfg Config) error {
 	logger := log.With().
-		Str("action", "checkConflicts()").
+		Str("action", "TerramateParser.checkConfigSanity()").
 		Logger()
 
 	rawconfig := p.Imported.Copy()

--- a/hcl/hcl.go
+++ b/hcl/hcl.go
@@ -630,7 +630,7 @@ func NewTerramate(reqversion string) *Terramate {
 
 // ParseDir will parse Terramate configuration from a given directory,
 // using root as project workspace, parsing all files with the suffixes .tm and
-// .tm.hcl. It's parses in non-strict mode for compatibility with older versions.
+// .tm.hcl. It parses in non-strict mode for compatibility with older versions.
 // Note: it does not recurse into child directories.
 func ParseDir(root string, dir string) (Config, error) {
 	logger := log.With().

--- a/hcl/hcl_stack_test.go
+++ b/hcl/hcl_stack_test.go
@@ -102,11 +102,12 @@ func TestHCLParserStackID(t *testing.T) {
 func TestHCLParserStack(t *testing.T) {
 	for _, tc := range []testcase{
 		{
-			name:      "empty stack block with terramate block works in nonStrict mode",
+			name:      "empty stack block with terramate block not in root works in nonStrict mode",
 			nonStrict: true,
+			parsedir:  "stack",
 			input: []cfgfile{
 				{
-					filename: "stack.tm",
+					filename: "stack/stack.tm",
 					body: `
 						terramate {
 							required_version = ""

--- a/hcl/hcl_stack_test.go
+++ b/hcl/hcl_stack_test.go
@@ -102,7 +102,7 @@ func TestHCLParserStackID(t *testing.T) {
 func TestHCLParserStack(t *testing.T) {
 	for _, tc := range []testcase{
 		{
-			name:      "empty stack block",
+			name:      "empty stack block with terramate block works in nonStrict mode",
 			nonStrict: true,
 			input: []cfgfile{
 				{
@@ -119,6 +119,26 @@ func TestHCLParserStack(t *testing.T) {
 				config: hcl.Config{
 					Terramate: &hcl.Terramate{},
 					Stack:     &hcl.Stack{},
+				},
+			},
+		},
+		{
+			name: "empty stack block with terramate block fails in strict mode",
+			input: []cfgfile{
+				{
+					filename: "stack.tm",
+					body: `
+						terramate {
+							required_version = ""
+						}
+						stack {}
+					`,
+				},
+			},
+			want: want{
+				errs: []error{
+					errors.E(hcl.ErrConfigConflict),
+					errors.E(hcl.ErrConfigConflict),
 				},
 			},
 		},

--- a/hcl/hcl_stack_test.go
+++ b/hcl/hcl_stack_test.go
@@ -123,7 +123,7 @@ func TestHCLParserStack(t *testing.T) {
 			},
 		},
 		{
-			name: "empty stack block with terramate block fails in strict mode",
+			name: "empty stack block with terramate block in root works in strict mode",
 			input: []cfgfile{
 				{
 					filename: "stack.tm",
@@ -136,9 +136,9 @@ func TestHCLParserStack(t *testing.T) {
 				},
 			},
 			want: want{
-				errs: []error{
-					errors.E(hcl.ErrConfigConflict),
-					errors.E(hcl.ErrConfigConflict),
+				config: hcl.Config{
+					Terramate: &hcl.Terramate{},
+					Stack:     &hcl.Stack{},
 				},
 			},
 		},

--- a/hcl/hcl_stack_test.go
+++ b/hcl/hcl_stack_test.go
@@ -102,7 +102,8 @@ func TestHCLParserStackID(t *testing.T) {
 func TestHCLParserStack(t *testing.T) {
 	for _, tc := range []testcase{
 		{
-			name: "empty stack block",
+			name:      "empty stack block",
+			nonStrict: true,
 			input: []cfgfile{
 				{
 					filename: "stack.tm",
@@ -160,7 +161,8 @@ func TestHCLParserStack(t *testing.T) {
 			},
 		},
 		{
-			name: "empty name",
+			name:      "empty name",
+			nonStrict: true,
 			input: []cfgfile{
 				{
 					filename: "stack.tm",
@@ -330,7 +332,8 @@ func TestHCLParserStack(t *testing.T) {
 			},
 		},
 		{
-			name: "after: empty set works",
+			name:      "after: empty set works",
+			nonStrict: true,
 			input: []cfgfile{
 				{
 					filename: "stack.tm",
@@ -350,7 +353,8 @@ func TestHCLParserStack(t *testing.T) {
 			},
 		},
 		{
-			name: "'after' single entry",
+			name:      "'after' single entry",
+			nonStrict: true,
 			input: []cfgfile{
 				{
 					filename: "stack.tm",
@@ -487,7 +491,8 @@ func TestHCLParserStack(t *testing.T) {
 			},
 		},
 		{
-			name: "'before' single entry",
+			name:      "'before' single entry",
+			nonStrict: true,
 			input: []cfgfile{
 				{
 					filename: "stack.tm",
@@ -512,7 +517,8 @@ func TestHCLParserStack(t *testing.T) {
 			},
 		},
 		{
-			name: "'before' multiple entries",
+			name:      "'before' multiple entries",
+			nonStrict: true,
 			input: []cfgfile{
 				{
 					filename: "stack.tm",
@@ -579,7 +585,8 @@ func TestHCLParserStack(t *testing.T) {
 			},
 		},
 		{
-			name: "'before' and 'after'",
+			name:      "'before' and 'after'",
+			nonStrict: true,
 			input: []cfgfile{
 				{
 					filename: "stack.tm",

--- a/hcl/hcl_test.go
+++ b/hcl/hcl_test.go
@@ -776,6 +776,33 @@ func TestHCLParserTerramateBlocksMerging(t *testing.T) {
 			},
 		},
 		{
+			name:     "terramate in non-root directory fails",
+			parsedir: "stack",
+			input: []cfgfile{
+				{
+					filename: "stack/stack.tm",
+					body: `
+						stack {
+							name = "stack"
+						}
+					`,
+				},
+				{
+					filename: "stack/terramate.tm",
+					body: `
+						terramate {
+
+						}
+					`,
+				},
+			},
+			want: want{
+				errs: []error{
+					errors.E(hcl.ErrUnexpectedTerramate),
+				},
+			},
+		},
+		{
 			name: "multiple files with conflicting terramate.config.git attributes fail",
 			input: []cfgfile{
 				{

--- a/hcl/hcl_test.go
+++ b/hcl/hcl_test.go
@@ -40,11 +40,12 @@ type (
 	}
 
 	testcase struct {
-		name     string
-		parsedir string
-		rootdir  string
-		input    []cfgfile
-		want     want
+		name      string
+		nonStrict bool
+		parsedir  string
+		rootdir   string
+		input     []cfgfile
+		want      want
 	}
 )
 
@@ -687,7 +688,8 @@ func TestHCLParserTerramateBlocksMerging(t *testing.T) {
 			},
 		},
 		{
-			name: "three config files with terramate and stack blocks",
+			name:      "three config files with terramate and stack blocks",
+			nonStrict: true,
 			input: []cfgfile{
 				{
 					filename: "version.tm",
@@ -843,7 +845,8 @@ func testParser(t *testing.T, tc testcase) {
 		} else {
 			tc.rootdir = filepath.Join(configsDir, tc.rootdir)
 		}
-		got, err := hcl.ParseDir(tc.rootdir, tc.parsedir)
+
+		got, err := parse(t, tc)
 		errtest.AssertErrorList(t, err, tc.want.errs)
 
 		var gotErrs *errors.List
@@ -888,6 +891,29 @@ func testParser(t *testing.T, tc testcase) {
 		}
 		testParser(t, newtc)
 	}
+}
+
+func parse(t *testing.T, tc testcase) (hcl.Config, error) {
+	var (
+		parser *hcl.TerramateParser
+		err    error
+	)
+
+	if tc.nonStrict {
+		parser, err = hcl.NewTerramateParser(tc.rootdir, tc.parsedir)
+	} else {
+		parser, err = hcl.NewStrictTerramateParser(tc.rootdir, tc.parsedir)
+	}
+
+	if err != nil {
+		return hcl.Config{}, err
+	}
+
+	err = parser.AddDir(tc.parsedir)
+	if err != nil {
+		return hcl.Config{}, errors.E("adding files to parser", err)
+	}
+	return parser.ParseConfig()
 }
 
 func TestHCLParseReParsingFails(t *testing.T) {

--- a/hcl/raw_config.go
+++ b/hcl/raw_config.go
@@ -46,6 +46,13 @@ func NewRawConfig() RawConfig {
 	}
 }
 
+// Copy cfg into a new RawConfig
+func (cfg RawConfig) Copy() RawConfig {
+	n := NewRawConfig()
+	n.Merge(cfg)
+	return n
+}
+
 func (cfg *RawConfig) mergeHandlers() map[string]mergeHandler {
 	return map[string]mergeHandler{
 		"terramate":     cfg.mergeBlock,

--- a/hcl/raw_config.go
+++ b/hcl/raw_config.go
@@ -49,7 +49,7 @@ func NewRawConfig() RawConfig {
 // Copy cfg into a new RawConfig
 func (cfg RawConfig) Copy() RawConfig {
 	n := NewRawConfig()
-	n.Merge(cfg)
+	_ = n.Merge(cfg)
 	return n
 }
 


### PR DESCRIPTION
```
$ cat stack-a/terramate.tm.hcl
stack {
	name = "awesome-stack-a"
}

terramate {

}
$ terramate list
2022-08-04T02:17:37+01:00 WRN  error="/home/i4k/src/mineiros/tm-example/stack-a/terramate.tm.hcl:5,1-10: `terramate` block is only allowed at the project root directory" action=checkConflicts()
stack-a
stack-b
stack-c
```
