### PR TITLE
feat: create: add --after and --before

### DIFF
--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -84,6 +84,8 @@ type cliSpec struct {
 		Name        string   `help:"Name of the stack, defaults to stack dir base name"`
 		Description string   `help:"Description of the stack, defaults to the stack name"`
 		Import      []string `help:"Add import block for the given path on the stack"`
+		After       []string `help:"Add a stack as after"`
+		Before      []string `help:"Add a stack as before"`
 	} `cmd:"" help:"Creates a stack on the project"`
 
 	Fmt struct {
@@ -585,6 +587,8 @@ func (c *cli) createStack() {
 		Str("workingDir", c.wd()).
 		Str("action", "cli.createStack()").
 		Str("imports", fmt.Sprint(c.parsedArgs.Create.Import)).
+		Str("after", fmt.Sprint(c.parsedArgs.Create.After)).
+		Str("before", fmt.Sprint(c.parsedArgs.Create.Before)).
 		Logger()
 
 	logger.Trace().Msg("creating stack")
@@ -618,6 +622,8 @@ func (c *cli) createStack() {
 		ID:          stackID,
 		Name:        stackName,
 		Description: stackDescription,
+		After:       c.parsedArgs.Create.After,
+		Before:      c.parsedArgs.Create.Before,
 		Imports:     c.parsedArgs.Create.Import,
 	})
 

--- a/cmd/terramate/e2etests/create_test.go
+++ b/cmd/terramate/e2etests/create_test.go
@@ -34,6 +34,10 @@ func TestCreateStack(t *testing.T) {
 		stackDescription = "stack description"
 		stackImport1     = "/core/file1.tm.hcl"
 		stackImport2     = "/core/file2.tm.hcl"
+		stackAfter1      = "stack-after-1"
+		stackAfter2      = "stack-after-2"
+		stackBefore1     = "stack-before-1"
+		stackBefore2     = "stack-before-2"
 		genFilename      = "file.txt"
 		genFileContent   = "testing is fun"
 	)
@@ -67,6 +71,10 @@ func TestCreateStack(t *testing.T) {
 			"--description", stackDescription,
 			"--import", stackImport1,
 			"--import", stackImport2,
+			"--after", stackAfter1,
+			"--after", stackAfter2,
+			"--before", stackBefore1,
+			"--before", stackBefore2,
 		)
 
 		t.Logf("run create stack %s", stackPath)
@@ -83,6 +91,8 @@ func TestCreateStack(t *testing.T) {
 		assert.EqualStrings(t, stackID, gotID)
 		assert.EqualStrings(t, stackName, got.Name(), "checking stack name")
 		assert.EqualStrings(t, stackDescription, got.Desc(), "checking stack description")
+		test.AssertDiff(t, got.After(), []string{stackAfter1, stackAfter2}, "created stack has invalid after")
+		test.AssertDiff(t, got.Before(), []string{stackBefore1, stackBefore2}, "created stack has invalid before")
 
 		test.AssertStackImports(t, s.RootDir(), got.HostPath(), []string{stackImport1, stackImport2})
 
@@ -102,6 +112,14 @@ func TestCreateStackDefaults(t *testing.T) {
 
 	assert.EqualStrings(t, "stack", got.Name(), "checking stack name")
 	assert.EqualStrings(t, "stack", got.Desc(), "checking stack description")
+
+	if len(got.After()) > 0 {
+		t.Fatalf("want no after, got: %v", got.After())
+	}
+
+	if len(got.Before()) > 0 {
+		t.Fatalf("want no before, got: %v", got.Before())
+	}
 
 	// By default the CLI generates an id with an UUID
 	gotID, _ := got.ID()

--- a/stack/create.go
+++ b/stack/create.go
@@ -56,6 +56,12 @@ type CreateCfg struct {
 
 	// Imports represents a set of import paths.
 	Imports []string
+
+	// After is the set of after stacks.
+	After []string
+
+	// Before is the set of before stacks.
+	Before []string
 }
 
 const (
@@ -107,7 +113,10 @@ func Create(rootdir string, cfg CreateCfg) (err error) {
 		return errors.E(ErrStackAlreadyExists, "name %q", parsedCfg.Stack.Name)
 	}
 
-	stackCfg := hcl.Stack{}
+	stackCfg := hcl.Stack{
+		After:  cfg.After,
+		Before: cfg.Before,
+	}
 
 	if cfg.Name != "" {
 		stackCfg.Name = cfg.Name
@@ -151,14 +160,18 @@ func Create(rootdir string, cfg CreateCfg) (err error) {
 	}()
 
 	if err := hcl.PrintConfig(stackFile, tmCfg); err != nil {
-		return errors.E(err, "writing stack imports to stack file")
+		return errors.E(err, "writing stack config to stack file")
 	}
 
 	if len(cfg.Imports) > 0 {
 		fmt.Fprint(stackFile, "\n")
 	}
 
-	return hcl.PrintImports(stackFile, cfg.Imports)
+	if err := hcl.PrintImports(stackFile, cfg.Imports); err != nil {
+		return errors.E(err, "writing stack imports to stack file")
+	}
+
+	return nil
 }
 
 func (cfg CreateCfg) String() string {

--- a/stack/create_test.go
+++ b/stack/create_test.go
@@ -32,6 +32,8 @@ func TestStackCreation(t *testing.T) {
 		name    string
 		desc    string
 		imports []string
+		after   []string
+		before  []string
 	}
 	type want struct {
 		err   error
@@ -148,7 +150,9 @@ func TestStackCreation(t *testing.T) {
 			create: stack.CreateCfg{
 				Dir: "stack-imports",
 				Imports: []string{
-					"/common/1.tm.hcl", "/common/2.tm.hcl"},
+					"/common/1.tm.hcl",
+					"/common/2.tm.hcl",
+				},
 			},
 			want: want{
 				stack: wantedStack{
@@ -157,6 +161,36 @@ func TestStackCreation(t *testing.T) {
 						"/common/1.tm.hcl",
 						"/common/2.tm.hcl",
 					},
+				},
+			},
+		},
+		{
+			name: "defining single after/before",
+			create: stack.CreateCfg{
+				Dir:    "stack-after-before",
+				After:  []string{"stack-after"},
+				Before: []string{"stack-before"},
+			},
+			want: want{
+				stack: wantedStack{
+					name:   "stack-after-before",
+					after:  []string{"stack-after"},
+					before: []string{"stack-before"},
+				},
+			},
+		},
+		{
+			name: "defining multiple after/before",
+			create: stack.CreateCfg{
+				Dir:    "stack-after-before",
+				After:  []string{"stack-1", "stack-2"},
+				Before: []string{"stack-3", "stack-4"},
+			},
+			want: want{
+				stack: wantedStack{
+					name:   "stack-after-before",
+					after:  []string{"stack-1", "stack-2"},
+					before: []string{"stack-3", "stack-4"},
 				},
 			},
 		},
@@ -223,6 +257,8 @@ func TestStackCreation(t *testing.T) {
 			assert.EqualStrings(t, want.desc, got.Desc(), "checking stack description")
 
 			test.AssertStackImports(t, s.RootDir(), got.HostPath(), want.imports)
+			test.AssertDiff(t, got.After(), want.after, "created stack has invalid after")
+			test.AssertDiff(t, got.Before(), want.before, "created stack has invalid before")
 		})
 	}
 }

--- a/stack/create_test.go
+++ b/stack/create_test.go
@@ -165,22 +165,7 @@ func TestStackCreation(t *testing.T) {
 			},
 		},
 		{
-			name: "defining single after/before",
-			create: stack.CreateCfg{
-				Dir:    "stack-after-before",
-				After:  []string{"stack-after"},
-				Before: []string{"stack-before"},
-			},
-			want: want{
-				stack: wantedStack{
-					name:   "stack-after-before",
-					after:  []string{"stack-after"},
-					before: []string{"stack-before"},
-				},
-			},
-		},
-		{
-			name: "defining multiple after/before",
+			name: "defining after/before",
 			create: stack.CreateCfg{
 				Dir:    "stack-after-before",
 				After:  []string{"stack-1", "stack-2"},

--- a/test/hcl.go
+++ b/test/hcl.go
@@ -15,6 +15,7 @@
 package test
 
 import (
+	"fmt"
 	"os"
 	"strings"
 	"testing"
@@ -76,11 +77,17 @@ func AssertTerramateConfig(t *testing.T, got, want hcl.Config) {
 
 // AssertDiff will compare the two values and fail if they are not the same
 // providing a comprehensive textual diff of the differences between them.
-func AssertDiff(t *testing.T, got, want interface{}) {
+// If provided msg must be a string + any formatting parameters. The msg will be
+// added if the assertion fails.
+func AssertDiff(t *testing.T, got, want interface{}, msg ...interface{}) {
 	t.Helper()
 
 	if diff := cmp.Diff(got, want); diff != "" {
-		t.Fatalf("-(got) +(want):\n%s", diff)
+		errmsg := fmt.Sprintf("-(got) +(want):\n%s", diff)
+		if len(msg) > 0 {
+			errmsg = fmt.Sprintf(msg[0].(string), msg[1:]...) + ": " + errmsg
+		}
+		t.Fatalf(errmsg)
 	}
 }
 


### PR DESCRIPTION
# Reason for This Change

Just as we can pass a list of imported stacks on `terramate create` with `--import` we want to define after/before for the created stack using `--after` and `--before`.

## Description of Changes

Added support to after/before on core logic + CLI.

## Example

```sh
#!/bin/bash

set -o errexit
set -o nounset
set -o pipefail

workdir=$(mktemp -d)
cd "${workdir}" || exit

cat > terramate.tm.hcl <<- EOM
terramate {
  config {
  }
}
EOM

terramate create stack 
cat stack/stack.tm.hcl
echo

mkdir common
touch common/file1.tm.hcl
touch common/file2.tm.hcl

mkdir stacks
cd stacks

terramate create stack-1 \
    --name "stack name" \
    --description "stack description" \
    --id "stack-id" \
    --after "stack-a" \
    --after "stack-b" \
    --before "stack-c" \
    --import "/common/file1.tm.hcl" \
    --import "/common/file2.tm.hcl"

echo
echo "=== created stack config ==="
cat stack-1/stack.tm.hcl
```