### PR TITLE
test: generate code for variable with optionals (tf 1.3)

### DIFF
--- a/generate/genhcl/genhcl_hclwrite_test.go
+++ b/generate/genhcl/genhcl_hclwrite_test.go
@@ -30,6 +30,10 @@ func block(name string, builders ...hclwrite.BlockBuilder) *hclwrite.Block {
 	return hclwrite.BuildBlock(name, builders...)
 }
 
+func variable(builders ...hclwrite.BlockBuilder) *hclwrite.Block {
+	return hclwrite.BuildBlock("variable", builders...)
+}
+
 func terraform(builders ...hclwrite.BlockBuilder) *hclwrite.Block {
 	return hclwrite.BuildBlock("terraform", builders...)
 }

--- a/generate/genhcl/genhcl_test.go
+++ b/generate/genhcl/genhcl_test.go
@@ -2162,6 +2162,57 @@ func TestPartialEval(t *testing.T) {
 			),
 		},
 		{
+			name: "variable definition optionals",
+			config: hcldoc(
+				variable(
+					labels("with_optional_attribute"),
+					expr("type", `object({
+					    a = string
+					    b = optional(string)
+					    c = optional(number, 1)
+					})`),
+				),
+			),
+			want: hcldoc(
+				variable(
+					labels("with_optional_attribute"),
+					expr("type", `object({
+					    a = string
+					    b = optional(string)
+					    c = optional(number, 1)
+					})`),
+				),
+			),
+		},
+		{
+			name: "variable definition with optional default from global",
+			globals: hcldoc(
+				globals(
+					number("default", 666),
+				),
+			),
+			config: hcldoc(
+				variable(
+					labels("with_optional_attribute"),
+					expr("type", `object({
+					    a = string
+					    b = optional(string)
+					    c = optional(number, global.default)
+					})`),
+				),
+			),
+			want: hcldoc(
+				variable(
+					labels("with_optional_attribute"),
+					expr("type", `object({
+					    a = string
+					    b = optional(string)
+					    c = optional(number, 666)
+					})`),
+				),
+			),
+		},
+		{
 			name: "function call on attr with mixed references is partially evaluated",
 			globals: hcldoc(
 				globals(

--- a/generate/genhcl/genhcl_test.go
+++ b/generate/genhcl/genhcl_test.go
@@ -2162,7 +2162,7 @@ func TestPartialEval(t *testing.T) {
 			),
 		},
 		{
-			name: "variable definition optionals",
+			name: "variable definition with optionals",
 			config: hcldoc(
 				variable(
 					labels("with_optional_attribute"),


### PR DESCRIPTION
# Reason for This Change

Just double checking that the new variable with optional descriptions work on Terramate. It parses it and partial evaluation also works on it.

## Description of Changes

Just added the test. Here is also a quick script to see it working live:

```sh
#!/bin/bash

set -o errexit
set -o nounset
set -o pipefail

workdir="$(mktemp -d)"
cd "${workdir}"

cat > terramate.tm.hcl <<- EOM
terramate {
  config {
  }
}
EOM

cat > variable.tm.hcl <<- EOM
globals {
  default = 666
}

generate_hcl "variable_optional.tf" {
  content {
    variable "with_optional_attribute" {
      type = object({
        a = string
        b = optional(string)
        c = optional(number, global.default)
      })
    }
  }
}
EOM

terramate create stack
terramate generate

echo
echo "generated code"
cat stack/variable_optional.tf
```
