### PR TITLE
fix: tm_dynamic fails with  duplicated labels

### DIFF
--- a/generate/genhcl/genhcl.go
+++ b/generate/genhcl/genhcl.go
@@ -430,7 +430,7 @@ func appendDynamicBlock(target *hclwrite.Body, block *hclsyntax.Block, evaluator
 				return true
 			}
 
-			labels, err = hcl.ParseStringList("labels", labelsVal)
+			labels, err = hcl.ValueAsStringList(labelsVal)
 			if err != nil {
 				tmDynamicErr = wrapHCLAttrErr(err, attrs.labels,
 					"parsing tm_dynamic.labels")

--- a/generate/genhcl/genhcl.go
+++ b/generate/genhcl/genhcl.go
@@ -292,7 +292,7 @@ func copyBody(dest *hclwrite.Body, src *hclsyntax.Body, eval hcl.Evaluator) erro
 		Str("action", "genhcl.copyBody()").
 		Logger()
 
-	logger.Trace().Msg("Sorting attributes.")
+	logger.Trace().Msg("sorting attributes")
 
 	attrs := ast.SortRawAttributes(src.Attributes)
 	for _, attr := range attrs {
@@ -310,7 +310,7 @@ func copyBody(dest *hclwrite.Body, src *hclsyntax.Body, eval hcl.Evaluator) erro
 		dest.SetAttributeRaw(attr.Name, tokens)
 	}
 
-	logger.Trace().Msg("Append blocks.")
+	logger.Trace().Msg("appending blocks")
 
 	for _, block := range src.Blocks {
 		err := appendBlock(dest, block, eval)
@@ -342,7 +342,7 @@ func appendDynamicBlock(target *hclwrite.Body, block *hclsyntax.Block, evaluator
 		Str("action", "genhcl.appendDynamicBlock").
 		Logger()
 
-	logger.Trace().Msg("parsing tm_dynamic block")
+	logger.Trace().Msg("appending tm_dynamic block")
 
 	errs := errors.L()
 
@@ -384,11 +384,13 @@ func appendDynamicBlock(target *hclwrite.Body, block *hclsyntax.Block, evaluator
 	if attrs.iterator != nil {
 		iteratorTraversal, diags := hhcl.AbsTraversalForExpr(attrs.iterator.Expr)
 		if diags.HasErrors() {
-			return errors.E(diags, ErrInvalidDynamicIterator,
-				"failed to parse iterator expression")
+			return errors.E(ErrInvalidDynamicIterator,
+				attrs.iterator.Range(),
+				"dynamic iterator must be a single variable name")
 		}
 		if len(iteratorTraversal) != 1 {
-			return hclAttrErr(attrs.iterator,
+			return errors.E(ErrInvalidDynamicIterator,
+				attrs.iterator.Range(),
 				"dynamic iterator must be a single variable name")
 		}
 		iterator = iteratorTraversal.RootName()

--- a/generate/genhcl/genhcl.go
+++ b/generate/genhcl/genhcl.go
@@ -20,10 +20,13 @@ import (
 	"sort"
 	"strings"
 
+	hhcl "github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/mineiros-io/terramate/errors"
 	"github.com/mineiros-io/terramate/hcl"
+	"github.com/mineiros-io/terramate/hcl/ast"
+	"github.com/mineiros-io/terramate/hcl/eval"
 	"github.com/mineiros-io/terramate/project"
 	"github.com/mineiros-io/terramate/stack"
 	"github.com/rs/zerolog/log"
@@ -61,6 +64,10 @@ const (
 	// ErrInvalidConditionType indicates the condition attribute
 	// has an invalid type.
 	ErrInvalidConditionType errors.Kind = "invalid condition type"
+
+	// ErrInvalidDynamicIterator indicates that the iterator of a tm_dynamic block
+	// is invalid.
+	ErrInvalidDynamicIterator errors.Kind = "invalid dynamic iterator"
 )
 
 // Name of the HCL code.
@@ -167,7 +174,7 @@ func Load(rootdir string, sm stack.Metadata, globals stack.Globals) ([]HCL, erro
 		logger.Trace().Msg("evaluating block")
 
 		gen := hclwrite.NewEmptyFile()
-		if err := hcl.CopyBody(gen.Body(), loadedHCL.block.Body, evalctx); err != nil {
+		if err := copyBody(gen.Body(), loadedHCL.block.Body, evalctx); err != nil {
 			return nil, errors.E(ErrContentEval, sm, err,
 				"generate_hcl %q", name,
 			)
@@ -208,6 +215,13 @@ type loadedHCL struct {
 	origin    string
 	block     *hclsyntax.Block
 	condition *hclsyntax.Attribute
+}
+
+type dynBlockAttributes struct {
+	attributes *hclsyntax.Attribute
+	iterator   *hclsyntax.Attribute
+	foreach    *hclsyntax.Attribute
+	labels     *hclsyntax.Attribute
 }
 
 // loadGenHCLBlocks will load all generate_hcl blocks.
@@ -264,4 +278,337 @@ func loadGenHCLBlocks(rootdir string, cfgdir string) ([]loadedHCL, error) {
 
 	logger.Trace().Msg("loaded generate_hcl blocks with success.")
 	return res, nil
+}
+
+// copyBody will copy the src body to the given target, evaluating attributes
+// using the given evaluation context.
+//
+// Scoped traversals, like name.traverse, for unknown namespaces will be copied
+// as is (original expression form, no evaluation).
+//
+// Returns an error if the evaluation fails.
+func copyBody(dest *hclwrite.Body, src *hclsyntax.Body, eval hcl.Evaluator) error {
+	logger := log.With().
+		Str("action", "genhcl.copyBody()").
+		Logger()
+
+	logger.Trace().Msg("Sorting attributes.")
+
+	attrs := ast.SortRawAttributes(src.Attributes)
+	for _, attr := range attrs {
+		logger := logger.With().
+			Str("attrName", attr.Name).
+			Logger()
+
+		logger.Trace().Msg("evaluating.")
+		tokens, err := eval.PartialEval(attr.Expr)
+		if err != nil {
+			return errors.E(err, attr.Expr.Range())
+		}
+
+		logger.Trace().Str("attribute", attr.Name).Msg("Setting evaluated attribute.")
+		dest.SetAttributeRaw(attr.Name, tokens)
+	}
+
+	logger.Trace().Msg("Append blocks.")
+
+	for _, block := range src.Blocks {
+		err := appendBlock(dest, block, eval)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func appendBlock(target *hclwrite.Body, block *hclsyntax.Block, eval hcl.Evaluator) error {
+	if block.Type == "tm_dynamic" {
+		return appendDynamicBlock(target, block, eval)
+	}
+
+	targetBlock := target.AppendNewBlock(block.Type, block.Labels)
+	if block.Body != nil {
+		err := copyBody(targetBlock.Body(), block.Body, eval)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func appendDynamicBlock(target *hclwrite.Body, block *hclsyntax.Block, evaluator hcl.Evaluator) error {
+	logger := log.With().
+		Str("action", "genhcl.appendDynamicBlock").
+		Logger()
+
+	logger.Trace().Msg("parsing tm_dynamic block")
+
+	errs := errors.L()
+
+	if len(block.Labels) != 1 {
+		errs.Append(errors.E(hcl.ErrTerramateSchema,
+			block.LabelRanges, "tm_dynamic requires a single label"))
+	}
+
+	attrs, err := getDynamicBlockAttrs(block)
+	errs.Append(err)
+
+	contentBlock, err := getContentBlock(block.Body.Blocks)
+	errs.Append(err)
+
+	if contentBlock == nil && attrs.attributes == nil {
+		errs.Append(errors.E(hcl.ErrTerramateSchema, block.Body.Range(),
+			"`content` block or `attributes` obj must be defined"))
+	}
+
+	if contentBlock != nil && attrs.attributes != nil {
+		errs.Append(errors.E(hcl.ErrTerramateSchema, block.Body.Range(),
+			"`content` block and `attributes` obj are not allowed together"))
+	}
+
+	if err := errs.AsError(); err != nil {
+		return err
+	}
+
+	genBlockType := block.Labels[0]
+
+	logger = logger.With().
+		Str("genBlockType", genBlockType).
+		Logger()
+
+	logger.Trace().Msg("defining iterator name")
+
+	iterator := genBlockType
+
+	if attrs.iterator != nil {
+		iteratorTraversal, diags := hhcl.AbsTraversalForExpr(attrs.iterator.Expr)
+		if diags.HasErrors() {
+			return errors.E(diags, ErrInvalidDynamicIterator,
+				"failed to parse iterator expression")
+		}
+		if len(iteratorTraversal) != 1 {
+			return hclAttrErr(attrs.iterator,
+				"dynamic iterator must be a single variable name")
+		}
+		iterator = iteratorTraversal.RootName()
+	}
+
+	logger = logger.With().
+		Str("iterator", iterator).
+		Logger()
+
+	logger.Trace().Msg("evaluating for_each attribute")
+
+	forEachVal, err := evaluator.Eval(attrs.foreach.Expr)
+	if err != nil {
+		return wrapHCLAttrErr(err, attrs.foreach, "evaluating `for_each` expression")
+	}
+
+	if !forEachVal.CanIterateElements() {
+		return hclAttrErr(attrs.foreach,
+			"`for_each` expression of type %s cannot be iterated",
+			forEachVal.Type().FriendlyName())
+	}
+
+	logger.Trace().Msg("generating blocks")
+
+	var tmDynamicErr error
+
+	forEachVal.ForEachElement(func(key, value cty.Value) (stop bool) {
+		evaluator.SetNamespace(iterator, map[string]cty.Value{
+			"key":   key,
+			"value": value,
+		})
+
+		var labels []string
+		if attrs.labels != nil {
+			labelsVal, err := evaluator.Eval(attrs.labels.Expr)
+			if err != nil {
+				tmDynamicErr = wrapHCLAttrErr(err, attrs.labels,
+					"failed to evaluate the `labels` attribute")
+				return true
+			}
+
+			labels, err = hcl.ParseStringList("labels", labelsVal)
+			if err != nil {
+				tmDynamicErr = err
+				return true
+			}
+		}
+
+		newblock := target.AppendBlock(hclwrite.NewBlock(genBlockType, labels))
+
+		if contentBlock != nil {
+			logger.Trace().Msg("using content block to define new block body")
+
+			err := copyBody(newblock.Body(), contentBlock.Body, evaluator)
+			if err != nil {
+				tmDynamicErr = err
+				return true
+			}
+
+			return false
+		}
+
+		logger.Trace().Msg("using attributes to define new block body")
+
+		partialEvalAttributes, err := evaluator.PartialEval(attrs.attributes.Expr)
+		if err != nil {
+			tmDynamicErr = wrapHCLAttrErr(err, attrs.attributes,
+				"partially evaluating tm_dynamic attributes")
+			return true
+		}
+
+		// Sadly hclsyntax doesn't export an easy way to build an expression from tokens,
+		// even though it would be easy to do so:
+		//
+		// - https://github.com/hashicorp/hcl2/blob/fb75b3253c80b3bc7ca99c4bfa2ad6743841b1af/hcl/hclsyntax/public.go#L41
+		//
+		// So here we need to convert the parsed attributes to []byte so it can be
+		// converted again to tokens :-).
+		attrsExpr, diags := hclsyntax.ParseExpression(partialEvalAttributes.Bytes(), "", hhcl.InitialPos)
+		if diags.HasErrors() {
+			// Panic here since Terramate generated an invalid expression after
+			// partial evaluation and it is a guaranteed invariant that partial
+			// evaluation only produces valid expressions.
+			log.Error().
+				Err(diags).
+				Str("partiallyEvaluated", string(partialEvalAttributes.Bytes())).
+				Msg("partially evaluated `attributes` should be a valid expression")
+			panic(wrapHCLAttrErr(err, attrs.attributes,
+				"internal error: partially evaluated `attributes` produced invalid expression: %v", diags))
+		}
+
+		objectExpr, ok := attrsExpr.(*hclsyntax.ObjectConsExpr)
+		if !ok {
+			tmDynamicErr = hclAttrErr(attrs.attributes,
+				"tm_dynamic attributes must be an object, got %T instead", objectExpr)
+			return true
+		}
+
+		newbody := newblock.Body()
+
+		for _, item := range objectExpr.Items {
+			keyVal, err := evaluator.Eval(item.KeyExpr)
+			if err != nil {
+				tmDynamicErr = wrapHCLAttrErr(err, attrs.attributes,
+					"evaluating tm_dynamic.attributes object key")
+				return true
+			}
+			if keyVal.Type() != cty.String {
+				tmDynamicErr = hclAttrErr(attrs.attributes,
+					"tm_dynamic.attributes key %q has type %q, must be a string",
+					keyVal.GoString(),
+					keyVal.Type().FriendlyName())
+				return true
+			}
+
+			// hclwrite lib will accept any arbitrary string as attr name
+			// allowing it to generate invalid HCL code, so here we check if
+			// the attribute is a proper HCL identifier.
+			attrName := keyVal.AsString()
+			if !hclsyntax.ValidIdentifier(attrName) {
+				tmDynamicErr = hclAttrErr(attrs.attributes,
+					"tm_dynamic.attributes key %q is not a valid HCL identifier",
+					attrName)
+				return true
+			}
+
+			valExpr, err := eval.GetExpressionTokens(partialEvalAttributes.Bytes(), item.ValueExpr)
+			if err != nil {
+				// Panic here since Terramate generated an invalid expression after
+				// partial evaluation and it is a guaranteed invariant that partial
+				// evaluation only produces valid expressions.
+				log.Error().
+					Err(err).
+					Str("attribute", attrName).
+					Str("partiallyEvaluated", string(partialEvalAttributes.Bytes())).
+					Msg("partially evaluated `attributes` has invalid value expression inside object")
+				panic(wrapHCLAttrErr(err, attrs.attributes,
+					"internal error: partially evaluated `attributes` has invalid value expressions inside object: %v", err))
+			}
+
+			logger.Trace().
+				Str("attribute", attrName).
+				Str("value", string(valExpr.Bytes())).
+				Msg("adding attribute on generated block")
+
+			newbody.SetAttributeRaw(attrName, valExpr)
+		}
+
+		return false
+	})
+
+	evaluator.DeleteNamespace(iterator)
+	return tmDynamicErr
+}
+
+func getDynamicBlockAttrs(block *hclsyntax.Block) (dynBlockAttributes, error) {
+	dynAttrs := dynBlockAttributes{}
+	errs := errors.L()
+
+	for name, attr := range block.Body.Attributes {
+		switch name {
+		case "attributes":
+			dynAttrs.attributes = attr
+		case "for_each":
+			dynAttrs.foreach = attr
+		case "labels":
+			dynAttrs.labels = attr
+		case "iterator":
+			dynAttrs.iterator = attr
+		default:
+			errs.Append(hclAttrErr(
+				attr, "tm_dynamic unsupported attribute %q", name))
+		}
+	}
+
+	if dynAttrs.foreach == nil {
+		errs.Append(errors.E(block.Body.Range(),
+			hcl.ErrTerramateSchema,
+			"tm_dynamic requires a `for_each` attribute"))
+	}
+
+	// Unusual but we return the value so further errors can still be added
+	// based on properties of the attributes that are valid.
+	return dynAttrs, errs.AsError()
+}
+
+func getContentBlock(blocks hclsyntax.Blocks) (*hclsyntax.Block, error) {
+	var contentBlock *hclsyntax.Block
+
+	errs := errors.L()
+
+	for _, b := range blocks {
+		if b.Type != "content" {
+			errs.Append(errors.E(hcl.ErrTerramateSchema,
+				b.TypeRange, "unrecognized block %s", b.Type))
+
+			continue
+		}
+
+		if contentBlock != nil {
+			errs.Append(errors.E(hcl.ErrTerramateSchema, b.TypeRange,
+				"multiple definitions of the `content` block"))
+
+			continue
+		}
+
+		contentBlock = b
+	}
+
+	if err := errs.AsError(); err != nil {
+		return nil, err
+	}
+
+	return contentBlock, nil
+}
+
+func hclAttrErr(attr *hclsyntax.Attribute, msg string, args ...interface{}) error {
+	return errors.E(hcl.ErrTerramateSchema, attr.Expr.Range(), fmt.Sprintf(msg, args...))
+}
+
+func wrapHCLAttrErr(err error, attr *hclsyntax.Attribute, msg string, args ...interface{}) error {
+	return errors.E(hcl.ErrTerramateSchema, err, attr.Expr.Range(), fmt.Sprintf(msg, args...))
 }

--- a/generate/genhcl/genhcl_dynamic_test.go
+++ b/generate/genhcl/genhcl_dynamic_test.go
@@ -1197,7 +1197,7 @@ func TestGenerateHCLDynamic(t *testing.T) {
 					),
 				},
 			},
-			wantErr: errors.E(genhcl.ErrParsing),
+			wantErr: errors.E(genhcl.ErrInvalidDynamicIterator),
 		},
 		{
 			name:  "tm_dynamic with undefined global on attributes fails",

--- a/generate/genhcl/genhcl_dynamic_test.go
+++ b/generate/genhcl/genhcl_dynamic_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/mineiros-io/terramate/errors"
+	"github.com/mineiros-io/terramate/generate/genhcl"
 	"github.com/mineiros-io/terramate/hcl"
 	"github.com/mineiros-io/terramate/hcl/eval"
 )
@@ -804,7 +805,7 @@ func TestGenerateHCLDynamic(t *testing.T) {
 					),
 				},
 			},
-			wantErr: errors.E(hcl.ErrInvalidDynamicIterator),
+			wantErr: errors.E(genhcl.ErrInvalidDynamicIterator),
 		},
 		{
 			name:  "no content block and no attributes fails",

--- a/generate/genhcl/genhcl_dynamic_test.go
+++ b/generate/genhcl/genhcl_dynamic_test.go
@@ -1151,7 +1151,7 @@ func TestGenerateHCLDynamic(t *testing.T) {
 					),
 				},
 			},
-			wantErr: errors.E(genhcl.ErrParsing),
+			wantErr: errors.E(genhcl.ErrInvalidDynamicLabels),
 		},
 		{
 			name:  "tm_dynamic with labels that is not a list fails",
@@ -1174,7 +1174,7 @@ func TestGenerateHCLDynamic(t *testing.T) {
 					),
 				},
 			},
-			wantErr: errors.E(genhcl.ErrParsing),
+			wantErr: errors.E(genhcl.ErrInvalidDynamicLabels),
 		},
 		{
 			name:  "tm_dynamic with iterator with traversal fails",

--- a/generate/genhcl/genhcl_dynamic_test.go
+++ b/generate/genhcl/genhcl_dynamic_test.go
@@ -222,8 +222,7 @@ func TestGenerateHCLDynamic(t *testing.T) {
 									expr("for_each", `["val"]`),
 									expr("labels", `["a", "a"]`),
 									content(
-										expr("value", "my_block.value"),
-										expr("key", "my_block.key"),
+										str("value", "str"),
 									),
 								),
 							),
@@ -240,8 +239,7 @@ func TestGenerateHCLDynamic(t *testing.T) {
 						body: hcldoc(
 							block("duplicated_labels",
 								labels("a", "a"),
-								number("key", 0),
-								str("value", "val"),
+								str("value", "str"),
 							),
 						),
 					},

--- a/generate/genhcl/genhcl_dynamic_test.go
+++ b/generate/genhcl/genhcl_dynamic_test.go
@@ -922,7 +922,7 @@ func TestGenerateHCLDynamic(t *testing.T) {
 					),
 				},
 			},
-			wantErr: errors.E(genhcl.ErrParsing),
+			wantErr: errors.E(genhcl.ErrDynamicAttrsEval),
 		},
 		{
 			name:  "attributes key is not a string fails",
@@ -1217,7 +1217,7 @@ func TestGenerateHCLDynamic(t *testing.T) {
 					),
 				},
 			},
-			wantErr: errors.E(eval.ErrPartial),
+			wantErr: errors.E(genhcl.ErrDynamicAttrsEval),
 		},
 		{
 			name:  "tm_dynamic with undefined global on content fails",

--- a/generate/genhcl/genhcl_dynamic_test.go
+++ b/generate/genhcl/genhcl_dynamic_test.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/mineiros-io/terramate/errors"
 	"github.com/mineiros-io/terramate/generate/genhcl"
-	"github.com/mineiros-io/terramate/hcl"
 	"github.com/mineiros-io/terramate/hcl/eval"
 )
 
@@ -202,6 +201,47 @@ func TestGenerateHCLDynamic(t *testing.T) {
 								labels("c"),
 								number("key", 2),
 								str("value", "c"),
+							),
+						),
+					},
+				},
+			},
+		},
+		{
+			name:  "tm_dynamic with duplicated labels",
+			stack: "/stack",
+			configs: []hclconfig{
+				{
+					path: "/stack",
+					add: hcldoc(
+						generateHCL(
+							labels("tm_dynamic_test.tf"),
+							content(
+								tmdynamic(
+									labels("duplicated_labels"),
+									expr("for_each", `["val"]`),
+									expr("labels", `["a", "a"]`),
+									content(
+										expr("value", "my_block.value"),
+										expr("key", "my_block.key"),
+									),
+								),
+							),
+						),
+					),
+				},
+			},
+			want: []result{
+				{
+					name: "tm_dynamic_test.tf",
+					hcl: genHCL{
+						origin:    defaultCfg("/stack"),
+						condition: true,
+						body: hcldoc(
+							block("duplicated_labels",
+								labels("a", "a"),
+								number("key", 0),
+								str("value", "val"),
 							),
 						),
 					},
@@ -824,7 +864,7 @@ func TestGenerateHCLDynamic(t *testing.T) {
 					),
 				},
 			},
-			wantErr: errors.E(hcl.ErrTerramateSchema),
+			wantErr: errors.E(genhcl.ErrParsing),
 		},
 		{
 			name:  "attributes is null fails",
@@ -844,7 +884,7 @@ func TestGenerateHCLDynamic(t *testing.T) {
 					),
 				},
 			},
-			wantErr: errors.E(hcl.ErrTerramateSchema),
+			wantErr: errors.E(genhcl.ErrParsing),
 		},
 		{
 			name:  "attributes is not object fails",
@@ -864,7 +904,7 @@ func TestGenerateHCLDynamic(t *testing.T) {
 					),
 				},
 			},
-			wantErr: errors.E(hcl.ErrTerramateSchema),
+			wantErr: errors.E(genhcl.ErrParsing),
 		},
 		{
 			name:  "attributes key is undefined fails",
@@ -884,7 +924,7 @@ func TestGenerateHCLDynamic(t *testing.T) {
 					),
 				},
 			},
-			wantErr: errors.E(hcl.ErrTerramateSchema),
+			wantErr: errors.E(genhcl.ErrParsing),
 		},
 		{
 			name:  "attributes key is not a string fails",
@@ -909,7 +949,7 @@ func TestGenerateHCLDynamic(t *testing.T) {
 					),
 				},
 			},
-			wantErr: errors.E(hcl.ErrTerramateSchema),
+			wantErr: errors.E(genhcl.ErrParsing),
 		},
 		{
 			name:  "attributes key has space fails",
@@ -931,7 +971,7 @@ func TestGenerateHCLDynamic(t *testing.T) {
 					),
 				},
 			},
-			wantErr: errors.E(hcl.ErrTerramateSchema),
+			wantErr: errors.E(genhcl.ErrParsing),
 		},
 		{
 			name:  "attributes key is empty string fails",
@@ -953,7 +993,7 @@ func TestGenerateHCLDynamic(t *testing.T) {
 					),
 				},
 			},
-			wantErr: errors.E(hcl.ErrTerramateSchema),
+			wantErr: errors.E(genhcl.ErrParsing),
 		},
 		{
 			name:  "attributes key starts with '-' fails",
@@ -975,7 +1015,7 @@ func TestGenerateHCLDynamic(t *testing.T) {
 					),
 				},
 			},
-			wantErr: errors.E(hcl.ErrTerramateSchema),
+			wantErr: errors.E(genhcl.ErrParsing),
 		},
 		{
 			name:  "attributes and unknown attribute fails",
@@ -996,7 +1036,7 @@ func TestGenerateHCLDynamic(t *testing.T) {
 					),
 				},
 			},
-			wantErr: errors.E(hcl.ErrTerramateSchema),
+			wantErr: errors.E(genhcl.ErrParsing),
 		},
 		{
 			name:  "tm_dynamic with more than one label fails",
@@ -1018,7 +1058,7 @@ func TestGenerateHCLDynamic(t *testing.T) {
 					),
 				},
 			},
-			wantErr: errors.E(hcl.ErrTerramateSchema),
+			wantErr: errors.E(genhcl.ErrParsing),
 		},
 		{
 			name:  "tm_dynamic with multiple content blocks fail",
@@ -1043,7 +1083,7 @@ func TestGenerateHCLDynamic(t *testing.T) {
 					),
 				},
 			},
-			wantErr: errors.E(hcl.ErrTerramateSchema),
+			wantErr: errors.E(genhcl.ErrParsing),
 		},
 		{
 			name:  "tm_dynamic with unknown block fail",
@@ -1068,7 +1108,7 @@ func TestGenerateHCLDynamic(t *testing.T) {
 					),
 				},
 			},
-			wantErr: errors.E(hcl.ErrTerramateSchema),
+			wantErr: errors.E(genhcl.ErrParsing),
 		},
 		{
 			name:  "tm_dynamic with undefined for_each fail",
@@ -1090,7 +1130,7 @@ func TestGenerateHCLDynamic(t *testing.T) {
 					),
 				},
 			},
-			wantErr: errors.E(hcl.ErrTerramateSchema),
+			wantErr: errors.E(genhcl.ErrParsing),
 		},
 		{
 			name:  "tm_dynamic with labels with undefined references fails",
@@ -1113,7 +1153,7 @@ func TestGenerateHCLDynamic(t *testing.T) {
 					),
 				},
 			},
-			wantErr: errors.E(hcl.ErrTerramateSchema),
+			wantErr: errors.E(genhcl.ErrParsing),
 		},
 		{
 			name:  "tm_dynamic with labels that is not a list fails",
@@ -1136,7 +1176,7 @@ func TestGenerateHCLDynamic(t *testing.T) {
 					),
 				},
 			},
-			wantErr: errors.E(hcl.ErrTerramateSchema),
+			wantErr: errors.E(genhcl.ErrParsing),
 		},
 		{
 			name:  "tm_dynamic with iterator with traversal fails",
@@ -1159,7 +1199,7 @@ func TestGenerateHCLDynamic(t *testing.T) {
 					),
 				},
 			},
-			wantErr: errors.E(hcl.ErrTerramateSchema),
+			wantErr: errors.E(genhcl.ErrParsing),
 		},
 		{
 			name:  "tm_dynamic with undefined global on attributes fails",
@@ -1223,7 +1263,7 @@ func TestGenerateHCLDynamic(t *testing.T) {
 					),
 				},
 			},
-			wantErr: errors.E(hcl.ErrTerramateSchema),
+			wantErr: errors.E(genhcl.ErrParsing),
 		},
 		{
 			name:  "tm_dynamic with no label fails",
@@ -1244,7 +1284,7 @@ func TestGenerateHCLDynamic(t *testing.T) {
 					),
 				},
 			},
-			wantErr: errors.E(hcl.ErrTerramateSchema),
+			wantErr: errors.E(genhcl.ErrParsing),
 		},
 		{
 			name:  "content and unknown attribute fails",
@@ -1267,7 +1307,7 @@ func TestGenerateHCLDynamic(t *testing.T) {
 					),
 				},
 			},
-			wantErr: errors.E(hcl.ErrTerramateSchema),
+			wantErr: errors.E(genhcl.ErrParsing),
 		},
 		{
 			name:  "content block and attributes fails",
@@ -1290,7 +1330,7 @@ func TestGenerateHCLDynamic(t *testing.T) {
 					),
 				},
 			},
-			wantErr: errors.E(hcl.ErrTerramateSchema),
+			wantErr: errors.E(genhcl.ErrParsing),
 		},
 		{
 			name:  "tm_dynamic with no for_each fails",
@@ -1311,7 +1351,7 @@ func TestGenerateHCLDynamic(t *testing.T) {
 					),
 				},
 			},
-			wantErr: errors.E(hcl.ErrTerramateSchema),
+			wantErr: errors.E(genhcl.ErrParsing),
 		},
 	}
 

--- a/hcl/hcl.go
+++ b/hcl/hcl.go
@@ -35,11 +35,10 @@ import (
 
 // Errors returned during the HCL parsing.
 const (
-	ErrHCLSyntax              errors.Kind = "HCL syntax error"
-	ErrTerramateSchema        errors.Kind = "terramate schema error"
-	ErrImport                 errors.Kind = "import error"
-	ErrInvalidDynamicIterator errors.Kind = "invalid dynamic iterator"
-	ErrUnexpectedTerramate    errors.Kind = "`terramate` block is only allowed at the project root directory"
+	ErrHCLSyntax           errors.Kind = "HCL syntax error"
+	ErrTerramateSchema     errors.Kind = "terramate schema error"
+	ErrImport              errors.Kind = "import error"
+	ErrUnexpectedTerramate errors.Kind = "`terramate` block is only allowed at the project root directory"
 )
 
 const (
@@ -816,351 +815,21 @@ func validateGenerateFileBlock(block *ast.Block) error {
 	return errs.AsError()
 }
 
-// CopyBody will copy the src body to the given target, evaluating attributes
-// using the given evaluation context.
-//
-// Scoped traversals, like name.traverse, for unknown namespaces will be copied
-// as is (original expression form, no evaluation).
-//
-// Returns an error if the evaluation fails.
-func CopyBody(dest *hclwrite.Body, src *hclsyntax.Body, eval Evaluator) error {
+// ParseStringList will parse the given val, with the given name, as a
+// string list.
+func ParseStringList(name string, val cty.Value) ([]string, error) {
 	logger := log.With().
-		Str("action", "CopyBody()").
-		Logger()
-
-	logger.Trace().Msg("Sorting attributes.")
-
-	attrs := ast.SortRawAttributes(src.Attributes)
-	for _, attr := range attrs {
-		logger := logger.With().
-			Str("attrName", attr.Name).
-			Logger()
-
-		logger.Trace().Msg("evaluating.")
-		tokens, err := eval.PartialEval(attr.Expr)
-		if err != nil {
-			return errors.E(err, attr.Expr.Range())
-		}
-
-		logger.Trace().Str("attribute", attr.Name).Msg("Setting evaluated attribute.")
-		dest.SetAttributeRaw(attr.Name, tokens)
-	}
-
-	logger.Trace().Msg("Append blocks.")
-
-	for _, block := range src.Blocks {
-		err := appendBlock(dest, block, eval)
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-func appendBlock(target *hclwrite.Body, block *hclsyntax.Block, eval Evaluator) error {
-	if block.Type == "tm_dynamic" {
-		return appendDynamicBlock(target, block, eval)
-	}
-
-	targetBlock := target.AppendNewBlock(block.Type, block.Labels)
-	if block.Body != nil {
-		err := CopyBody(targetBlock.Body(), block.Body, eval)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func getContentBlock(blocks hclsyntax.Blocks) (*hclsyntax.Block, error) {
-	var contentBlock *hclsyntax.Block
-
-	errs := errors.L()
-
-	for _, b := range blocks {
-		if b.Type != "content" {
-			errs.Append(errors.E(ErrTerramateSchema,
-				b.TypeRange, "unrecognized block %s", b.Type))
-
-			continue
-		}
-
-		if contentBlock != nil {
-			errs.Append(errors.E(ErrTerramateSchema, b.TypeRange,
-				"multiple definitions of the `content` block"))
-
-			continue
-		}
-
-		contentBlock = b
-	}
-
-	if err := errs.AsError(); err != nil {
-		return nil, err
-	}
-
-	return contentBlock, nil
-}
-
-type dynBlockAttributes struct {
-	attributes *hclsyntax.Attribute
-	iterator   *hclsyntax.Attribute
-	foreach    *hclsyntax.Attribute
-	labels     *hclsyntax.Attribute
-}
-
-func getDynamicBlockAttrs(block *hclsyntax.Block) (dynBlockAttributes, error) {
-	dynAttrs := dynBlockAttributes{}
-	errs := errors.L()
-
-	for name, attr := range block.Body.Attributes {
-		switch name {
-		case "attributes":
-			dynAttrs.attributes = attr
-		case "for_each":
-			dynAttrs.foreach = attr
-		case "labels":
-			dynAttrs.labels = attr
-		case "iterator":
-			dynAttrs.iterator = attr
-		default:
-			errs.Append(hclAttrErr(
-				attr, "tm_dynamic unsupported attribute %q", name))
-		}
-	}
-
-	if dynAttrs.foreach == nil {
-		errs.Append(errors.E(block.Body.Range(),
-			ErrTerramateSchema,
-			"tm_dynamic requires a `for_each` attribute"))
-	}
-
-	// Unusual but we return the value so further errors can still be added
-	// based on properties of the attributes that are valid.
-	return dynAttrs, errs.AsError()
-}
-
-func appendDynamicBlock(target *hclwrite.Body, block *hclsyntax.Block, evaluator Evaluator) error {
-	logger := log.With().
-		Str("action", "hcl.appendDynamicBlock").
-		Logger()
-
-	logger.Trace().Msg("parsing tm_dynamic block")
-
-	errs := errors.L()
-
-	if len(block.Labels) != 1 {
-		errs.Append(errors.E(ErrTerramateSchema,
-			block.LabelRanges, "tm_dynamic requires a single label"))
-	}
-
-	attrs, err := getDynamicBlockAttrs(block)
-	errs.Append(err)
-
-	contentBlock, err := getContentBlock(block.Body.Blocks)
-	errs.Append(err)
-
-	if contentBlock == nil && attrs.attributes == nil {
-		errs.Append(errors.E(ErrTerramateSchema, block.Body.Range(),
-			"`content` block or `attributes` obj must be defined"))
-	}
-
-	if contentBlock != nil && attrs.attributes != nil {
-		errs.Append(errors.E(ErrTerramateSchema, block.Body.Range(),
-			"`content` block and `attributes` obj are not allowed together"))
-	}
-
-	if err := errs.AsError(); err != nil {
-		return err
-	}
-
-	genBlockType := block.Labels[0]
-
-	logger = logger.With().
-		Str("genBlockType", genBlockType).
-		Logger()
-
-	logger.Trace().Msg("defining iterator name")
-
-	iterator := genBlockType
-
-	if attrs.iterator != nil {
-		iteratorTraversal, diags := hcl.AbsTraversalForExpr(attrs.iterator.Expr)
-		if diags.HasErrors() {
-			return errors.E(diags, ErrInvalidDynamicIterator,
-				"failed to parse iterator expression")
-		}
-		if len(iteratorTraversal) != 1 {
-			return hclAttrErr(attrs.iterator,
-				"dynamic iterator must be a single variable name")
-		}
-		iterator = iteratorTraversal.RootName()
-	}
-
-	logger = logger.With().
-		Str("iterator", iterator).
-		Logger()
-
-	logger.Trace().Msg("evaluating for_each attribute")
-
-	forEachVal, err := evaluator.Eval(attrs.foreach.Expr)
-	if err != nil {
-		return wrapHCLAttrErr(err, attrs.foreach, "evaluating `for_each` expression")
-	}
-
-	if !forEachVal.CanIterateElements() {
-		return hclAttrErr(attrs.foreach,
-			"`for_each` expression of type %s cannot be iterated",
-			forEachVal.Type().FriendlyName())
-	}
-
-	logger.Trace().Msg("generating blocks")
-
-	var tmDynamicErr error
-
-	forEachVal.ForEachElement(func(key, value cty.Value) (stop bool) {
-		evaluator.SetNamespace(iterator, map[string]cty.Value{
-			"key":   key,
-			"value": value,
-		})
-
-		var labels []string
-		if attrs.labels != nil {
-			labelsVal, err := evaluator.Eval(attrs.labels.Expr)
-			if err != nil {
-				tmDynamicErr = wrapHCLAttrErr(err, attrs.labels,
-					"failed to evaluate the `labels` attribute")
-				return true
-			}
-
-			err = assignSet("labels", &labels, labelsVal)
-			if err != nil {
-				tmDynamicErr = err
-				return true
-			}
-		}
-
-		newblock := target.AppendBlock(hclwrite.NewBlock(genBlockType, labels))
-
-		if contentBlock != nil {
-			logger.Trace().Msg("using content block to define new block body")
-
-			err := CopyBody(newblock.Body(), contentBlock.Body, evaluator)
-			if err != nil {
-				tmDynamicErr = err
-				return true
-			}
-
-			return false
-		}
-
-		logger.Trace().Msg("using attributes to define new block body")
-
-		partialEvalAttributes, err := evaluator.PartialEval(attrs.attributes.Expr)
-		if err != nil {
-			tmDynamicErr = wrapHCLAttrErr(err, attrs.attributes,
-				"partially evaluating tm_dynamic attributes")
-			return true
-		}
-
-		// Sadly hclsyntax doesn't export an easy way to build an expression from tokens,
-		// even though it would be easy to do so:
-		//
-		// - https://github.com/hashicorp/hcl2/blob/fb75b3253c80b3bc7ca99c4bfa2ad6743841b1af/hcl/hclsyntax/public.go#L41
-		//
-		// So here we need to convert the parsed attributes to []byte so it can be
-		// converted again to tokens :-).
-		attrsExpr, diags := hclsyntax.ParseExpression(partialEvalAttributes.Bytes(), "", hcl.InitialPos)
-		if diags.HasErrors() {
-			// Panic here since Terramate generated an invalid expression after
-			// partial evaluation and it is a guaranteed invariant that partial
-			// evaluation only produces valid expressions.
-			log.Error().
-				Err(diags).
-				Str("partiallyEvaluated", string(partialEvalAttributes.Bytes())).
-				Msg("partially evaluated `attributes` should be a valid expression")
-			panic(wrapHCLAttrErr(err, attrs.attributes,
-				"internal error: partially evaluated `attributes` produced invalid expression: %v", diags))
-		}
-
-		objectExpr, ok := attrsExpr.(*hclsyntax.ObjectConsExpr)
-		if !ok {
-			tmDynamicErr = hclAttrErr(attrs.attributes,
-				"tm_dynamic attributes must be an object, got %T instead", objectExpr)
-			return true
-		}
-
-		newbody := newblock.Body()
-
-		for _, item := range objectExpr.Items {
-			keyVal, err := evaluator.Eval(item.KeyExpr)
-			if err != nil {
-				tmDynamicErr = wrapHCLAttrErr(err, attrs.attributes,
-					"evaluating tm_dynamic.attributes object key")
-				return true
-			}
-			if keyVal.Type() != cty.String {
-				tmDynamicErr = hclAttrErr(attrs.attributes,
-					"tm_dynamic.attributes key %q has type %q, must be a string",
-					keyVal.GoString(),
-					keyVal.Type().FriendlyName())
-				return true
-			}
-
-			// hclwrite lib will accept any arbitrary string as attr name
-			// allowing it to generate invalid HCL code, so here we check if
-			// the attribute is a proper HCL identifier.
-			attrName := keyVal.AsString()
-			if !hclsyntax.ValidIdentifier(attrName) {
-				tmDynamicErr = hclAttrErr(attrs.attributes,
-					"tm_dynamic.attributes key %q is not a valid HCL identifier",
-					attrName)
-				return true
-			}
-
-			valExpr, err := eval.GetExpressionTokens(partialEvalAttributes.Bytes(), item.ValueExpr)
-			if err != nil {
-				// Panic here since Terramate generated an invalid expression after
-				// partial evaluation and it is a guaranteed invariant that partial
-				// evaluation only produces valid expressions.
-				log.Error().
-					Err(err).
-					Str("attribute", attrName).
-					Str("partiallyEvaluated", string(partialEvalAttributes.Bytes())).
-					Msg("partially evaluated `attributes` has invalid value expression inside object")
-				panic(wrapHCLAttrErr(err, attrs.attributes,
-					"internal error: partially evaluated `attributes` has invalid value expressions inside object: %v", err))
-			}
-
-			logger.Trace().
-				Str("attribute", attrName).
-				Str("value", string(valExpr.Bytes())).
-				Msg("adding attribute on generated block")
-
-			newbody.SetAttributeRaw(attrName, valExpr)
-		}
-
-		return false
-	})
-
-	evaluator.DeleteNamespace(iterator)
-	return tmDynamicErr
-}
-
-func assignSet(name string, target *[]string, val cty.Value) error {
-	logger := log.With().
-		Str("action", "assignSet()").
+		Str("action", "hcl.ParseStringList()").
 		Logger()
 
 	if val.IsNull() {
-		return nil
+		return nil, nil
 	}
 
 	// as the parser is schemaless it only creates tuples (lists of arbitrary types).
 	// we have to check the elements themselves.
 	if !val.Type().IsTupleType() && !val.Type().IsListType() {
-		return errors.E(ErrTerramateSchema, "field %q must be a set(string) but "+
+		return nil, errors.E(ErrTerramateSchema, "field %q must be a set(string) but "+
 			"found a %q", name, val.Type().FriendlyName())
 	}
 
@@ -1198,11 +867,10 @@ func assignSet(name string, target *[]string, val cty.Value) error {
 	}
 
 	if err := errs.AsError(); err != nil {
-		return err
+		return nil, err
 	}
 
-	*target = elems
-	return nil
+	return elems, nil
 }
 
 func parseStack(evalctx *eval.Context, stack *Stack, stackblock *ast.Block) error {
@@ -1265,16 +933,20 @@ func parseStack(evalctx *eval.Context, stack *Stack, stackblock *ast.Block) erro
 			stack.Name = attrVal.AsString()
 
 		case "after":
-			errs.Append(assignSet(attr.Name, &stack.After, attrVal))
+			stack.After, err = ParseStringList(attr.Name, attrVal)
+			errs.Append(err)
 
 		case "before":
-			errs.Append(assignSet(attr.Name, &stack.Before, attrVal))
+			stack.Before, err = ParseStringList(attr.Name, attrVal)
+			errs.Append(err)
 
 		case "wants":
-			errs.Append(assignSet(attr.Name, &stack.Wants, attrVal))
+			stack.Wants, err = ParseStringList(attr.Name, attrVal)
+			errs.Append(err)
 
 		case "watch":
-			errs.Append(assignSet(attr.Name, &stack.Watch, attrVal))
+			stack.Watch, err = ParseStringList(attr.Name, attrVal)
+			errs.Append(err)
 
 		case "description":
 			logger.Trace().Msg("parsing stack description.")
@@ -1823,10 +1495,6 @@ func isTerramateFile(filename string) bool {
 
 func hclAttrErr(attr *hclsyntax.Attribute, msg string, args ...interface{}) error {
 	return errors.E(ErrTerramateSchema, attr.Expr.Range(), fmt.Sprintf(msg, args...))
-}
-
-func wrapHCLAttrErr(err error, attr *hclsyntax.Attribute, msg string, args ...interface{}) error {
-	return errors.E(ErrTerramateSchema, err, attr.Expr.Range(), fmt.Sprintf(msg, args...))
 }
 
 func attrErr(attr ast.Attribute, msg string, args ...interface{}) error {


### PR DESCRIPTION
# Reason for This Change

Currently using tm_dynamic with duplicated labels on the labels attribute will fail but it shouldn't.

## Description of Changes

Refactored the CopyBody from hcl to genhcl since it contains a lot of logic that is genhcl specific. We still have some parsing that could be on hcl that is now done on genhcl, so it would be better to improve this further, but at least for now it simplifies the already big hcl package.

Instead of using the assignSet function that handle a cty.Value we have a function that handles a cty.Value as a list of strings.

## Reproducing Issue

```sh
#!/bin/bash

set -o errexit
set -o nounset
set -o pipefail

workdir="$(mktemp -d)"
cd "${workdir}"

cat > terramate.tm.hcl <<- EOM
terramate {
  config {
  }
}
EOM

cat > test.tm.hcl <<- EOM
generate_hcl "test.tf" {
  content {
    tm_dynamic "resource" {
      for_each = ["a"]
      labels = ["a", "a"]
      attributes = {}
    }
  }
}
EOM

terramate create stack
terramate generate

echo
echo "generated providers:"
cat stack/test.tf
```