### PR TITLE
fix: fs.CopyDir creates empty dirs

### DIFF
--- a/fs/copy.go
+++ b/fs/copy.go
@@ -58,11 +58,6 @@ func CopyDir(destdir, srcdir string, filter CopyFilterFunc) error {
 		if !filter(srcdir, entry) {
 			continue
 		}
-		// Only create dir if we have another dir or file to copy to it
-		// if all files/subdirs are filtered out no dir is created.
-		if err := createDir(); err != nil {
-			return err
-		}
 
 		srcpath := filepath.Join(srcdir, entry.Name())
 		destpath := filepath.Join(destdir, entry.Name())
@@ -72,6 +67,12 @@ func CopyDir(destdir, srcdir string, filter CopyFilterFunc) error {
 				return errors.E(err, "copying src to dest dir")
 			}
 			continue
+		}
+
+		// Only create dir if there is a file to copy to it or if some of
+		// its subdirs have a file to copy on it.
+		if err := createDir(); err != nil {
+			return err
 		}
 
 		if err := copyFile(destpath, srcpath); err != nil {

--- a/fs/copy_test.go
+++ b/fs/copy_test.go
@@ -32,6 +32,9 @@ func TestCopyIfAllFilesAreFilteredDirIsNotCreated(t *testing.T) {
 		"f:test/2",
 		"f:test/3",
 		"f:test/sub/notcopy",
+		"f:test/sub/sub2/notcopy",
+		"f:test/sub/sub2/sub3/notcopy",
+		"f:test/anothersub/sub2/sub3/notcopy",
 		"f:test3/notcopy",
 	})
 


### PR DESCRIPTION
# Reason for This Change

On fs.CopyDir the dir is created as soon as the filter function returns true. But when the filtered path is a dir we should not create the dir yet since it may have no files inside it. This would cause some features, like vendoring with manifest, to create empty dirs in some scenarios.

## Description of Changes

Only create directories when there is an actual file to copy to it. Also improved the tests to catch this scenario.
