### PR TITLE
feat: vendor: disable git prompt

### DIFF
--- a/modvendor/modvendor.go
+++ b/modvendor/modvendor.go
@@ -335,10 +335,16 @@ func downloadVendor(rootdir string, vendorDir project.Path, modsrc tf.Source) (s
 
 	logger.Trace().Msg("setting up git wrapper")
 
+	// Same strategy used on the Go toolchain:
+	// - https://github.com/golang/go/blob/2ebe77a2fda1ee9ff6fd9a3e08933ad1ebaea039/src/cmd/go/internal/get/get.go#L129
+	env := os.Environ()
+	if os.Getenv("GIT_TERMINAL_PROMPT") == "" {
+		env = append(env, "GIT_TERMINAL_PROMPT=0")
+	}
 	g, err := git.WithConfig(git.Config{
 		WorkingDir:     clonedRepoDir,
 		AllowPorcelain: true,
-		Env:            os.Environ(),
+		Env:            env,
 	})
 	if err != nil {
 		return "", err

--- a/modvendor/modvendor.go
+++ b/modvendor/modvendor.go
@@ -337,10 +337,8 @@ func downloadVendor(rootdir string, vendorDir project.Path, modsrc tf.Source) (s
 
 	// Same strategy used on the Go toolchain:
 	// - https://github.com/golang/go/blob/2ebe77a2fda1ee9ff6fd9a3e08933ad1ebaea039/src/cmd/go/internal/get/get.go#L129
-	env := os.Environ()
-	if os.Getenv("GIT_TERMINAL_PROMPT") == "" {
-		env = append(env, "GIT_TERMINAL_PROMPT=0")
-	}
+
+	env := append(os.Environ(), "GIT_TERMINAL_PROMPT=0")
 	g, err := git.WithConfig(git.Config{
 		WorkingDir:     clonedRepoDir,
 		AllowPorcelain: true,


### PR DESCRIPTION
# Reason for This Change

Specially when using the new `tm_vendor` function allowing interaction on git can be quite confusing. So by default if `GIT_TERMINAL_PROMPT` is not set we disable the prompt. Not having credentials will result in an error like:

```
terramate  experimental vendor download github.com/katcipis/test v18.15.10
Vendor report:

[!] github.com/katcipis/test
    reason: failed to vendor "https://github.com/katcipis/test.git" with ref "v18.15.10": failed to exec: /usr/bin/git clone https://github.com/katcipis/test.git /tmp/.tmvendor200743037 : stderr="Cloning into '/tmp/.tmvendor200743037'...\nfatal: could not read Username for 'https://github.com': terminal prompts disabled\n", stdout=""
```
