### PR TITLE
chore: improve experimental generate debug output

### DIFF
--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -1098,9 +1098,6 @@ func (c *cli) generateDebug() {
 			c.output.Err(out.V, errmsg)
 			continue
 		}
-		if len(res.Files) == 0 {
-			continue
-		}
 
 		files := make([]generate.GenFile, 0, len(res.Files))
 		for _, f := range res.Files {
@@ -1109,9 +1106,9 @@ func (c *cli) generateDebug() {
 			}
 		}
 
-		c.output.Msg(out.V, "Generated files for %s:", res.Dir)
 		for _, file := range files {
-			c.output.Msg(out.V, "\t- %s origin: %v", file.Label(), file.Range())
+			filepath := path.Join(res.Dir.String(), file.Label())
+			c.output.Msg(out.V, "%s origin: %v", filepath, file.Range())
 		}
 	}
 }

--- a/cmd/terramate/e2etests/exp_generate_test.go
+++ b/cmd/terramate/e2etests/exp_generate_test.go
@@ -100,12 +100,10 @@ func TestGenerateDebug(t *testing.T) {
 				},
 			},
 			want: runExpected{
-				Stdout: `Generated files for /stack-1:
-	- file.hcl origin: /stack-1/config.tm:1,1-6,2
-	- file.txt origin: /config.tm:5,1-8,2
-Generated files for /stack-2:
-	- file.hcl origin: /stack-2/config.tm:1,1-6,2
-	- file.txt origin: /config.tm:5,1-8,2
+				Stdout: `/stack-1/file.hcl origin: /stack-1/config.tm:1,1-6,2
+/stack-1/file.txt origin: /config.tm:5,1-8,2
+/stack-2/file.hcl origin: /stack-2/config.tm:1,1-6,2
+/stack-2/file.txt origin: /config.tm:5,1-8,2
 `,
 			},
 		},
@@ -145,12 +143,10 @@ Generated files for /stack-2:
 				},
 			},
 			want: runExpected{
-				Stdout: `Generated files for /stack-1:
-	- file.hcl origin: /stack-1/config.tm:1,1-5,2
-	- file.txt origin: /config.tm:5,1-7,2
-Generated files for /stack-1/dir/child:
-	- file.hcl origin: /stack-1/config.tm:1,1-5,2
-	- file.txt origin: /config.tm:5,1-7,2
+				Stdout: `/stack-1/file.hcl origin: /stack-1/config.tm:1,1-5,2
+/stack-1/file.txt origin: /config.tm:5,1-7,2
+/stack-1/dir/child/file.hcl origin: /stack-1/config.tm:1,1-5,2
+/stack-1/dir/child/file.txt origin: /config.tm:5,1-7,2
 `,
 			},
 		},
@@ -210,11 +206,9 @@ func TestGenerateDebugWithChanged(t *testing.T) {
 
 	g.CommitAll("changed stack-1")
 
-	want := `Generated files for /stack-1:
-	- file.hcl origin: /config.tm:4,1-8,2
-	- file.txt origin: /config.tm:1,1-3,2
+	want := `/stack-1/file.hcl origin: /config.tm:4,1-8,2
+/stack-1/file.txt origin: /config.tm:1,1-3,2
 `
-
 	ts := newCLI(t, s.RootDir())
 	assertRunResult(t, ts.run("experimental", "generate", "debug", "--changed"), runExpected{
 		Stdout: want,


### PR DESCRIPTION
The output should be more grep-able now, like this:

```
/stacks/organizations/mineiros.io/project-factory/mineiros-iac-shr/iam/terramate_generated_terraform.tf origin: /modules/github.com/mineiros-io/terramate-google-landing-zone/v0.2.0/terraform/provider.tm.hcl:22,1-54,2
/stacks/organizations/mineiros.io/project-factory/mineiros-iac-shr/service-apis/terramate_generated_backend.tf origin: /modules/github.com/mineiros-io/terramate-google-landing-zone/v0.2.0/terraform/backend.tm.hcl:8,1-27,2
/stacks/organizations/mineiros.io/project-factory/mineiros-iac-shr/iam/terramate_generated_terraform.tf origin: /modules/github.com/mineiros-io/terramate-google-landing-zone/v0.2.0/terraform/provider.tm.hcl:22,1-54,2
/stacks/organizations/mineiros.io/project-factory/mineiros-iac-shr/service-apis/terramate_generated_backend.tf origin: /modules/github.com/mineiros-io/terramate-google-landing-zone/v0.2.0/terraform/backend.tm.hcl:8,1-27,2
```