### PR TITLE
chore: improve logging of errors with range

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -277,7 +277,7 @@ func loadTree(rootdir string, cfgdir string, rootcfg *hcl.Config) (*Tree, error)
 
 		node, err := LoadTree(rootdir, dir)
 		if err != nil {
-			return nil, errors.E(err, "failed to load config from %s", dir)
+			return nil, errors.E(err, "loading from %s", dir)
 		}
 
 		node.Parent = tree

--- a/errors/errlog/errlog.go
+++ b/errors/errlog/errlog.go
@@ -76,10 +76,10 @@ func logerr(
 
 	ctx := logger.With()
 	if !tmerr.FileRange.Empty() {
-		ctx.Stringer("file", tmerr.FileRange)
+		ctx = ctx.Stringer("file", tmerr.FileRange)
 	}
 	if tmerr.Stack != nil {
-		ctx.Str("stack", tmerr.Stack.Path())
+		ctx = ctx.Str("stack", tmerr.Stack.Path())
 	}
 
 	msgparts := []string{}


### PR DESCRIPTION
# Reason for This Change

There was a bug on how the logger context was created, now we should get a nice fatal msg with the file origin:

```
terramate list
2022-10-18T14:50:40+02:00 FTL looking up project root: HCL syntax error: loading from /tmp/test/test: A comma is required to separate each function argument from the next. file=/tmp/test/test/stack.tm:1,14-15
```