### PR TITLE
chore: add space just for testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,7 @@ jobs:
         os: ["ubuntu-20.04", "macos-10.15", "macos-11"] 
         go: ["1.17", "1.18"]
 
+
     steps:
       - name: checkout repo
         uses: actions/checkout@v2


### PR DESCRIPTION
Just to check if the macos runner is going to work. It is getting automatically cancelled for some reason.