### PR TITLE
fix: create report codegen error properly

### DIFF
--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -780,11 +780,14 @@ func (c *cli) createStack() {
 	c.output.Msg(out.V, "Created stack %s", stackPath)
 
 	report := generate.Do(c.cfg(), stackDir)
-	c.output.Msg(out.VV, report.Minimal())
 
 	if report.HasFailures() {
+		c.output.Msg(out.V, "Code generation failed")
+		c.output.Msg(out.V, report.Minimal())
 		os.Exit(1)
 	}
+
+	c.output.Msg(out.VV, report.Minimal())
 }
 
 func (c *cli) format() {


### PR DESCRIPTION
# Reason for This Change

When we started sending the code generation report to a -v output we would still fail the create command if the code generation had any failures, so the command will exit with -1 but no output about what happened. This fix uses the default output level when the code generation report has any errors on it, retaining the old behavior of silently working when all is well.

Example code to check outputs:

```sh
#!/bin/bash

set -o errexit
set -o nounset

project="$(mktemp -d)"
cd "${project}"

cat > terramate.tm <<- EOM
terramate {
  config {
  }
}
EOM

terramate create stack-1

cat > config.tm <<- EOM
generate_hcl "test.hcl" {
  content {
    a = global.ohno
  }
}
EOM

terramate create stack-2
```

Outputs:

```
Created stack /stack-1
Created stack /stack-2
Error on /stack-2: /tmp/tmp.JS1QNiSNVB/config.tm:3,9-20: evaluating content block: generate_hcl "test.hcl": at stack "/stack-2": partial evaluation failed: <generated-code>:1,7-12: eval expression: This object does not have an attribute named "ohno".
```