### PR TITLE
chore: improve warning messages

### DIFF
--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -1485,18 +1485,7 @@ func (c *cli) runOnStacks() {
 	)
 
 	if err != nil {
-		logger.Warn().Msg("one or more commands failed")
-
-		var errs *errors.List
-		if errors.As(err, &errs) {
-			for _, err := range errs.Errors() {
-				logger.Warn().Err(err).Send()
-			}
-		} else {
-			logger.Warn().Err(err).Send()
-		}
-
-		os.Exit(1)
+		fatalerr(log.Logger, "one or more commands failed", err)
 	}
 }
 
@@ -1658,11 +1647,11 @@ func lookupProject(wd string) (prj project, found bool, err error) {
 			rootdir := filepath.Dir(gitabs)
 
 			if rootfound && strings.HasPrefix(rootCfgPath, rootdir) && rootCfgPath != rootdir {
-				logger.Warn().
+				log.Warn().
 					Str("rootConfig", rootCfgPath).
 					Str("projectRoot", rootdir).
 					Err(errors.E(ErrRootCfgInvalidDir)).
-					Msg("the config will be ignored")
+					Msg("ignoring root config")
 			}
 
 			logger.Trace().Msg("Load root config.")

--- a/generate/generate.go
+++ b/generate/generate.go
@@ -102,7 +102,7 @@ func Do(rootdir string, workingDir string) Report {
 				assertRange := assert.Range
 				assertRange.Filename = filepath.ToSlash(strings.TrimPrefix(assert.Range.Filename, rootdir))
 				if assert.Warning {
-					logger.Warn().
+					log.Warn().
 						Stringer("origin", assertRange).
 						Str("msg", assert.Message).
 						Msg("assertion failed")

--- a/run/order.go
+++ b/run/order.go
@@ -148,7 +148,7 @@ func BuildDAG(
 	visited dag.Visited,
 ) error {
 	logger := log.With().
-		Str("action", "BuildDAG()").
+		Str("action", "run.BuildDAG()").
 		Str("path", root).
 		Stringer("stack", s.Path()).
 		Logger()
@@ -170,12 +170,12 @@ func BuildDAG(
 			}
 			st, err := os.Stat(abspath)
 			if err != nil {
-				logger.Warn().
+				log.Warn().
 					Err(err).
-					Msgf("failed to stat %s path %s - ignoring", fieldname, abspath)
+					Msgf("building dag: failed to stat %s path %s - ignoring", fieldname, abspath)
 			} else if !st.IsDir() {
-				logger.Warn().
-					Msgf("stack.%s path %s is not a directory - ignoring",
+				log.Warn().
+					Msgf("building dag: stack.%s path %s is not a directory - ignoring",
 						fieldname, pathstr)
 			} else {
 				cleanpaths = append(cleanpaths, pathstr)


### PR DESCRIPTION
# Reason for This Change

The idea is to log less detailed information on warn messages, leaving details to other levels like debug/trace. For info/warning/fatal I think we could drop the "action" field since it is quite specific to details of the code (private function names, etc).
