### PR TITLE
fix: outdated code detection not handling condition

### DIFF
--- a/generate/generate.go
+++ b/generate/generate.go
@@ -433,6 +433,9 @@ func updateOutdatedFiles(
 
 	logger.Trace().Msg("Checking for outdated generated code on stack.")
 
+	// So we can properly check blocks with false/true in any order
+	blocksCondTrue := map[string]struct{}{}
+
 	for _, genfile := range generated {
 		filename := genfile.Label()
 		targetpath := filepath.Join(stackpath, filename)
@@ -447,8 +450,15 @@ func updateOutdatedFiles(
 		if err != nil {
 			return err
 		}
+
+		if genfile.Condition() {
+			blocksCondTrue[filename] = struct{}{}
+		}
+
+		_, prevBlockCondTrue := blocksCondTrue[filename]
+
 		if !codeFound {
-			if !genfile.Condition() {
+			if !genfile.Condition() && !prevBlockCondTrue {
 				logger.Trace().Msg("Not outdated since file not found and condition is false")
 				outdatedFiles.remove(filename)
 				continue
@@ -460,6 +470,10 @@ func updateOutdatedFiles(
 		}
 
 		if !genfile.Condition() {
+			if prevBlockCondTrue {
+				logger.Trace().Msg("ignoring block since previous one had condition=true")
+				continue
+			}
 			logger.Trace().Msg("outdated since file exists but condition for generation is false")
 			outdatedFiles.add(filename)
 			continue

--- a/generate/generate_file_check_test.go
+++ b/generate/generate_file_check_test.go
@@ -262,6 +262,7 @@ func TestCheckOutdatedIgnoresWhenGenFileConditionIsFalse(t *testing.T) {
 	assertOutdatedFiles := func(want []string) {
 		t.Helper()
 
+		s.ReloadConfig()
 		got, err := generate.CheckStack(s.Config(), s.LoadProjectMetadata(), stack)
 		assert.NoError(t, err)
 		assertEqualStringList(t, got, want)


### PR DESCRIPTION
# Reason for This Change

Outdated code detection was not handling multiple blocks with different conditions properly. It was working before because of details on how the blocks were ordered that were changed. Made the code be not dependent on the ordering since ordering is mostly used to test deterministically and to output results nicelly.
