### PR TITLE
chore: generate: improve lets/globals eval errs logs

### DIFF
--- a/errors/error.go
+++ b/errors/error.go
@@ -21,7 +21,6 @@ package errors
 import (
 	"errors"
 	"fmt"
-	"path/filepath"
 	"strings"
 
 	"github.com/hashicorp/hcl/v2"
@@ -464,7 +463,7 @@ func equalStack(s1, s2 StackMeta) bool {
 }
 
 func cleanFilename(fname string) string {
-	if ext := filepath.Ext(fname); ext == ".tm" || ext == ".tm.hcl" {
+	if strings.HasSuffix(fname, ".tm") || strings.HasSuffix(fname, ".tm.hcl") {
 		return fname
 	}
 	return "<generated-code>"

--- a/errors/error.go
+++ b/errors/error.go
@@ -463,7 +463,7 @@ func equalStack(s1, s2 StackMeta) bool {
 		s1.Path() == s2.Path()
 }
 
-// cleanFilename will clean the given filename returning a placehold if
+// cleanFilename will clean the given filename returning a placeholder if
 // it is not a valid unix/win path. This is necessary since we use some
 // hacks on partial evaluation like adding a Filename on expressions that
 // is not a valid path but that includes information required by terramate

--- a/errors/error.go
+++ b/errors/error.go
@@ -470,7 +470,7 @@ func equalStack(s1, s2 StackMeta) bool {
 // embedded on them, like the expression raw bytes.
 func cleanFilename(fname string) string {
 	// One of the few restrictions for paths to be valid is to not
-	// have any zeroes in the middle of the string.
+	// have any NUL bytes in the middle of the string.
 	if _, err := syscall.BytePtrFromString(fname); err != nil {
 		return "<generated-code>"
 	}

--- a/errors/error.go
+++ b/errors/error.go
@@ -71,41 +71,50 @@ const separator = ": "
 //
 // The supported types are:
 //
-//		errors.Kind
-//			The kind of error (eg.: HCLSyntax, TerramateSchema, etc).
-//		hcl.Range
-//			The file range where the error originated.
-//		errors.StackMeta
-//			The stack that originated the error.
-//		hcl.Diagnostics
-//			The underlying hcl error that triggered this one.
-//			Only the first hcl.Diagnostic will be used.
-//			If hcl.Range is not set, the diagnostic subject range is pulled.
-//			If the string Description is not set, the diagnostic detail field is
-//			pulled.
-//		hcl.Diagnostic
-//			Same behavior as hcl.Diagnostics but for a single diagnostic.
-//		string
-//			The error description. It supports formatting using the Go's fmt verbs
-//			as long as the arguments are not one of the defined types.
+//   - [errors.Kind]
+//     The kind of error (eg.: HCLSyntax, TerramateSchema, etc).
 //
-//	 The underlying error types are:
+//   - [hcl.Range]
+//     The file range where the error originated.
 //
-//	 *List
-//			The underlying error list wrapped by this one.
-//			This error wraps all of its individual errors so they carry all the
-//			context to print them individually.
-//		hcl.Diagnostics
-//			The underlying list of hcl errors wrapped by this one.
-//			This type is converted to a *List containing only the hcl.DiagError values.
-//		hcl.Diagnostic
-//			The underlying hcl error wrapped by this one.
-//			It's ignored if its type is not hcl.DiagError.
-//			If hcl.Range is not already set, the diagnostic subject range is pulled.
-//			If the string Description is not set, the diagnostic detail field is
-//			pulled.
-//		error
-//			The underlying error that triggered this one.
+//   - [errors.StackMeta]
+//     The stack that originated the error.
+//
+//   - [hcl.Diagnostics]
+//     The underlying hcl error that triggered this one.
+//     Only the first hcl.Diagnostic will be used.
+//     If hcl.Range is not set, the diagnostic subject range is pulled.
+//     If the string Description is not set, the diagnostic detail field is pulled.
+//
+//   - [hcl.Diagnostic]
+//     Same behavior as hcl.Diagnostics but for a single diagnostic.
+//
+//   - string
+//     The error description. It supports formatting using the Go's fmt verbs
+//     as long as the arguments are not one of the defined types.
+//
+// The underlying error types are:
+//
+//   - [*errors.List]
+//     The underlying error list wrapped by this one.
+//     This error wraps all of its individual errors so they carry all the
+//     context to print them individually but keeping the wrapped error as
+//     as an [*errors.List].
+//     If the list length is 1 the underlying error will be the single error
+//     inside the list, so the wrapped error will not be a [*errors.List].
+//
+//   - [hcl.Diagnostics]
+//     The underlying list of hcl errors wrapped by this one.
+//     This type is converted to a *List containing only the hcl.DiagError values.
+//
+//   - [hcl.Diagnostic]
+//     The underlying hcl error wrapped by this one.
+//     It's ignored if its type is not hcl.DiagError.
+//     If hcl.Range is not already set, the diagnostic subject range is pulled.
+//     If the string Description is not set, the diagnostic detail field is  pulled.
+//
+//   - error
+//     The underlying error that triggered this one.
 //
 // If the error is printed, only those items that have been
 // set to non-zero values will appear in the result. For the `hcl.Range` type,
@@ -114,15 +123,14 @@ const separator = ": "
 // When the underlying error is a single error, then the fields below are
 // promoted from the underlying error when absent:
 //
-// - errors.Kind
-// - errors.StackMeta
-// - hcl.Range
+// - [errors.Kind]
+// - [errors.StackMeta]
+// - [hcl.Range]
 //
 // Minimization:
 //
 // In order to avoid duplicated messages, if the underlying error is an *Error,
-// we erase the fields present in it if already set with same value in this
-// error.
+// we erase the fields present in it if already set with same value in this error.
 func E(args ...interface{}) *Error {
 	if len(args) == 0 {
 		panic("called with no args")

--- a/errors/error_test.go
+++ b/errors/error_test.go
@@ -460,30 +460,40 @@ func TestErrorIs(t *testing.T) {
 	}
 }
 
-func TestRangeRepresentationDependsOnFilenameSuffix(t *testing.T) {
-	t.Run("suffix .tm has filename", func(t *testing.T) {
+func TestErrorRangeRepresentation(t *testing.T) {
+	t.Run("valid abspath", func(t *testing.T) {
 		filerange := hcl.Range{
-			Filename: "test.tm",
+			Filename: "/test/test.tm",
 			Start:    hcl.Pos{Line: 1, Column: 5, Byte: 3},
 			End:      hcl.Pos{Line: 1, Column: 10, Byte: 13},
 		}
 		err := E(filerange)
-		assert.EqualStrings(t, "test.tm:1,5-10", err.Error())
+		assert.EqualStrings(t, "/test/test.tm:1,5-10", err.Error())
 	})
 
-	t.Run("suffix .tm.hcl has filename", func(t *testing.T) {
+	t.Run("valid relpath", func(t *testing.T) {
 		filerange := hcl.Range{
-			Filename: "test.tm.hcl",
+			Filename: "name/test.tm.hcl",
 			Start:    hcl.Pos{Line: 2, Column: 5, Byte: 3},
 			End:      hcl.Pos{Line: 2, Column: 10, Byte: 13},
 		}
 		err := E(filerange)
-		assert.EqualStrings(t, "test.tm.hcl:2,5-10", err.Error())
+		assert.EqualStrings(t, "name/test.tm.hcl:2,5-10", err.Error())
 	})
 
-	t.Run("suffix .hcl has generated code as filename", func(t *testing.T) {
+	t.Run("valid abspath with any suffix", func(t *testing.T) {
 		filerange := hcl.Range{
-			Filename: "something.hcl",
+			Filename: "/test/test.tf",
+			Start:    hcl.Pos{Line: 1, Column: 5, Byte: 3},
+			End:      hcl.Pos{Line: 1, Column: 10, Byte: 13},
+		}
+		err := E(filerange)
+		assert.EqualStrings(t, "/test/test.tf:1,5-10", err.Error())
+	})
+
+	t.Run("invalid path containing zeroes", func(t *testing.T) {
+		filerange := hcl.Range{
+			Filename: string([]byte{'a', 0, 'b'}),
 			Start:    hcl.Pos{Line: 2, Column: 5, Byte: 3},
 			End:      hcl.Pos{Line: 2, Column: 10, Byte: 13},
 		}

--- a/errors/error_test.go
+++ b/errors/error_test.go
@@ -460,6 +460,38 @@ func TestErrorIs(t *testing.T) {
 	}
 }
 
+func TestRangeRepresentationDependsOnFilenameSuffix(t *testing.T) {
+	t.Run("suffix .tm has filename", func(t *testing.T) {
+		filerange := hcl.Range{
+			Filename: "test.tm",
+			Start:    hcl.Pos{Line: 1, Column: 5, Byte: 3},
+			End:      hcl.Pos{Line: 1, Column: 10, Byte: 13},
+		}
+		err := E(filerange)
+		assert.EqualStrings(t, "test.tm:1,5-10", err.Error())
+	})
+
+	t.Run("suffix .tm.hcl has filename", func(t *testing.T) {
+		filerange := hcl.Range{
+			Filename: "test.tm.hcl",
+			Start:    hcl.Pos{Line: 2, Column: 5, Byte: 3},
+			End:      hcl.Pos{Line: 2, Column: 10, Byte: 13},
+		}
+		err := E(filerange)
+		assert.EqualStrings(t, "test.tm.hcl:2,5-10", err.Error())
+	})
+
+	t.Run("suffix .hcl has generated code as filename", func(t *testing.T) {
+		filerange := hcl.Range{
+			Filename: "something.hcl",
+			Start:    hcl.Pos{Line: 2, Column: 5, Byte: 3},
+			End:      hcl.Pos{Line: 2, Column: 10, Byte: 13},
+		}
+		err := E(filerange)
+		assert.EqualStrings(t, "<generated-code>:2,5-10", err.Error())
+	})
+}
+
 func TestDetailedRepresentation(t *testing.T) {
 	stack := stackmeta{
 		name: "stack",

--- a/generate/genhcl/genhcl.go
+++ b/generate/genhcl/genhcl.go
@@ -16,7 +16,7 @@
 package genhcl
 
 import (
-	stdmt "fmt"
+	stdfmt "fmt"
 	"sort"
 
 	hhcl "github.com/hashicorp/hcl/v2"
@@ -89,7 +89,7 @@ func (h HCL) Label() string {
 
 // Header returns the header of the generated HCL file.
 func (h HCL) Header() string {
-	return stdmt.Sprintf(
+	return stdfmt.Sprintf(
 		"%s\n// TERRAMATE: originated from generate_hcl block on %s\n\n",
 		Header,
 		h.origin,
@@ -114,7 +114,7 @@ func (h HCL) Condition() bool {
 }
 
 func (h HCL) String() string {
-	return stdmt.Sprintf("Generating file %q (condition %t) (body %q) (origin %q)",
+	return stdfmt.Sprintf("Generating file %q (condition %t) (body %q) (origin %q)",
 		h.Label(), h.Condition(), h.Body(), h.Origin())
 }
 
@@ -254,20 +254,10 @@ type dynBlockAttributes struct {
 // to the original block and the path (relative to project root) of the config
 // from where it was parsed.
 func loadGenHCLBlocks(tree *config.Tree, cfgdir project.Path) ([]loadedHCL, error) {
-	logger := log.With().
-		Str("action", "genhcl.loadGenHCLBlocks()").
-		Str("root", tree.RootDir()).
-		Stringer("configDir", cfgdir).
-		Logger()
-
-	logger.Trace().Msg("Parsing generate_hcl blocks.")
-
 	res := []loadedHCL{}
 	cfg, ok := tree.Lookup(cfgdir)
 	if ok && !cfg.IsEmptyConfig() {
 		blocks := cfg.Node.Generate.HCLs
-
-		logger.Trace().Msg("Parsed generate_hcl blocks.")
 
 		for _, genhclBlock := range blocks {
 			name := genhclBlock.Label
@@ -280,8 +270,6 @@ func loadGenHCLBlocks(tree *config.Tree, cfgdir project.Path) ([]loadedHCL, erro
 				block:     genhclBlock.Content,
 				condition: genhclBlock.Condition,
 			})
-
-			logger.Trace().Msg("loaded generate_hcl block.")
 		}
 	}
 
@@ -297,7 +285,6 @@ func loadGenHCLBlocks(tree *config.Tree, cfgdir project.Path) ([]loadedHCL, erro
 
 	res = append(res, parentRes...)
 
-	logger.Trace().Msg("loaded generate_hcl blocks with success.")
 	return res, nil
 }
 
@@ -675,9 +662,9 @@ func getContentBlock(blocks hclsyntax.Blocks) (*hclsyntax.Block, error) {
 }
 
 func attrErr(attr *hclsyntax.Attribute, msg string, args ...interface{}) error {
-	return errors.E(ErrParsing, attr.Expr.Range(), stdmt.Sprintf(msg, args...))
+	return errors.E(ErrParsing, attr.Expr.Range(), stdfmt.Sprintf(msg, args...))
 }
 
 func wrapAttrErr(err error, attr *hclsyntax.Attribute, msg string, args ...interface{}) error {
-	return errors.E(ErrParsing, err, attr.Expr.Range(), stdmt.Sprintf(msg, args...))
+	return errors.E(ErrParsing, err, attr.Expr.Range(), stdfmt.Sprintf(msg, args...))
 }

--- a/globals/globals.go
+++ b/globals/globals.go
@@ -208,7 +208,7 @@ func (globalExprs Exprs) Eval(ctx *eval.Context) EvalReport {
 
 			val, err := ctx.Eval(expr)
 			if err != nil {
-				pendingExprsErrs[accessor].Append(errors.E(err, "global.%s", accessor))
+				pendingExprsErrs[accessor].Append(errors.E(ErrEval, err, "global.%s", accessor))
 				continue
 			}
 

--- a/globals/globals.go
+++ b/globals/globals.go
@@ -30,7 +30,7 @@ import (
 
 // Errors returned when parsing and evaluating globals.
 const (
-	ErrEval      errors.Kind = "global eval failed"
+	ErrEval      errors.Kind = "global eval"
 	ErrRedefined errors.Kind = "global redefined"
 )
 
@@ -52,14 +52,6 @@ type (
 
 // Load loads all the globals from the cfgdir.
 func Load(tree *config.Tree, cfgdir project.Path, ctx *eval.Context) EvalReport {
-	logger := log.With().
-		Str("action", "globals.Load()").
-		Str("root", tree.RootDir()).
-		Stringer("cfgdir", cfgdir).
-		Logger()
-
-	logger.Trace().Msg("loading expressions")
-
 	exprs, err := LoadExprs(tree, cfgdir)
 	if err != nil {
 		report := NewEvalReport()
@@ -216,7 +208,7 @@ func (globalExprs Exprs) Eval(ctx *eval.Context) EvalReport {
 
 			val, err := ctx.Eval(expr)
 			if err != nil {
-				pendingExprsErrs[accessor].Append(err)
+				pendingExprsErrs[accessor].Append(errors.E(err, "global.%s", accessor))
 				continue
 			}
 

--- a/hcl/eval/eval.go
+++ b/hcl/eval/eval.go
@@ -30,7 +30,7 @@ import (
 )
 
 // ErrEval indicates a failure during the evaluation process
-const ErrEval errors.Kind = "failed to evaluate expression"
+const ErrEval errors.Kind = "eval expression"
 
 // Context is used to evaluate HCL code.
 type Context struct {

--- a/lets/lets.go
+++ b/lets/lets.go
@@ -27,7 +27,7 @@ import (
 
 // Errors returned when parsing and evaluating lets.
 const (
-	ErrEval      errors.Kind = "lets eval failed"
+	ErrEval      errors.Kind = "lets eval"
 	ErrRedefined errors.Kind = "lets redefined"
 )
 
@@ -57,12 +57,6 @@ type (
 
 // Load loads all the lets from the hcl blocks.
 func Load(letblocks hclsyntax.Blocks, ctx *eval.Context) error {
-	logger := log.With().
-		Str("action", "lets.Load()").
-		Logger()
-
-	logger.Trace().Msg("loading expressions")
-
 	exprs, err := loadExprs(letblocks)
 	if err != nil {
 		return err
@@ -138,7 +132,7 @@ func (letExprs Exprs) Eval(ctx *eval.Context) error {
 
 			val, err := ctx.Eval(expr)
 			if err != nil {
-				pendingExprsErrs[name].Append(err)
+				pendingExprsErrs[name].Append(errors.E(err, "let.%s", name))
 				continue
 			}
 

--- a/lets/lets.go
+++ b/lets/lets.go
@@ -132,7 +132,7 @@ func (letExprs Exprs) Eval(ctx *eval.Context) error {
 
 			val, err := ctx.Eval(expr)
 			if err != nil {
-				pendingExprsErrs[name].Append(errors.E(err, "let.%s", name))
+				pendingExprsErrs[name].Append(errors.E(ErrEval, err, "let.%s", name))
 				continue
 			}
 


### PR DESCRIPTION
# Reason for This Change

Improve error messages on some generate errors. Also fix a bug on the errors pkg where we were ommiting the filename from the range when the origin file is .tm.hcl.
