### PR TITLE
chore: improve generation message for up to date code

### DIFF
--- a/generate/generate_report.go
+++ b/generate/generate_report.go
@@ -64,7 +64,7 @@ func (r Report) HasFailures() bool {
 
 func (r Report) String() string {
 	if r.empty() {
-		return "Nothing to do, code generation is updated"
+		return "Nothing to do, generated code is up to date"
 	}
 	if r.BootstrapErr != nil {
 		return fmt.Sprintf(

--- a/generate/generate_report_test.go
+++ b/generate/generate_report_test.go
@@ -35,7 +35,7 @@ func TestReportRepresentation(t *testing.T) {
 		{
 			name:   "empty report",
 			report: generate.Report{},
-			want:   "Nothing to do, code generation is updated",
+			want:   "Nothing to do, generated code is up to date",
 		},
 		{
 			name: "with bootstrap err",


### PR DESCRIPTION
# Reason for This Change

The `nothing-to-do` message was confusing, it's now unconfusing.