### PR TITLE
chore: improve docs for errors pkg

### DIFF
--- a/errors/error.go
+++ b/errors/error.go
@@ -71,41 +71,47 @@ const separator = ": "
 //
 // The supported types are:
 //
-//		errors.Kind
-//			The kind of error (eg.: HCLSyntax, TerramateSchema, etc).
-//		hcl.Range
-//			The file range where the error originated.
-//		errors.StackMeta
-//			The stack that originated the error.
-//		hcl.Diagnostics
-//			The underlying hcl error that triggered this one.
-//			Only the first hcl.Diagnostic will be used.
-//			If hcl.Range is not set, the diagnostic subject range is pulled.
-//			If the string Description is not set, the diagnostic detail field is
-//			pulled.
-//		hcl.Diagnostic
-//			Same behavior as hcl.Diagnostics but for a single diagnostic.
-//		string
-//			The error description. It supports formatting using the Go's fmt verbs
-//			as long as the arguments are not one of the defined types.
+//   - errors.Kind
+//     The kind of error (eg.: HCLSyntax, TerramateSchema, etc).
 //
-//	 The underlying error types are:
+//   - hcl.Range
+//     The file range where the error originated.
 //
-//	 *List
-//			The underlying error list wrapped by this one.
-//			This error wraps all of its individual errors so they carry all the
-//			context to print them individually.
-//		hcl.Diagnostics
-//			The underlying list of hcl errors wrapped by this one.
-//			This type is converted to a *List containing only the hcl.DiagError values.
-//		hcl.Diagnostic
-//			The underlying hcl error wrapped by this one.
-//			It's ignored if its type is not hcl.DiagError.
-//			If hcl.Range is not already set, the diagnostic subject range is pulled.
-//			If the string Description is not set, the diagnostic detail field is
-//			pulled.
-//		error
-//			The underlying error that triggered this one.
+//   - errors.StackMeta
+//     The stack that originated the error.
+//
+//   - hcl.Diagnostics
+//     The underlying hcl error that triggered this one.
+//     Only the first hcl.Diagnostic will be used.
+//     If hcl.Range is not set, the diagnostic subject range is pulled.
+//     If the string Description is not set, the diagnostic detail field is pulled.
+//
+//   - hcl.Diagnostic
+//     Same behavior as hcl.Diagnostics but for a single diagnostic.
+//
+//   - string
+//     The error description. It supports formatting using the Go's fmt verbs
+//     as long as the arguments are not one of the defined types.
+//
+// The underlying error types are:
+//
+//   - *List
+//     The underlying error list wrapped by this one.
+//     This error wraps all of its individual errors so they carry all the
+//     context to print them individually.
+//
+//   - hcl.Diagnostics
+//     The underlying list of hcl errors wrapped by this one.
+//     This type is converted to a *List containing only the hcl.DiagError values.
+//
+//   - hcl.Diagnostic
+//     The underlying hcl error wrapped by this one.
+//     It's ignored if its type is not hcl.DiagError.
+//     If hcl.Range is not already set, the diagnostic subject range is pulled.
+//     If the string Description is not set, the diagnostic detail field is  pulled.
+//
+//   - error
+//     The underlying error that triggered this one.
 //
 // If the error is printed, only those items that have been
 // set to non-zero values will appear in the result. For the `hcl.Range` type,

--- a/errors/error.go
+++ b/errors/error.go
@@ -71,22 +71,22 @@ const separator = ": "
 //
 // The supported types are:
 //
-//   - errors.Kind
+//   - [errors.Kind]
 //     The kind of error (eg.: HCLSyntax, TerramateSchema, etc).
 //
-//   - hcl.Range
+//   - [hcl.Range]
 //     The file range where the error originated.
 //
-//   - errors.StackMeta
+//   - [errors.StackMeta]
 //     The stack that originated the error.
 //
-//   - hcl.Diagnostics
+//   - [hcl.Diagnostics]
 //     The underlying hcl error that triggered this one.
 //     Only the first hcl.Diagnostic will be used.
 //     If hcl.Range is not set, the diagnostic subject range is pulled.
 //     If the string Description is not set, the diagnostic detail field is pulled.
 //
-//   - hcl.Diagnostic
+//   - [hcl.Diagnostic]
 //     Same behavior as hcl.Diagnostics but for a single diagnostic.
 //
 //   - string
@@ -95,16 +95,19 @@ const separator = ": "
 //
 // The underlying error types are:
 //
-//   - *List
+//   - [*errors.List]
 //     The underlying error list wrapped by this one.
 //     This error wraps all of its individual errors so they carry all the
-//     context to print them individually.
+//     context to print them individually but keeping the wrapped error as
+//     as an [*errors.List].
+//     If the list length is 1 the underlying error will be the single error
+//     inside the list, so the wrapped error will not be a [*errors.List].
 //
-//   - hcl.Diagnostics
+//   - [hcl.Diagnostics]
 //     The underlying list of hcl errors wrapped by this one.
 //     This type is converted to a *List containing only the hcl.DiagError values.
 //
-//   - hcl.Diagnostic
+//   - [hcl.Diagnostic]
 //     The underlying hcl error wrapped by this one.
 //     It's ignored if its type is not hcl.DiagError.
 //     If hcl.Range is not already set, the diagnostic subject range is pulled.
@@ -120,15 +123,14 @@ const separator = ": "
 // When the underlying error is a single error, then the fields below are
 // promoted from the underlying error when absent:
 //
-// - errors.Kind
-// - errors.StackMeta
-// - hcl.Range
+// - [errors.Kind]
+// - [errors.StackMeta]
+// - [hcl.Range]
 //
 // Minimization:
 //
 // In order to avoid duplicated messages, if the underlying error is an *Error,
-// we erase the fields present in it if already set with same value in this
-// error.
+// we erase the fields present in it if already set with same value in this error.
 func E(args ...interface{}) *Error {
 	if len(args) == 0 {
 		panic("called with no args")


### PR DESCRIPTION
# Reason for This Change

Add some extra information + format the docs according to some new features on Go 1.19 for lists/links. It should still work well for older Go versions too.