### PR TITLE
feat: add .tmskip

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -259,8 +259,8 @@ func loadTree(rootdir string, cfgdir string, rootcfg *hcl.Config) (*Tree, error)
 			Str("filename", name).
 			Logger()
 
-		if ignoreFilename(name) {
-			logger.Trace().Msg("ignoring dot file")
+		if Skip(name) {
+			logger.Trace().Msg("skipping file")
 			continue
 		}
 		dir := filepath.Join(cfgdir, name)
@@ -347,11 +347,13 @@ func NewTree(cfgdir string) *Tree {
 	}
 }
 
+// Skip returns true if the given file/dir name should be ignored by Terramate.
+func Skip(name string) bool {
+	// assumes filename length > 0
+	return name[0] == '.'
+}
+
 func parentDir(dir string) (string, bool) {
 	parent := filepath.Dir(dir)
 	return parent, parent != dir
-}
-
-func ignoreFilename(name string) bool {
-	return name[0] == '.' // assumes filename length > 0
 }

--- a/config/config.go
+++ b/config/config.go
@@ -30,6 +30,9 @@ import (
 const (
 	// DefaultFilename is the name of the default Terramate configuration file.
 	DefaultFilename = "terramate.tm.hcl"
+
+	// SkipFilename is the name of Terramate skip file.
+	SkipFilename = ".tmskip"
 )
 
 const (
@@ -234,7 +237,7 @@ func loadTree(rootdir string, cfgdir string, rootcfg *hcl.Config) (*Tree, error)
 	}
 
 	for _, name := range names {
-		if name == ".tmskip" {
+		if name == SkipFilename {
 			logger.Debug().Msg("skip file found: skipping whole subtree")
 			return NewTree(cfgdir), nil
 		}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -261,7 +261,7 @@ func TestConfigSkipdir(t *testing.T) {
 	s.BuildTree([]string{
 		"s:/stack",
 		"s:/stack-2",
-		"f:/stack/.tmskip",
+		"f:/stack/" + config.SkipFilename,
 		"f:/stack/ignored.tm:not valid hcl but wont be parsed",
 		"f:/stack/subdir/ignored.tm:not valid hcl but wont be parsed",
 	})

--- a/docs/config-overview.md
+++ b/docs/config-overview.md
@@ -97,6 +97,17 @@ terramate {
 }
 ```
 
+# Skipping Directories
+
+If you want to have a directory that is not hidden but want Terramate to ignore the
+directory contents all you have to do is create an empty file called `.tmskip` inside
+the directory. After the file is created the directory will be ignored by
+all Terramate features, its contents will not be parsed even if it contains
+Terramate files.
+
+You can still import code that is located inside such a directory.
+
+
 # Terramate Configuration Schema
 
 The terramate configuration is defined by the following top-level blocks:

--- a/generate/generate.go
+++ b/generate/generate.go
@@ -232,6 +232,7 @@ func ListGenFiles(cfg *config.Tree, dir string) ([]string, error) {
 	pendingSubDirs := []string{""}
 	genfiles := []string{}
 
+processSubdirs:
 	for len(pendingSubDirs) > 0 {
 		relSubdir := pendingSubDirs[0]
 		pendingSubDirs = pendingSubDirs[1:]
@@ -241,14 +242,26 @@ func ListGenFiles(cfg *config.Tree, dir string) ([]string, error) {
 			return nil, errors.E(err)
 		}
 
+		logger = logger.With().
+			Str("dir", relSubdir).
+			Logger()
+
+		// We need to skip all other files/dirs if we find a config.SkipFilename
+		for _, entry := range entries {
+			if entry.Name() == config.SkipFilename {
+				logger.Trace().Msg("found skip file: ignoring dir and all its contents")
+				continue processSubdirs
+			}
+		}
+
 		for _, entry := range entries {
 			logger := logger.With().
 				Str("entry", entry.Name()).
 				Str("dir", absSubdir).
 				Logger()
 
-			if strings.HasPrefix(entry.Name(), ".") {
-				logger.Trace().Msg("ignoring dot file/dir")
+			if config.Skip(entry.Name()) {
+				logger.Trace().Msg("ignoring file/dir")
 				continue
 			}
 

--- a/generate/generate_list_test.go
+++ b/generate/generate_list_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/madlambda/spells/assert"
+	"github.com/mineiros-io/terramate/config"
 	"github.com/mineiros-io/terramate/generate"
 	"github.com/mineiros-io/terramate/generate/genhcl"
 	"github.com/mineiros-io/terramate/test/sandbox"
@@ -107,6 +108,32 @@ func TestGeneratedFilesListing(t *testing.T) {
 				"f:manual2.tf:data",
 			},
 			want: []string{"gen.tf", "gen2.tf"},
+		},
+		{
+			name: "on root ignores generated files inside dir with .tmskip",
+			layout: []string{
+				genfile("genfiles/1.tf"),
+				genfile("genfiles/2.tf"),
+				genfile("genfiles/" + config.SkipFilename),
+				genfile("genfiles/subdir/1.tf"),
+				genfile("genfiles2/1.tf"),
+			},
+			want: []string{
+				"genfiles2/1.tf",
+			},
+		},
+		{
+			name: "on stack ignores generated files inside dir with .tmskip",
+			dir:  "stack",
+			layout: []string{
+				"s:stack",
+				genfile("stack/1.tf"),
+				genfile("stack/dir/" + config.SkipFilename),
+				genfile("stack/dir/1.tf"),
+			},
+			want: []string{
+				"1.tf",
+			},
 		},
 		{
 			name: "on root lists all generated files except inside stacks",

--- a/generate/generate_test.go
+++ b/generate/generate_test.go
@@ -61,6 +61,71 @@ func (s stringer) String() string {
 	return string(s)
 }
 
+func TestGenerateIgnore(t *testing.T) {
+	testCodeGeneration(t, []testcase{
+		{
+			name: "dir with skip file",
+			layout: []string{
+				"s:stacks/stack",
+				"s:stacks/stack-2",
+				"f:stacks/stack-2/" + config.SkipFilename,
+			},
+			configs: []hclconfig{
+				{
+					path: "/stacks",
+					add: GenerateHCL(
+						Labels("file.hcl"),
+						Content(
+							Block("block",
+								Str("data", "data"),
+							),
+						),
+					),
+				},
+				{
+					path: "/stacks",
+					add: GenerateHCL(
+						Labels("dir/file.hcl"),
+						Content(
+							Block("block",
+								Str("data", "data"),
+							),
+						),
+					),
+				},
+			},
+			want: []generatedFile{
+				{
+					stack: "/stacks/stack",
+					files: map[string]fmt.Stringer{
+						"file.hcl": Doc(
+							Block("block",
+								Str("data", "data"),
+							),
+						),
+						"dir/file.hcl": Doc(
+							Block("block",
+								Str("data", "data"),
+							),
+						),
+					},
+				},
+			},
+			wantReport: generate.Report{
+				Successes: []generate.Result{
+					{
+						Dir: "/stacks/stack",
+						Created: []string{
+							"dir/file.hcl",
+							"file.hcl",
+						},
+					},
+				},
+			},
+		},
+	})
+}
+
 func TestGenerateSubDirsOnLabels(t *testing.T) {
 	testCodeGeneration(t, []testcase{
 		{


### PR DESCRIPTION
# Reason for This Change

So we can add root context configurations in some directory and then import it without processing the configuration twice. This is also useful to ignore vendored content (in the future we can add .tmskip on vendored dirs).