### PR TITLE
test: add regression test for issue #515

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -17,7 +17,6 @@ package config
 import (
 	"path/filepath"
 
-	"github.com/mineiros-io/terramate/errors"
 	"github.com/mineiros-io/terramate/hcl"
 	"github.com/rs/zerolog/log"
 )
@@ -41,13 +40,10 @@ func TryLoadRootConfig(fromdir string) (cfg hcl.Config, configpath string, found
 
 		cfg, err = hcl.ParseDir(fromdir, fromdir)
 		if err != nil {
-			// the imports only works for the correct rootdir.
-			// As we are looking for the rootdir, we should ignore ErrImport
-			// errors.
-			if !errors.IsKind(err, hcl.ErrImport) {
-				return hcl.Config{}, "", false, err
-			}
-		} else if cfg.Terramate != nil && cfg.Terramate.Config != nil {
+			return hcl.Config{}, "", false, err
+		}
+
+		if cfg.Terramate != nil && cfg.Terramate.Config != nil {
 			return cfg, fromdir, true, nil
 		}
 

--- a/config/config.go
+++ b/config/config.go
@@ -17,6 +17,7 @@ package config
 import (
 	"path/filepath"
 
+	"github.com/mineiros-io/terramate/errors"
 	"github.com/mineiros-io/terramate/hcl"
 	"github.com/rs/zerolog/log"
 )
@@ -40,10 +41,13 @@ func TryLoadRootConfig(fromdir string) (cfg hcl.Config, configpath string, found
 
 		cfg, err = hcl.ParseDir(fromdir, fromdir)
 		if err != nil {
-			return hcl.Config{}, "", false, err
-		}
-
-		if cfg.Terramate != nil && cfg.Terramate.Config != nil {
+			// the imports only works for the correct rootdir.
+			// As we are looking for the rootdir, we should ignore ErrImport
+			// errors.
+			if !errors.IsKind(err, hcl.ErrImport) {
+				return hcl.Config{}, "", false, err
+			}
+		} else if cfg.Terramate != nil && cfg.Terramate.Config != nil {
 			return cfg, fromdir, true, nil
 		}
 


### PR DESCRIPTION
# Reason for This Change

Adding a regression test for the issue reported on #515.

## Description of Changes

The code was reverted to confirm the test is catching the same error.
We reproduced the error with an e2e test:

```
--- FAIL: TestBug515 (0.19s)
    general_test.go:514: stdout mismatch: got "" != want ".\n"
    general_test.go:514: stderr mismatch: got "2022-08-04T15:24:51+02:00 FTL failed to lookup project root error=\"/tmp/TestBug5152882507097/001/sandbox/stacks/stack/import.tm:3,14-31: import error: failed to create sub parser: failed to stat directory \\\"/tmp/TestBug5152882507097/001/sandbox/stacks/stack/common\\\": stat /tmp/TestBug5152882507097/001/sandbox/stacks/stack/common: no such file or directory\" action=newCli() workingDir=/home/katz/workspace/terramate/cmd/terramate/e2etests\n" != want ""
    general_test.go:514: wanted[0] but got[1]: exit status mismatch
```

It shows the failure + the same error message involving the creation of the sub parser for the import block (this can be observed [here](https://github.com/mineiros-io/terramate/runs/7673098448?check_suite_focus=true#step:4:38)).
