### PR TITLE
test:generate: run tests in parallel

### DIFF
--- a/generate/assert_test.go
+++ b/generate/assert_test.go
@@ -25,6 +25,8 @@ import (
 )
 
 func TestGenerateAssert(t *testing.T) {
+	t.Parallel()
+
 	testCodeGeneration(t, []testcase{
 		{
 			name: "no generate blocks with success assertion",

--- a/generate/generate_file_check_test.go
+++ b/generate/generate_file_check_test.go
@@ -25,6 +25,8 @@ import (
 )
 
 func TestCheckStackForGenFileWithChildStacks(t *testing.T) {
+	t.Parallel()
+
 	s := sandbox.New(t)
 	s.BuildTree([]string{
 		"s:/stack",
@@ -95,6 +97,8 @@ func TestCheckStackForGenFileWithChildStacks(t *testing.T) {
 }
 
 func TestCheckStackForGenFile(t *testing.T) {
+	t.Parallel()
+
 	s := sandbox.New(t)
 
 	stackEntry := s.CreateStack("stacks/stack")
@@ -189,6 +193,8 @@ func TestCheckStackForGenFile(t *testing.T) {
 }
 
 func TestCheckOutdatedDetectsEmptyGenerateFileContent(t *testing.T) {
+	t.Parallel()
+
 	s := sandbox.New(t)
 
 	stackEntry := s.CreateStack("stacks/stack")
@@ -244,6 +250,8 @@ func TestCheckOutdatedDetectsEmptyGenerateFileContent(t *testing.T) {
 }
 
 func TestCheckOutdatedIgnoresWhenGenFileConditionIsFalse(t *testing.T) {
+	t.Parallel()
+
 	const filename = "test.txt"
 
 	s := sandbox.New(t)

--- a/generate/generate_file_test.go
+++ b/generate/generate_file_test.go
@@ -28,6 +28,8 @@ import (
 )
 
 func TestGenerateFile(t *testing.T) {
+	t.Parallel()
+
 	testCodeGeneration(t, []testcase{
 		{
 			name: "empty generate_file content generates empty file",
@@ -260,6 +262,8 @@ func TestGenerateFile(t *testing.T) {
 }
 
 func TestGenerateFileRemoveFilesWhenConditionIsFalse(t *testing.T) {
+	t.Parallel()
+
 	const filename = "file.txt"
 
 	s := sandbox.New(t)
@@ -327,6 +331,8 @@ func TestGenerateFileRemoveFilesWhenConditionIsFalse(t *testing.T) {
 }
 
 func TestGenerateFileTerramateRootMetadata(t *testing.T) {
+	t.Parallel()
+
 	// We need to know the sandbox abspath to test terramate.root properly
 	const generatedFile = "file.hcl"
 

--- a/generate/generate_hcl_check_test.go
+++ b/generate/generate_hcl_check_test.go
@@ -25,6 +25,8 @@ import (
 )
 
 func TestCheckStackForGenHCLWithChildStacks(t *testing.T) {
+	t.Parallel()
+
 	s := sandbox.New(t)
 	s.BuildTree([]string{
 		"s:/stack",
@@ -120,6 +122,8 @@ func TestCheckStackForGenHCLWithChildStacks(t *testing.T) {
 }
 
 func TestCheckStackForGenHCL(t *testing.T) {
+	t.Parallel()
+
 	s := sandbox.New(t)
 
 	stackEntry := s.CreateStack("stacks/stack")
@@ -292,6 +296,8 @@ func TestCheckStackForGenHCL(t *testing.T) {
 }
 
 func TestCheckOutdatedDetectsEmptyGenerateHCLBlocks(t *testing.T) {
+	t.Parallel()
+
 	s := sandbox.New(t)
 
 	stackEntry := s.CreateStack("stacks/stack")
@@ -354,6 +360,8 @@ func TestCheckOutdatedDetectsEmptyGenerateHCLBlocks(t *testing.T) {
 }
 
 func TestCheckOutdatedIgnoresWhenGenHCLConditionIsFalse(t *testing.T) {
+	t.Parallel()
+
 	const filename = "test.tf"
 
 	s := sandbox.New(t)

--- a/generate/generate_hcl_test.go
+++ b/generate/generate_hcl_test.go
@@ -35,6 +35,8 @@ import (
 )
 
 func TestGenerateHCL(t *testing.T) {
+	t.Parallel()
+
 	provider := func(builders ...hclwrite.BlockBuilder) *hclwrite.Block {
 		return hclwrite.BuildBlock("provider", builders...)
 	}
@@ -834,6 +836,8 @@ func TestGenerateHCL(t *testing.T) {
 }
 
 func TestWontOverwriteManuallyDefinedTerraform(t *testing.T) {
+	t.Parallel()
+
 	const (
 		genFilename  = "test.tf"
 		manualTfCode = "some manual stuff, doesn't matter"
@@ -866,6 +870,8 @@ func TestWontOverwriteManuallyDefinedTerraform(t *testing.T) {
 }
 
 func TestGenerateHCLOverwriting(t *testing.T) {
+	t.Parallel()
+
 	const genFilename = "test.tf"
 
 	firstConfig := GenerateHCL(
@@ -928,6 +934,8 @@ func TestGenerateHCLOverwriting(t *testing.T) {
 }
 
 func TestGeneratedHCLHeaders(t *testing.T) {
+	t.Parallel()
+
 	const (
 		rootFilename        = "root.tf"
 		stackFilename       = "stack.tf"
@@ -976,6 +984,8 @@ func TestGeneratedHCLHeaders(t *testing.T) {
 }
 
 func TestGenerateHCLCleanupFilesOnDirThatIsNotStack(t *testing.T) {
+	t.Parallel()
+
 	s := sandbox.New(t)
 	stackEntry := s.CreateStack("stack")
 	childStack := s.CreateStack("stack/child")
@@ -1054,6 +1064,8 @@ func TestGenerateHCLCleanupFilesOnDirThatIsNotStack(t *testing.T) {
 }
 
 func TestGenerateHCLCleanupOldFiles(t *testing.T) {
+	t.Parallel()
+
 	s := sandbox.New(t)
 	stackEntry := s.CreateStack("stack")
 	rootEntry := s.DirEntry(".")
@@ -1211,6 +1223,7 @@ func TestGenerateHCLCleanupOldFilesIgnoreSymlinks(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("skipped on windows because it requires privileges")
 	}
+	t.Parallel()
 
 	s := sandbox.NoGit(t)
 	rootEntry := s.RootEntry().CreateDir("root")
@@ -1262,6 +1275,8 @@ func TestGenerateHCLCleanupOldFilesIgnoreSymlinks(t *testing.T) {
 }
 
 func TestGenerateHCLCleanupOldFilesIgnoreDotDirs(t *testing.T) {
+	t.Parallel()
+
 	s := sandbox.NoGit(t)
 
 	// Creates a file with a generated header inside dot dirs.
@@ -1272,6 +1287,8 @@ func TestGenerateHCLCleanupOldFilesIgnoreDotDirs(t *testing.T) {
 }
 
 func TestGenerateHCLTerramateRootMetadata(t *testing.T) {
+	t.Parallel()
+
 	// We need to know the sandbox abspath to test terramate.root properly
 	const generatedFile = "file.hcl"
 

--- a/generate/generate_test.go
+++ b/generate/generate_test.go
@@ -62,6 +62,8 @@ func (s stringer) String() string {
 }
 
 func TestGenerateSubDirsOnLabels(t *testing.T) {
+	t.Parallel()
+
 	testCodeGeneration(t, []testcase{
 		{
 			name: "subdirs with no relative walk are allowed",
@@ -401,6 +403,8 @@ func TestGenerateSubDirsOnLabels(t *testing.T) {
 }
 
 func TestGenerateCleanup(t *testing.T) {
+	t.Parallel()
+
 	testCodeGeneration(t, []testcase{
 		{
 			name: "deletes generated files outside stacks",
@@ -498,6 +502,8 @@ func TestGenerateCleanup(t *testing.T) {
 }
 
 func TestGenerateCleanupFailsToReadFiles(t *testing.T) {
+	t.Parallel()
+
 	s := sandbox.New(t)
 	dir := s.RootEntry().CreateDir("dir")
 	file := dir.CreateFile("file.hcl", genhcl.Header)
@@ -512,6 +518,8 @@ func TestGenerateCleanupFailsToReadFiles(t *testing.T) {
 }
 
 func TestGenerateConflictsBetweenGenerateTypes(t *testing.T) {
+	t.Parallel()
+
 	testCodeGeneration(t, []testcase{
 		{
 			name: "stack with different generate blocks but same label",
@@ -640,6 +648,8 @@ func TestGenerateConflictsBetweenGenerateTypes(t *testing.T) {
 }
 
 func TestCheckDetectsFilesOutsideStacks(t *testing.T) {
+	t.Parallel()
+
 	s := sandbox.New(t)
 	s.BuildTree([]string{
 		"s:stack-1",
@@ -671,9 +681,12 @@ func TestCheckDetectsFilesOutsideStacks(t *testing.T) {
 func testCodeGeneration(t *testing.T, tcases []testcase) {
 	t.Helper()
 
-	for _, tcase := range tcases {
+	for _, tc := range tcases {
+		tcase := tc
+
 		t.Run(tcase.name, func(t *testing.T) {
 			t.Helper()
+			t.Parallel()
 
 			if tcase.skipOn == runtime.GOOS {
 				t.Skipf("skipping on GOOS %q", tcase.skipOn)

--- a/generate/genfile/genfile_test.go
+++ b/generate/genfile/genfile_test.go
@@ -33,6 +33,8 @@ import (
 )
 
 func TestLoadGenerateFiles(t *testing.T) {
+	t.Parallel()
+
 	type (
 		hclconfig struct {
 			path string
@@ -988,6 +990,8 @@ stack_id=stack-id
 
 	for _, tcase := range tcases {
 		t.Run(tcase.name, func(t *testing.T) {
+			t.Parallel()
+
 			s := sandbox.New(t)
 			s.BuildTree([]string{"s:" + tcase.stack})
 			stacks := s.LoadStacks()

--- a/generate/genhcl/genhcl_dynamic_test.go
+++ b/generate/genhcl/genhcl_dynamic_test.go
@@ -24,6 +24,8 @@ import (
 )
 
 func TestGenerateHCLDynamic(t *testing.T) {
+	t.Parallel()
+
 	tcases := []testcase{
 		{
 			name:  "tm_dynamic with empty content block",

--- a/generate/genhcl/genhcl_partial_eval_test.go
+++ b/generate/genhcl/genhcl_partial_eval_test.go
@@ -34,6 +34,7 @@ import (
 )
 
 func TestPartialEval(t *testing.T) {
+	t.Parallel()
 	// These tests simplify the overall setup/description and focus only
 	// on how code will be partially evaluated.
 	// No support for multiple config files or generating multiple
@@ -1526,8 +1527,12 @@ func TestPartialEval(t *testing.T) {
 		},
 	}
 
-	for _, tcase := range tcases {
+	for _, tc := range tcases {
+		tcase := tc
+
 		t.Run(tcase.name, func(t *testing.T) {
+			t.Parallel()
+
 			const genname = "test"
 			const stackname = "stack"
 

--- a/generate/genhcl/genhcl_test.go
+++ b/generate/genhcl/genhcl_test.go
@@ -38,6 +38,8 @@ import (
 )
 
 func TestGenerateHCL(t *testing.T) {
+	t.Parallel()
+
 	tcases := []testcase{
 		{
 			name:  "no generation",
@@ -1702,6 +1704,8 @@ type (
 
 func (tcase testcase) run(t *testing.T) {
 	t.Run(tcase.name, func(t *testing.T) {
+		t.Parallel()
+
 		s := sandbox.New(t)
 		s.BuildTree([]string{"s:" + tcase.stack})
 		stacks := s.LoadStacks()

--- a/generate/report_test.go
+++ b/generate/report_test.go
@@ -25,6 +25,8 @@ import (
 )
 
 func TestReportRepresentation(t *testing.T) {
+	t.Parallel()
+
 	type testcase struct {
 		name   string
 		report generate.Report
@@ -277,8 +279,11 @@ Hint: '+', '~' and '-' means the file was created, changed and deleted, respecti
 		},
 	}
 
-	for _, tcase := range tcases {
+	for _, tc := range tcases {
+		tcase := tc
 		t.Run(tcase.name, func(t *testing.T) {
+			t.Parallel()
+
 			got := tcase.report.String()
 			if diff := cmp.Diff(got, tcase.want); diff != "" {
 				t.Errorf("got:\n%s\n", got)


### PR DESCRIPTION
# Reason for This Change

Make generate/genfile/genhcl tests faster. Specially genhcl is quite slow, so tried to speed things up a little.

Sequential tests here:

```
ok      github.com/mineiros-io/terramate/generate       3.735s
ok      github.com/mineiros-io/terramate/generate/genfile       1.490s
ok      github.com/mineiros-io/terramate/generate/genhcl        13.570s
```

With Parallel:

```
ok      github.com/mineiros-io/terramate/generate       1.854s
ok      github.com/mineiros-io/terramate/generate/genfile       0.911s
ok      github.com/mineiros-io/terramate/generate/genhcl        5.307s
```