### PR TITLE
fix: vendor download does not work with commit IDs

### DIFF
--- a/git/git.go
+++ b/git/git.go
@@ -420,13 +420,13 @@ func (git *Git) Add(files ...string) error {
 	return err
 }
 
-// CloneBranch will clone a single branch of the given repo inside the given dir.
-// Beware: CloneBranch is a porcelain method.
-func (git *Git) CloneBranch(repoURL, branch, dir string) error {
+// Clone will clone the given repo inside the given dir.
+// Beware: Clone is a porcelain method.
+func (git *Git) Clone(repoURL, dir string) error {
 	if !git.config.AllowPorcelain {
 		return fmt.Errorf("Clone: %w", ErrDenyPorcelain)
 	}
-	_, err := git.exec("clone", "--single-branch", "--branch", branch, repoURL, dir)
+	_, err := git.exec("clone", repoURL, dir)
 	return err
 }
 

--- a/git/git_test.go
+++ b/git/git_test.go
@@ -140,7 +140,7 @@ func TestRevParse(t *testing.T) {
 	assert.EqualStrings(t, CookedCommitID, out, "commit mismatch")
 }
 
-func TestCloneBranch(t *testing.T) {
+func TestClone(t *testing.T) {
 	const (
 		filename = "test.txt"
 		content  = "test"
@@ -152,27 +152,11 @@ func TestCloneBranch(t *testing.T) {
 	git.CommitAll("add file")
 
 	repoURL := "file://" + s.RootDir()
-	mainCloneDir := t.TempDir()
-	git.CloneBranch(repoURL, "main", mainCloneDir)
+	cloneDir := t.TempDir()
+	git.Clone(repoURL, cloneDir)
 
-	got := test.ReadFile(t, mainCloneDir, filename)
+	got := test.ReadFile(t, cloneDir, filename)
 	assert.EqualStrings(t, content, string(got))
-
-	const (
-		newFilename = "new.txt"
-		newContent  = "new"
-	)
-
-	git.CheckoutNew("branch")
-	s.RootEntry().CreateFile(newFilename, newContent)
-	git.CommitAll("add new file on branch")
-	git.Checkout("main")
-
-	branchCloneDir := t.TempDir()
-	git.CloneBranch(repoURL, "branch", branchCloneDir)
-
-	assert.EqualStrings(t, content, string(test.ReadFile(t, branchCloneDir, filename)))
-	assert.EqualStrings(t, newContent, string(test.ReadFile(t, branchCloneDir, newFilename)))
 }
 
 func TestCurrentBranch(t *testing.T) {

--- a/modvendor/modvendor.go
+++ b/modvendor/modvendor.go
@@ -97,9 +97,11 @@ func Vendor(vendordir string, modsrc tf.Source) (string, error) {
 
 	logger.Trace().Msg("cloning to workdir")
 
-	if err := g.CloneBranch(modsrc.URL, modsrc.Ref, workdir); err != nil {
+	if err := g.Clone(modsrc.URL, workdir); err != nil {
 		return "", err
 	}
+
+	// TODO(katcipis): now we need to checkout the correct branch/commitID
 
 	if err := os.RemoveAll(filepath.Join(workdir, ".git")); err != nil {
 		return "", errors.E(err, "removing .git dir from cloned repo")

--- a/modvendor/modvendor.go
+++ b/modvendor/modvendor.go
@@ -101,7 +101,11 @@ func Vendor(vendordir string, modsrc tf.Source) (string, error) {
 		return "", err
 	}
 
-	// TODO(katcipis): now we need to checkout the correct branch/commitID
+	const create = false
+
+	if err := g.Checkout(modsrc.Ref, create); err != nil {
+		return "", errors.E(err, "checking revision %s", modsrc.Ref)
+	}
 
 	if err := os.RemoveAll(filepath.Join(workdir, ".git")); err != nil {
 		return "", errors.E(err, "removing .git dir from cloned repo")

--- a/modvendor/modvendor.go
+++ b/modvendor/modvendor.go
@@ -104,7 +104,7 @@ func Vendor(vendordir string, modsrc tf.Source) (string, error) {
 	const create = false
 
 	if err := g.Checkout(modsrc.Ref, create); err != nil {
-		return "", errors.E(err, "checking revision %s", modsrc.Ref)
+		return "", errors.E(err, "checking ref %s", modsrc.Ref)
 	}
 
 	if err := os.RemoveAll(filepath.Join(workdir, ".git")); err != nil {

--- a/test/sandbox/git.go
+++ b/test/sandbox/git.go
@@ -175,12 +175,12 @@ func (git Git) Commit(msg string, args ...string) {
 	}
 }
 
-// CloneBranch will clone a repository into the given dir.
-func (git Git) CloneBranch(repoURL, branch, dir string) {
+// Clone will clone a repository into the given dir.
+func (git Git) Clone(repoURL, dir string) {
 	git.t.Helper()
 
-	if err := git.g.CloneBranch(repoURL, branch, dir); err != nil {
-		git.t.Fatalf("Git.CloneBranch(%q, %q, %q) = %v", repoURL, branch, dir, err)
+	if err := git.g.Clone(repoURL, dir); err != nil {
+		git.t.Fatalf("Git.Clone(%q, %q) = %v", repoURL, dir, err)
 	}
 }
 


### PR DESCRIPTION
# Reason for This Change

Vendoring with commit IDs is not working.

## Description of Changes

We were using git clone --branch but that only works for branches, not specific commit IDs. Now we do a clone + checkout on the cloned repo.

## Test Script

```sh
#!/bin/bash

set -o errexit
set -o nounset
set -o pipefail

workdir="$(mktemp -d)"
cd "${workdir}"

cat > terramate.tm.hcl <<- EOM
terramate {
  config {
  }
}
EOM

terramate experimental vendor download github.com/mineiros-io/terramate main
terramate experimental vendor download github.com/mineiros-io/terramate c6847ea138d0008de79b6a0e1790a15c3b5524ef
terramate experimental vendor download git@github.com:mineiros-io/terramate.git v0.1.19

echo "vendor:"
tree -d -L 4 vendor

echo "checking VERSION files of each vendored repo"
cat vendor/github.com/mineiros-io/terramate/main/VERSION
cat vendor/github.com/mineiros-io/terramate/c6847ea138d0008de79b6a0e1790a15c3b5524ef/VERSION
cat vendor/github.com/mineiros-io/terramate/v0.1.19/VERSION
```
