### PR TITLE
chore: avoid cleanup dotdirs on generate

### DIFF
--- a/generate/generate.go
+++ b/generate/generate.go
@@ -733,14 +733,20 @@ func listGenFilesOutsideStacks(rootdir, dir string) ([]dirGenFiles, error) {
 	}
 
 	for _, entry := range entries {
-		if entry.IsDir() {
-			childPath := filepath.Join(dir, entry.Name())
-			childGenFiles, err := listGenFilesOutsideStacks(rootdir, childPath)
-			if err != nil {
-				return nil, err
-			}
-			dirsFiles = append(dirsFiles, childGenFiles...)
+		if !entry.IsDir() {
+			continue
 		}
+
+		if strings.HasPrefix(entry.Name(), ".") {
+			continue
+		}
+
+		childPath := filepath.Join(dir, entry.Name())
+		childGenFiles, err := listGenFilesOutsideStacks(rootdir, childPath)
+		if err != nil {
+			return nil, err
+		}
+		dirsFiles = append(dirsFiles, childGenFiles...)
 	}
 
 	return dirsFiles, nil

--- a/generate/generate_hcl_test.go
+++ b/generate/generate_hcl_test.go
@@ -1332,6 +1332,16 @@ func TestGenerateHCLCleanupOldFilesIgnoreSymlinks(t *testing.T) {
 	})
 }
 
+func TestGenerateHCLCleanupOldFilesIgnoreDotDirs(t *testing.T) {
+	s := sandbox.NoGit(t)
+
+	// Creates a file with a generated header inside dot dirs.
+	test.WriteFile(t, filepath.Join(s.RootDir(), ".terramate"), "test.tf", genhcl.Header)
+	test.WriteFile(t, filepath.Join(s.RootDir(), ".another"), "test.tf", genhcl.Header)
+
+	assertEqualReports(t, s.Generate(), generate.Report{})
+}
+
 func TestGenerateHCLTerramateRootMetadata(t *testing.T) {
 	// We need to know the sandbox abspath to test terramate.root properly
 	const generatedFile = "file.hcl"


### PR DESCRIPTION
# Reason for This Change

We are currently checking for files to cleanup on generate inside dot dirs.

## Description of Changes

Filter out dot dirs when cleaning up files.
