### PR TITLE
fix: vendor download should use env vars on git clone

### DIFF
--- a/modvendor/modvendor.go
+++ b/modvendor/modvendor.go
@@ -90,6 +90,7 @@ func Vendor(vendordir string, modsrc tf.Source) (string, error) {
 	g, err := git.WithConfig(git.Config{
 		WorkingDir:     workdir,
 		AllowPorcelain: true,
+		Env:            os.Environ(),
 	})
 	if err != nil {
 		return "", err


### PR DESCRIPTION
# Reason for This Change

Currently when running git clone on modvendor we are not loading any of the environment variables since by default our git instances force an empty env. 

## Description of Changes

For clone, on modvendor, we add the parent process env.
