### PR TITLE
chore: add mac 10.15 back to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,9 +45,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # removed "macos-10.15" because of failures on GHA
         # maybe in the future: windows-2019, windows-2022
-        os: ["ubuntu-20.04", "macos-11"] 
+        os: ["ubuntu-20.04", "macos-10.15", "macos-11"] 
         go: ["1.17", "1.18"]
 
     steps:


### PR DESCRIPTION
We had some odd issues with it in the past on GHA, the runner was hanging forever. But now it seems to be OK.