### PR TITLE
fix: project paths must not use portable path library

### DIFF
--- a/hcl/hcl.go
+++ b/hcl/hcl.go
@@ -17,6 +17,7 @@ package hcl
 import (
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 	"regexp"
 	"sort"
@@ -523,9 +524,9 @@ func (p *TerramateParser) handleImport(importBlock *ast.Block) error {
 	}
 
 	src := srcVal.AsString()
-	srcBase := filepath.Base(src)
-	srcDir := filepath.Dir(src)
-	if filepath.IsAbs(srcDir) { // project-path
+	srcBase := path.Base(src)
+	srcDir := path.Dir(src)
+	if path.IsAbs(srcDir) { // project-path
 		srcDir = filepath.Join(p.rootdir, srcDir)
 	} else {
 		srcDir = filepath.Join(p.dir, srcDir)


### PR DESCRIPTION
Required to make terramate-ls works on Windows again.