### PR TITLE
fix: too many open files while vendoring huge projects

### DIFF
--- a/fs/copy.go
+++ b/fs/copy.go
@@ -20,6 +20,7 @@ import (
 	"path/filepath"
 
 	"github.com/mineiros-io/terramate/errors"
+	"github.com/rs/zerolog/log"
 )
 
 // CopyFilterFunc filters which files/dirs will be copied by CopyDir.
@@ -73,10 +74,22 @@ func copyFile(destfile, srcfile string) error {
 	if err != nil {
 		return errors.E(err, "opening source file")
 	}
+	defer closeFile(src)
 	dest, err := os.Create(destfile)
 	if err != nil {
 		return errors.E(err, "creating dest file")
 	}
+	defer closeFile(dest)
 	_, err = io.Copy(dest, src)
 	return err
+}
+
+func closeFile(file *os.File) {
+	err := file.Close()
+	if err != nil {
+		log.Warn().
+			Str("file", file.Name()).
+			Err(err).
+			Msg("closing file ")
+	}
 }


### PR DESCRIPTION
Got this issue while testing the #553 feature.
```
$ terramate experimental vendor download github.com/SebastianUA/terraform v18.15.10
2022-08-26T03:56:03Z WRN deleting temp dir inside terramate project error="open /home/i4k/src/mineiros/tm-example: too many open files"
2022-08-26T03:56:03Z WRN deleting tmp clone dir error="open /tmp: too many open files"
Vendor report:

[!] github.com/SebastianUA/terraform
    reason: failed to vendor "https://github.com/SebastianUA/terraform.git" with ref "v18.15.10": copying cloned module: copying src to dest dir: copying src to dest file: opening source file: open /tmp/.tmvendor2299994787/aws/modules/api_gateway/api_gateway_deployment.tf: too many open files
```