### PR TITLE
fix: stack.S doesn't implement errors.StackMeta

### DIFF
--- a/errors/errlog/errlog.go
+++ b/errors/errlog/errlog.go
@@ -79,7 +79,7 @@ func logerr(
 		ctx = ctx.Stringer("file", tmerr.FileRange)
 	}
 	if tmerr.Stack != nil {
-		ctx = ctx.Str("stack", tmerr.Stack.Path())
+		ctx = ctx.Stringer("stack", tmerr.Stack.Path())
 	}
 
 	msgparts := []string{}

--- a/errors/error.go
+++ b/errors/error.go
@@ -25,6 +25,7 @@ import (
 	"syscall"
 
 	"github.com/hashicorp/hcl/v2"
+	"github.com/mineiros-io/terramate/project"
 )
 
 // Error is the default Terramate error type.
@@ -50,12 +51,13 @@ type Error struct {
 type (
 	// Kind defines the kind of an error.
 	Kind string
+
 	// StackMeta has the metadata of the stack which originated the error.
 	// Same interface as stack.Metadata.
 	StackMeta interface {
 		Name() string
 		Desc() string
-		Path() string
+		Path() project.Path
 	}
 )
 

--- a/errors/error_test.go
+++ b/errors/error_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/hashicorp/hcl/v2"
 	"github.com/madlambda/spells/assert"
 	"github.com/mineiros-io/terramate/errors"
+	"github.com/mineiros-io/terramate/project"
 )
 
 var E = errors.E
@@ -531,9 +532,9 @@ func fmt(format string, args ...interface{}) string {
 type stackmeta struct {
 	name string
 	desc string
-	path string
+	path project.Path
 }
 
-func (s stackmeta) Name() string { return s.name }
-func (s stackmeta) Path() string { return s.path }
-func (s stackmeta) Desc() string { return s.desc }
+func (s stackmeta) Name() string       { return s.name }
+func (s stackmeta) Path() project.Path { return s.path }
+func (s stackmeta) Desc() string       { return s.desc }

--- a/project/project.go
+++ b/project/project.go
@@ -15,12 +15,12 @@
 package project
 
 import (
+	"fmt"
 	"path"
 	"path/filepath"
 	"sort"
 	"strings"
 
-	"github.com/mineiros-io/terramate/errors"
 	"github.com/rs/zerolog/log"
 	"github.com/zclconf/go-cty/cty"
 )
@@ -41,7 +41,7 @@ type Paths []Path
 // It panics if a relative path is provided.
 func NewPath(p string) Path {
 	if !path.IsAbs(p) {
-		panic(errors.E("project path must be absolute but got %s", p))
+		panic(fmt.Errorf("project path must be absolute but got %s", p))
 	}
 	return Path(path.Clean(p))
 }

--- a/stack/stack.go
+++ b/stack/stack.go
@@ -103,6 +103,9 @@ const (
 	ErrInvalidWatch errors.Kind = "invalid stack.watch attribute"
 )
 
+// ensure we get a compiler error if stack doesn't implement errors.StackMeta.
+var _ errors.StackMeta = &S{}
+
 // New creates a new stack from configuration cfg.
 func New(root string, cfg hcl.Config) (*S, error) {
 	name := cfg.Stack.Name


### PR DESCRIPTION
Running `terramate run` gave me this error messages:

```
2022-10-23T15:23:58+01:00 ERR running /stack%!(EXTRA *exec.Cmd=/usr/bin/make): exit status 2
2022-10-23T15:23:58+01:00 FTL one or more commands failed
```

The reason was that #608  broke the assumption that `stack.S` implements `errors.StackMeta`.

This line was added to ensure this doesn't happen again: https://github.com/mineiros-io/terramate/pull/662/files#diff-3255e7799f07c4f38eb7328b59a25c5a9d25b9661dcf83b1ea9a817d2bde6629R107