### PR TITLE
fix: vendor: fails on subdir references

### DIFF
--- a/cmd/terramate/e2etests/exp_vendor_test.go
+++ b/cmd/terramate/e2etests/exp_vendor_test.go
@@ -66,6 +66,23 @@ func TestVendorModule(t *testing.T) {
 		res := tmcli.run("experimental", "vendor", "download", gitSource, "main")
 		checkVendoredFiles(t, res, filepath.Join(s.RootDir(), rootcfg))
 	})
+
+	t.Run(".terramate configuration", func(t *testing.T) {
+		dotTerramateCfg := "/from/dottm/cfg"
+		dotTerramateDir := s.RootEntry().CreateDir(".terramate")
+
+		dotTerramateDir.CreateFile("vendor.tm", vendorHCLConfig(dotTerramateCfg))
+		tmcli := newCLI(t, s.RootDir())
+		res := tmcli.run("experimental", "vendor", "download", gitSource, "main")
+		checkVendoredFiles(t, res, filepath.Join(s.RootDir(), dotTerramateCfg))
+	})
+
+	t.Run("CLI configuration", func(t *testing.T) {
+		cliCfg := "/from/cli/cfg"
+		tmcli := newCLI(t, s.RootDir())
+		res := tmcli.run("experimental", "vendor", "download", "--dir", cliCfg, gitSource, "main")
+		checkVendoredFiles(t, res, filepath.Join(s.RootDir(), cliCfg))
+	})
 }
 
 func TestVendorModuleRecursive1DependencyIsPatched(t *testing.T) {

--- a/cmd/terramate/e2etests/exp_vendor_test.go
+++ b/cmd/terramate/e2etests/exp_vendor_test.go
@@ -83,6 +83,14 @@ func TestVendorModule(t *testing.T) {
 		res := tmcli.run("experimental", "vendor", "download", "--dir", cliCfg, gitSource, "main")
 		checkVendoredFiles(t, res, filepath.Join(s.RootDir(), cliCfg))
 	})
+
+	t.Run("CLI configuration with subdir", func(t *testing.T) {
+		cliCfg := "/with/subdir"
+		gitSource := gitSource + "//subdir"
+		tmcli := newCLI(t, s.RootDir())
+		res := tmcli.run("experimental", "vendor", "download", "--dir", cliCfg, gitSource, "main")
+		checkVendoredFiles(t, res, filepath.Join(s.RootDir(), cliCfg))
+	})
 }
 
 func TestVendorModuleRecursive1DependencyIsPatched(t *testing.T) {

--- a/modvendor/modvendor.go
+++ b/modvendor/modvendor.go
@@ -65,7 +65,7 @@ type modinfo struct {
 //
 // It returns a report of everything vendored and ignored (with a reason).
 func Vendor(rootdir string, vendorDir string, modsrc tf.Source) Report {
-	report := NewReport()
+	report := NewReport(vendorDir)
 	if !filepath.IsAbs(vendorDir) {
 		report.Error = errors.E("vendor dir %q must be absolute path", vendorDir)
 		return report
@@ -78,7 +78,7 @@ func Vendor(rootdir string, vendorDir string, modsrc tf.Source) Report {
 // It will scan all .tf files in the directory and vendor each module declaration
 // containing the supported remote source URLs.
 func VendorAll(rootdir string, vendorDir string, tfdir string) Report {
-	return vendorAll(rootdir, vendorDir, tfdir, NewReport())
+	return vendorAll(rootdir, vendorDir, tfdir, NewReport(vendorDir))
 }
 
 func vendor(rootdir string, vendorDir string, modsrc tf.Source, report Report, info *modinfo) Report {
@@ -110,7 +110,7 @@ func vendor(rootdir string, vendorDir string, modsrc tf.Source, report Report, i
 
 	logger.Trace().Msg("successfully downloaded")
 
-	report.addVendored(modsrc, Dir(vendorDir, modsrc))
+	report.addVendored(modsrc)
 	return vendorAll(rootdir, vendorDir, moddir, report)
 }
 

--- a/modvendor/modvendor.go
+++ b/modvendor/modvendor.go
@@ -115,7 +115,7 @@ func vendor(rootdir string, vendorDir string, modsrc tf.Source, report Report, i
 }
 
 // sourcesInfo represents information about module sources. It retains
-// the original order that sources where appended, like an ordered map.
+// the original order that sources were appended, like an ordered map.
 // both list and set always have the same modinfo inside, one is used
 // for ordering dependent iteration, the other one for quick access of
 // specific sources.

--- a/modvendor/modvendor.go
+++ b/modvendor/modvendor.go
@@ -110,7 +110,7 @@ func vendor(rootdir string, vendorDir string, modsrc tf.Source, report Report, i
 
 	logger.Trace().Msg("successfully downloaded")
 
-	report.addVendored(modsrc.Raw, modsrc, Dir(vendorDir, modsrc))
+	report.addVendored(modsrc, Dir(vendorDir, modsrc))
 	return vendorAll(rootdir, vendorDir, moddir, report)
 }
 
@@ -175,21 +175,23 @@ func vendorAll(rootdir string, vendorDir string, tfdir string, report Report) Re
 			Str("origin", info.origin).
 			Logger()
 
-		if v, ok := report.Vendored[source]; ok {
-			logger.Trace().Msg("already vendored")
-			info.vendoredAt = v.Dir
-			info.subdir = v.Source.Subdir
-			continue
-		}
-
 		modsrc, err := tf.ParseSource(source)
 		if err != nil {
 			report.addIgnored(source, err.Error())
 			delete(sourcemap, source)
 			continue
 		}
+
+		info.subdir = modsrc.Subdir
+
+		if v, ok := report.Vendored[Dir(vendorDir, modsrc)]; ok {
+			logger.Trace().Msg("already vendored")
+			info.vendoredAt = v.Dir
+			continue
+		}
+
 		report = vendor(rootdir, vendorDir, modsrc, report, info)
-		if v, ok := report.Vendored[source]; ok {
+		if v, ok := report.Vendored[Dir(vendorDir, modsrc)]; ok {
 			info.vendoredAt = Dir(vendorDir, modsrc)
 			info.subdir = v.Source.Subdir
 

--- a/modvendor/modvendor_report.go
+++ b/modvendor/modvendor_report.go
@@ -42,12 +42,15 @@ type Report struct {
 	Vendored map[string]Vendored
 	Ignored  []IgnoredVendor
 	Error    error
+
+	vendorDir string
 }
 
 // NewReport returns a new empty report.
-func NewReport() Report {
+func NewReport(vendordir string) Report {
 	return Report{
-		Vendored: make(map[string]Vendored),
+		Vendored:  make(map[string]Vendored),
+		vendorDir: vendordir,
 	}
 }
 
@@ -105,7 +108,8 @@ func (r Report) Verbose() string {
 	return strings.Join(report, "\n")
 }
 
-func (r *Report) addVendored(source tf.Source, dir string) {
+func (r *Report) addVendored(source tf.Source) {
+	dir := Dir(r.vendorDir, source)
 	r.Vendored[dir] = Vendored{
 		Source: source,
 		Dir:    dir,

--- a/modvendor/modvendor_report.go
+++ b/modvendor/modvendor_report.go
@@ -105,8 +105,8 @@ func (r Report) Verbose() string {
 	return strings.Join(report, "\n")
 }
 
-func (r *Report) addVendored(rawSource string, source tf.Source, dir string) {
-	r.Vendored[rawSource] = Vendored{
+func (r *Report) addVendored(source tf.Source, dir string) {
+	r.Vendored[dir] = Vendored{
 		Source: source,
 		Dir:    dir,
 	}

--- a/modvendor/modvendor_test.go
+++ b/modvendor/modvendor_test.go
@@ -266,8 +266,6 @@ func TestModVendor(t *testing.T) {
 			wantVendored: []string{
 				"git::file://{{.}}/module-test?ref=main",
 				"git::file://{{.}}/another-module?ref=main",
-				"git::file://{{.}}/another-module//sub/dir?ref=main",
-				"git::file://{{.}}/another-module//sub?ref=main",
 			},
 		},
 		{

--- a/modvendor/modvendor_test.go
+++ b/modvendor/modvendor_test.go
@@ -817,7 +817,7 @@ func applyReportTemplate(t *testing.T, r wantReport, value string, vendordir str
 		rawSource := applyConfigTemplate(t, vendored, value)
 		modsrc, err := tf.ParseSource(rawSource)
 		assert.NoError(t, err)
-		out.Vendored[rawSource] = modvendor.Vendored{
+		out.Vendored[modvendor.Dir(vendordir, modsrc)] = modvendor.Vendored{
 			Source: modsrc,
 			Dir:    modvendor.Dir(vendordir, modsrc),
 		}
@@ -969,14 +969,14 @@ func TestModVendorWithCommitIDRef(t *testing.T) {
 	got := modvendor.Vendor(rootdir, vendordir, source)
 	assertVendorReport(t, modvendor.Report{
 		Vendored: map[string]modvendor.Vendored{
-			source.Raw: {
+			modvendor.Dir(vendordir, source): {
 				Source: source,
 				Dir:    modvendor.Dir(vendordir, source),
 			},
 		},
 	}, got)
 
-	cloneDir := modvendor.AbsVendorDir(rootdir, vendordir, got.Vendored[source.Raw].Source)
+	cloneDir := modvendor.AbsVendorDir(rootdir, vendordir, got.Vendored[modvendor.Dir(vendordir, source)].Source)
 	gotContent := test.ReadFile(t, cloneDir, filename)
 	assert.EqualStrings(t, content, string(gotContent))
 	assertNoGitDir(t, cloneDir)
@@ -1005,20 +1005,21 @@ func TestModVendorWithRef(t *testing.T) {
 
 	const vendordir = "/vendor"
 	got := modvendor.Vendor(rootdir, vendordir, source)
+	vendoredAt := modvendor.Dir(vendordir, source)
 	assertVendorReport(t, modvendor.Report{
 		Vendored: map[string]modvendor.Vendored{
-			source.Raw: {
+			vendoredAt: {
 				Source: source,
 				Dir:    modvendor.Dir(vendordir, source),
 			},
 		},
 	}, got)
 
-	cloneDir := got.Vendored[source.Raw].Dir
+	cloneDir := got.Vendored[vendoredAt].Dir
 	wantCloneDir := modvendor.Dir(vendordir, source)
 	assert.EqualStrings(t, wantCloneDir, cloneDir)
 
-	absCloneDir := modvendor.AbsVendorDir(rootdir, vendordir, got.Vendored[source.Raw].Source)
+	absCloneDir := modvendor.AbsVendorDir(rootdir, vendordir, got.Vendored[vendoredAt].Source)
 	gotContent := test.ReadFile(t, absCloneDir, filename)
 	assert.EqualStrings(t, content, string(gotContent))
 	assertNoGitDir(t, absCloneDir)
@@ -1044,10 +1045,10 @@ func TestModVendorWithRef(t *testing.T) {
 	got = modvendor.Vendor(rootdir, vendordir, source)
 
 	wantCloneDir = modvendor.Dir(vendordir, source)
-	newCloneDir := got.Vendored[source.Raw].Dir
+	newCloneDir := got.Vendored[wantCloneDir].Dir
 	assert.EqualStrings(t, wantCloneDir, newCloneDir)
 
-	absCloneDir = modvendor.AbsVendorDir(rootdir, vendordir, got.Vendored[source.Raw].Source)
+	absCloneDir = modvendor.AbsVendorDir(rootdir, vendordir, got.Vendored[wantCloneDir].Source)
 	assertNoGitDir(t, absCloneDir)
 
 	gotContent = test.ReadFile(t, absCloneDir, filename)

--- a/tf/mod_source_parse.go
+++ b/tf/mod_source_parse.go
@@ -31,6 +31,10 @@ type Source struct {
 	// Eg. github.com/mineiros-io/example
 	Path string
 
+	// Subdir is the subdir component of the source path, if any, as defined
+	// here: https://www.terraform.io/language/modules/sources#modules-in-package-sub-directories
+	Subdir string
+
 	// Ref is the specific reference of this source, if any.
 	Ref string
 
@@ -61,15 +65,18 @@ func ParseSource(modsource string) (Source, error) {
 				"%s is not a URL", modsource)
 		}
 		ref := u.Query().Get("ref")
+		subdir := parseURLSubdir(u)
 		u.RawQuery = ""
 		u.Scheme = "https"
 		u.Path = strings.TrimSuffix(u.Path, ".git")
+
 		path := filepath.Join(u.Host, u.Path)
 		return Source{
-			Raw:  modsource,
-			URL:  u.String() + ".git",
-			Path: path,
-			Ref:  ref,
+			Raw:    modsource,
+			URL:    u.String() + ".git",
+			Path:   path,
+			Subdir: subdir,
+			Ref:    ref,
 		}, nil
 
 	case strings.HasPrefix(modsource, "git@"):
@@ -91,13 +98,16 @@ func ParseSource(modsource string) (Source, error) {
 
 		ref := u.Query().Get("ref")
 		u.RawQuery = ""
-		path := strings.TrimSuffix(filepath.Join(u.Scheme, u.Opaque), ".git")
+		path, subdir := parseSubdir(u.Opaque)
+		u.Opaque = path
+		path = strings.TrimSuffix(filepath.Join(u.Scheme, u.Opaque), ".git")
 
 		return Source{
-			Raw:  modsource,
-			URL:  "git@" + u.String(),
-			Path: path,
-			Ref:  ref,
+			Raw:    modsource,
+			URL:    "git@" + u.String(),
+			Path:   path,
+			Subdir: subdir,
+			Ref:    ref,
 		}, nil
 
 	case strings.HasPrefix(modsource, "git::"):
@@ -128,4 +138,21 @@ func ParseSource(modsource string) (Source, error) {
 	default:
 		return Source{}, errors.E(ErrUnsupportedModSrc)
 	}
+}
+
+func parseSubdir(s string) (string, string) {
+	if !strings.Contains(s, "//") {
+		return s, ""
+	}
+
+	// From the specs we should have a single // on the path:
+	// https://www.terraform.io/language/modules/sources#modules-in-package-sub-directories
+	parsed := strings.Split(s, "//")
+	return parsed[0], "/" + parsed[1]
+}
+
+func parseURLSubdir(u *url.URL) string {
+	path, subdir := parseSubdir(u.Path)
+	u.Path = path
+	return subdir
 }

--- a/tf/mod_source_parse.go
+++ b/tf/mod_source_parse.go
@@ -118,11 +118,11 @@ func ParseSource(modsource string) (Source, error) {
 			return Source{}, errors.E(ErrInvalidModSrc, "invalid URL inside %s", modsource)
 		}
 
+		subdir := parseURLSubdir(u)
 		// We don't want : on the path. So we replace the possible :
 		// that can exist on the host.
 		path := filepath.Join(strings.Replace(u.Host, ":", "-", -1), u.Path)
 		path = strings.TrimSuffix(path, ".git")
-		subdir := parseURLSubdir(u)
 
 		if err != nil {
 			return Source{}, err

--- a/tf/mod_source_parse.go
+++ b/tf/mod_source_parse.go
@@ -120,9 +120,9 @@ func ParseSource(modsource string) (Source, error) {
 
 		// We don't want : on the path. So we replace the possible :
 		// that can exist on the host.
-		subdir := parseURLSubdir(u)
 		path := filepath.Join(strings.Replace(u.Host, ":", "-", -1), u.Path)
 		path = strings.TrimSuffix(path, ".git")
+		subdir := parseURLSubdir(u)
 
 		if err != nil {
 			return Source{}, err

--- a/tf/mod_source_parse.go
+++ b/tf/mod_source_parse.go
@@ -150,6 +150,9 @@ func parseSubdir(s string) (string, string) {
 	// From the specs we should have a single // on the path:
 	// https://www.terraform.io/language/modules/sources#modules-in-package-sub-directories
 	parsed := strings.Split(s, "//")
+	if len(parsed[1]) == 0 {
+		return parsed[0], ""
+	}
 	return parsed[0], "/" + parsed[1]
 }
 

--- a/tf/mod_source_parse.go
+++ b/tf/mod_source_parse.go
@@ -120,6 +120,7 @@ func ParseSource(modsource string) (Source, error) {
 
 		// We don't want : on the path. So we replace the possible :
 		// that can exist on the host.
+		subdir := parseURLSubdir(u)
 		path := filepath.Join(strings.Replace(u.Host, ":", "-", -1), u.Path)
 		path = strings.TrimSuffix(path, ".git")
 
@@ -129,10 +130,11 @@ func ParseSource(modsource string) (Source, error) {
 		ref := u.Query().Get("ref")
 		u.RawQuery = ""
 		return Source{
-			Raw:  modsource,
-			URL:  u.String(),
-			Path: path,
-			Ref:  ref,
+			Raw:    modsource,
+			URL:    u.String(),
+			Path:   path,
+			Subdir: subdir,
+			Ref:    ref,
 		}, nil
 
 	default:

--- a/tf/mod_source_parse_test.go
+++ b/tf/mod_source_parse_test.go
@@ -199,6 +199,17 @@ func TestParseGitSources(t *testing.T) {
 			},
 		},
 		{
+			name:   "git::https source with subdir",
+			source: "git::https://example.com/vpc.git//subdir",
+			want: want{
+				parsed: tf.Source{
+					URL:    "https://example.com/vpc.git",
+					Path:   "example.com/vpc",
+					Subdir: "/subdir",
+				},
+			},
+		},
+		{
 			name:   "git::https source with ref",
 			source: "git::https://example.com/vpc.git?ref=v3",
 			want: want{
@@ -210,6 +221,18 @@ func TestParseGitSources(t *testing.T) {
 			},
 		},
 		{
+			name:   "git::https source with ref and subdir",
+			source: "git::https://example.com/vpc.git//sub/dir?ref=v3",
+			want: want{
+				parsed: tf.Source{
+					URL:    "https://example.com/vpc.git",
+					Path:   "example.com/vpc",
+					Subdir: "/sub/dir",
+					Ref:    "v3",
+				},
+			},
+		},
+		{
 			name:   "git::https source with port",
 			source: "git::https://example.com:443/vpc.git?ref=v3",
 			want: want{
@@ -217,6 +240,18 @@ func TestParseGitSources(t *testing.T) {
 					URL:  "https://example.com:443/vpc.git",
 					Path: "example.com-443/vpc",
 					Ref:  "v3",
+				},
+			},
+		},
+		{
+			name:   "git::https source with port and subdir",
+			source: "git::https://example.com:443/vpc.git//port/dir?ref=v3",
+			want: want{
+				parsed: tf.Source{
+					URL:    "https://example.com:443/vpc.git",
+					Path:   "example.com-443/vpc",
+					Subdir: "/port/dir",
+					Ref:    "v3",
 				},
 			},
 		},
@@ -241,12 +276,34 @@ func TestParseGitSources(t *testing.T) {
 			},
 		},
 		{
+			name:   "git::ssh source and subdir",
+			source: "git::ssh://username@example.com/storage.git//subdir",
+			want: want{
+				parsed: tf.Source{
+					URL:    "ssh://username@example.com/storage.git",
+					Path:   "example.com/storage",
+					Subdir: "/subdir",
+				},
+			},
+		},
+		{
 			name:   "git::ssh source with port",
 			source: "git::ssh://username@example.com:666/storage.git",
 			want: want{
 				parsed: tf.Source{
 					URL:  "ssh://username@example.com:666/storage.git",
 					Path: "example.com-666/storage",
+				},
+			},
+		},
+		{
+			name:   "git::ssh source with port and subdir",
+			source: "git::ssh://username@example.com:666/storage.git//ssh/dir",
+			want: want{
+				parsed: tf.Source{
+					URL:    "ssh://username@example.com:666/storage.git",
+					Path:   "example.com-666/storage",
+					Subdir: "/ssh/dir",
 				},
 			},
 		},
@@ -258,6 +315,18 @@ func TestParseGitSources(t *testing.T) {
 					URL:  "ssh://username@example.com/storage.git",
 					Path: "example.com/storage",
 					Ref:  "v4",
+				},
+			},
+		},
+		{
+			name:   "git::ssh source with ref and subdir",
+			source: "git::ssh://username@example.com/storage.git//sub/ref?ref=v4",
+			want: want{
+				parsed: tf.Source{
+					URL:    "ssh://username@example.com/storage.git",
+					Path:   "example.com/storage",
+					Subdir: "/sub/ref",
+					Ref:    "v4",
 				},
 			},
 		},

--- a/tf/mod_source_parse_test.go
+++ b/tf/mod_source_parse_test.go
@@ -240,6 +240,17 @@ func TestParseGitSources(t *testing.T) {
 			},
 		},
 		{
+			name:   "git::file:// source with subdir",
+			source: "git::file:///tmp/test/repo//subdir",
+			want: want{
+				parsed: tf.Source{
+					URL:    "file:///tmp/test/repo",
+					Path:   "/tmp/test/repo",
+					Subdir: "/subdir",
+				},
+			},
+		},
+		{
 			name:   "git::https source with ref",
 			source: "git::https://example.com/vpc.git?ref=v3",
 			want: want{

--- a/tf/mod_source_parse_test.go
+++ b/tf/mod_source_parse_test.go
@@ -47,12 +47,34 @@ func TestParseGitSources(t *testing.T) {
 			},
 		},
 		{
+			name:   "github source with subdir",
+			source: "github.com/mineiros-io/example//subdir",
+			want: want{
+				parsed: tf.Source{
+					URL:    "https://github.com/mineiros-io/example.git",
+					Path:   "github.com/mineiros-io/example",
+					Subdir: "/subdir",
+				},
+			},
+		},
+		{
 			name:   "github source with .git suffix",
 			source: "github.com/mineiros-io/example.git",
 			want: want{
 				parsed: tf.Source{
 					URL:  "https://github.com/mineiros-io/example.git",
 					Path: "github.com/mineiros-io/example",
+				},
+			},
+		},
+		{
+			name:   "github source with .git suffix and subdir",
+			source: "github.com/mineiros-io/example.git//subdir/dir",
+			want: want{
+				parsed: tf.Source{
+					URL:    "https://github.com/mineiros-io/example.git",
+					Path:   "github.com/mineiros-io/example",
+					Subdir: "/subdir/dir",
 				},
 			},
 		},
@@ -68,6 +90,18 @@ func TestParseGitSources(t *testing.T) {
 			},
 		},
 		{
+			name:   "github source with ref and subdir",
+			source: "github.com/mineiros-io/example//sub/ref?ref=v1",
+			want: want{
+				parsed: tf.Source{
+					URL:    "https://github.com/mineiros-io/example.git",
+					Path:   "github.com/mineiros-io/example",
+					Subdir: "/sub/ref",
+					Ref:    "v1",
+				},
+			},
+		},
+		{
 			name:   "github source with ref and .git suffix",
 			source: "github.com/mineiros-io/example.git?ref=v1",
 			want: want{
@@ -75,6 +109,18 @@ func TestParseGitSources(t *testing.T) {
 					URL:  "https://github.com/mineiros-io/example.git",
 					Path: "github.com/mineiros-io/example",
 					Ref:  "v1",
+				},
+			},
+		},
+		{
+			name:   "github source with ref .git suffix and subdir",
+			source: "github.com/mineiros-io/example.git//dir?ref=v1",
+			want: want{
+				parsed: tf.Source{
+					URL:    "https://github.com/mineiros-io/example.git",
+					Path:   "github.com/mineiros-io/example",
+					Subdir: "/dir",
+					Ref:    "v1",
 				},
 			},
 		},
@@ -99,6 +145,17 @@ func TestParseGitSources(t *testing.T) {
 			},
 		},
 		{
+			name:   "git@ source with subdir",
+			source: "git@github.com:mineiros-io/example.git//subdir",
+			want: want{
+				parsed: tf.Source{
+					URL:    "git@github.com:mineiros-io/example.git",
+					Path:   "github.com/mineiros-io/example",
+					Subdir: "/subdir",
+				},
+			},
+		},
+		{
 			name:   "git@ source with ref",
 			source: "git@github.com:mineiros-io/example.git?ref=v2",
 			want: want{
@@ -106,6 +163,18 @@ func TestParseGitSources(t *testing.T) {
 					URL:  "git@github.com:mineiros-io/example.git",
 					Path: "github.com/mineiros-io/example",
 					Ref:  "v2",
+				},
+			},
+		},
+		{
+			name:   "git@ source with ref and subdir",
+			source: "git@github.com:mineiros-io/example.git//sub/dir?ref=v2",
+			want: want{
+				parsed: tf.Source{
+					URL:    "git@github.com:mineiros-io/example.git",
+					Path:   "github.com/mineiros-io/example",
+					Subdir: "/sub/dir",
+					Ref:    "v2",
 				},
 			},
 		},

--- a/tf/mod_source_parse_test.go
+++ b/tf/mod_source_parse_test.go
@@ -58,6 +58,16 @@ func TestParseGitSources(t *testing.T) {
 			},
 		},
 		{
+			name:   "github source with empty subdir",
+			source: "github.com/mineiros-io/example//",
+			want: want{
+				parsed: tf.Source{
+					URL:  "https://github.com/mineiros-io/example.git",
+					Path: "github.com/mineiros-io/example",
+				},
+			},
+		},
+		{
 			name:   "github source with .git suffix",
 			source: "github.com/mineiros-io/example.git",
 			want: want{
@@ -156,6 +166,16 @@ func TestParseGitSources(t *testing.T) {
 			},
 		},
 		{
+			name:   "git@ source with empty subdir",
+			source: "git@github.com:mineiros-io/example.git//",
+			want: want{
+				parsed: tf.Source{
+					URL:  "git@github.com:mineiros-io/example.git",
+					Path: "github.com/mineiros-io/example",
+				},
+			},
+		},
+		{
 			name:   "git@ source with ref",
 			source: "git@github.com:mineiros-io/example.git?ref=v2",
 			want: want{
@@ -206,6 +226,16 @@ func TestParseGitSources(t *testing.T) {
 					URL:    "https://example.com/vpc.git",
 					Path:   "example.com/vpc",
 					Subdir: "/subdir",
+				},
+			},
+		},
+		{
+			name:   "git::https source with empty subdir",
+			source: "git::https://example.com/vpc.git//",
+			want: want{
+				parsed: tf.Source{
+					URL:  "https://example.com/vpc.git",
+					Path: "example.com/vpc",
 				},
 			},
 		},
@@ -283,6 +313,16 @@ func TestParseGitSources(t *testing.T) {
 					URL:    "ssh://username@example.com/storage.git",
 					Path:   "example.com/storage",
 					Subdir: "/subdir",
+				},
+			},
+		},
+		{
+			name:   "git::ssh source and empty subdir",
+			source: "git::ssh://username@example.com/storage.git//",
+			want: want{
+				parsed: tf.Source{
+					URL:  "ssh://username@example.com/storage.git",
+					Path: "example.com/storage",
 				},
 			},
 		},


### PR DESCRIPTION
# Reason for This Change

Today we fail on vendoring when there are [sub directories references](https://www.terraform.io/language/modules/sources#modules-in-package-sub-directories) on the source.

## Description of Changes

Add support to parsing the subdir and use that information when patching terraform files.

## Reproducing the issue

```sh
#!/bin/bash

set -o errexit
set -o nounset
set -o pipefail

workdir="$(mktemp -d)"
cd "${workdir}"

cat > terramate.tm.hcl <<- EOM
terramate {
  config {
  }
}
EOM

terramate experimental vendor download github.com/mineiros-io/terramate//hcl main
terramate experimental vendor download github.com/mineiros-io/terramate//config c6847ea138d0008de79b6a0e1790a15c3b5524ef
terramate experimental vendor download git@github.com:mineiros-io/terramate.git//modvendor v0.1.19

echo "vendor:"
tree -d -L 4 vendor

echo "checking VERSION files of each vendored repo"
cat vendor/github.com/mineiros-io/terramate/main/VERSION
cat vendor/github.com/mineiros-io/terramate/c6847ea138d0008de79b6a0e1790a15c3b5524ef/VERSION
cat vendor/github.com/mineiros-io/terramate/v0.1.19/VERSION
```
