### PR TITLE
chore: update macos runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
       fail-fast: false
       matrix:
         # maybe in the future: windows-2019, windows-2022
-        os: ["ubuntu-20.04", "macos-10.15", "macos-11"] 
+        os: ["ubuntu-20.04", "macos-11", "macos-12"]
         go: ["1.17", "1.18"]
 
     steps:


### PR DESCRIPTION
# Reason for This Change

macos-10.15 is being deprecated. Sorry I added it back again, I wasn't able to find this before:

https://github.blog/changelog/2022-07-20-github-actions-the-macos-10-15-actions-runner-image-is-being-deprecated-and-will-be-removed-by-8-30-22/

And apparently the best way to communicate deprecation is by making things fail inside a schedule, so people can observe the behavior of "sometimes it work, sometimes it breaks" and then realize that obviously that means the runner is being deprecated.

And the workflow is just marked as cancelled...with no information on why, kudos to GHA :laughing: 
