### PR TITLE
feat: add --ignore-existing on terramate create

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-golang 1.17.1
+golang 1.18.7

--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -724,7 +724,8 @@ func (c *cli) createStack() {
 	})
 
 	if err != nil {
-		if c.parsedArgs.Create.IgnoreExisting {
+		if c.parsedArgs.Create.IgnoreExisting &&
+			errors.IsKind(err, stack.ErrStackAlreadyExists) {
 			return
 		}
 		fatal(err, "creating stack")

--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -734,15 +734,16 @@ func (c *cli) createStack() {
 	stackPath := filepath.ToSlash(strings.TrimPrefix(stackDir, c.root()))
 
 	if err != nil {
-		if c.parsedArgs.Create.IgnoreExisting &&
-			(errors.IsKind(err, stack.ErrStackAlreadyExists) ||
-				errors.IsKind(err, stack.ErrStackDefaultCfgFound)) {
-			return
-		}
-
 		logger := log.With().
 			Str("stack", stackPath).
 			Logger()
+
+		if c.parsedArgs.Create.IgnoreExisting &&
+			(errors.IsKind(err, stack.ErrStackAlreadyExists) ||
+				errors.IsKind(err, stack.ErrStackDefaultCfgFound)) {
+			logger.Debug().Msg("stack already exists, ignoring")
+			return
+		}
 
 		if errors.IsKind(err, stack.ErrStackDefaultCfgFound) {
 			logger = logger.With().

--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -94,13 +94,14 @@ type cliSpec struct {
 	DisableCheckGitUncommitted bool `optional:"true" default:"false" help:"Disable git check for uncommitted files"`
 
 	Create struct {
-		Path        string   `arg:"" name:"path" predictor:"file" help:"Path of the new stack relative to the working dir"`
-		ID          string   `help:"ID of the stack, defaults to UUID"`
-		Name        string   `help:"Name of the stack, defaults to stack dir base name"`
-		Description string   `help:"Description of the stack, defaults to the stack name"`
-		Import      []string `help:"Add import block for the given path on the stack"`
-		After       []string `help:"Add a stack as after"`
-		Before      []string `help:"Add a stack as before"`
+		Path           string   `arg:"" name:"path" predictor:"file" help:"Path of the new stack relative to the working dir"`
+		ID             string   `help:"ID of the stack, defaults to UUID"`
+		Name           string   `help:"Name of the stack, defaults to stack dir base name"`
+		Description    string   `help:"Description of the stack, defaults to the stack name"`
+		Import         []string `help:"Add import block for the given path on the stack"`
+		After          []string `help:"Add a stack as after"`
+		Before         []string `help:"Add a stack as before"`
+		IgnoreExisting bool     `help:"If the stack already exists do nothing and don't fail"`
 	} `cmd:"" help:"Creates a stack on the project"`
 
 	Fmt struct {
@@ -723,6 +724,9 @@ func (c *cli) createStack() {
 	})
 
 	if err != nil {
+		if c.parsedArgs.Create.IgnoreExisting {
+			return
+		}
 		fatal(err, "creating stack")
 	}
 

--- a/cmd/terramate/e2etests/create_test.go
+++ b/cmd/terramate/e2etests/create_test.go
@@ -133,6 +133,21 @@ func TestCreateStackDefaults(t *testing.T) {
 	test.AssertStackImports(t, s.RootDir(), got.HostPath(), []string{})
 }
 
+func TestCreateStackIgnoreExisting(t *testing.T) {
+	t.Parallel()
+
+	s := sandbox.New(t)
+	cli := newCLI(t, s.RootDir())
+	assertRunResult(t, cli.run("create", "stack"), runExpected{
+		IgnoreStdout: true,
+	})
+	assertRunResult(t, cli.run("create", "stack"), runExpected{
+		Status:       1,
+		IgnoreStderr: true,
+	})
+	assertRun(t, cli.run("create", "stack", "--ignore-existing"))
+}
+
 func newStackID(t *testing.T) string {
 	t.Helper()
 

--- a/cmd/terramate/e2etests/create_test.go
+++ b/cmd/terramate/e2etests/create_test.go
@@ -133,7 +133,7 @@ func TestCreateStackDefaults(t *testing.T) {
 	test.AssertStackImports(t, s.RootDir(), got.HostPath(), []string{})
 }
 
-func TestCreateStackIgnoreExisting(t *testing.T) {
+func TestCreateStackIgnoreExistingOnDefaultStackCfgFound(t *testing.T) {
 	t.Parallel()
 
 	s := sandbox.New(t)
@@ -146,6 +146,37 @@ func TestCreateStackIgnoreExisting(t *testing.T) {
 		IgnoreStderr: true,
 	})
 	assertRun(t, cli.run("create", "stack", "--ignore-existing"))
+}
+
+func TestCreateStackIgnoreExistingOnStackFound(t *testing.T) {
+	t.Parallel()
+
+	s := sandbox.New(t)
+	s.BuildTree([]string{
+		"f:stack/non_default_cfg.tm:stack{\n}",
+	})
+	cli := newCLI(t, s.RootDir())
+	assertRunResult(t, cli.run("create", "stack"), runExpected{
+		Status:       1,
+		IgnoreStderr: true,
+	})
+	assertRun(t, cli.run("create", "stack", "--ignore-existing"))
+}
+
+func TestCreateStackIgnoreExistingFatalOnOtherErrors(t *testing.T) {
+	t.Parallel()
+
+	s := sandbox.New(t)
+	root := s.RootEntry()
+	root.CreateDir("stack")
+	// Here we fail stack creating with an access error
+	root.Chmod("stack", 0444)
+	cli := newCLI(t, s.RootDir())
+
+	assertRunResult(t, cli.run("create", "stack", "--ignore-existing"), runExpected{
+		Status:       1,
+		IgnoreStderr: true,
+	})
 }
 
 func newStackID(t *testing.T) string {

--- a/test/sandbox/sandbox.go
+++ b/test/sandbox/sandbox.go
@@ -25,6 +25,7 @@ package sandbox
 import (
 	"bytes"
 	"fmt"
+	"io/fs"
 	"os"
 	"path"
 	"path/filepath"
@@ -428,6 +429,12 @@ func (de DirEntry) DeleteConfig() {
 // must be relative to the stack directory.
 func (de DirEntry) CreateDir(relpath string) DirEntry {
 	return newDirEntry(de.t, de.abspath, relpath)
+}
+
+// Chmod does the same as [test.Chmod] for the given file/dir inside
+// this DirEntry.
+func (de DirEntry) Chmod(relpath string, mode fs.FileMode) {
+	test.Chmod(de.t, filepath.Join(de.abspath, relpath), mode)
 }
 
 // ReadFile will read a file inside this dir entry with the given name.


### PR DESCRIPTION
# Reason for This Change

Allow `terramate create --ignore-existing` which then will not fail if the stack already exists (but won't do any changes on the stack).
