### PR TITLE
chore: add internal err sentinel for panics

### DIFF
--- a/errors/errlog/errlog.go
+++ b/errors/errlog/errlog.go
@@ -107,7 +107,7 @@ func msgfmt(args []any) string {
 	}
 	msgfmt, ok := args[0].(string)
 	if !ok {
-		panic("terramate internal error: invalid call to errlog.Fatal or errlog.Warn, message is not a string")
+		panic(errors.E(errors.ErrInternal, "invalid call to errlog.Fatal or errlog.Warn, message is not a string"))
 	}
 	return fmt.Sprintf(msgfmt, args[1:]...)
 }

--- a/errors/error.go
+++ b/errors/error.go
@@ -29,6 +29,12 @@ import (
 	"github.com/mineiros-io/terramate/project"
 )
 
+const (
+	// ErrInternal indicates that an unrecoverable internal error
+	// happened. This error kind is intended to be used when panicking.
+	ErrInternal Kind = "terramate internal error"
+)
+
 // Error is the default Terramate error type.
 // At least one of the error fields must be set.
 // See E() for its usage.

--- a/globals/globals.go
+++ b/globals/globals.go
@@ -218,7 +218,7 @@ func (globalExprs Exprs) Eval(ctx *eval.Context) EvalReport {
 				if _, ok := globals.GetKeyPath(accessor.Path()); ok {
 					err := globals.DeleteAt(accessor.Path())
 					if err != nil {
-						panic(errors.E(err, "terramate internal error"))
+						panic(errors.E(errors.ErrInternal, err))
 					}
 				}
 

--- a/hcl/hcl.go
+++ b/hcl/hcl.go
@@ -759,7 +759,7 @@ func parseGenerateHCLBlock(block *ast.Block) (GenHCLBlock, error) {
 			content = subBlock.Block
 		default:
 			// already validated but sanity checks...
-			panic(errors.E("terramate internal error: unexpected block type %s", subBlock.Type))
+			panic(errors.E(errors.ErrInternal, "unexpected block type %s", subBlock.Type))
 		}
 	}
 
@@ -805,7 +805,7 @@ func parseGenerateFileBlock(block *ast.Block) (GenFileBlock, error) {
 			asserts = append(asserts, assertCfg)
 		default:
 			// already validated but sanity checks...
-			panic(errors.E("terramate internal error: unexpected block type %s", subBlock.Type))
+			panic(errors.E(errors.ErrInternal, "unexpected block type %s", subBlock.Type))
 		}
 	}
 


### PR DESCRIPTION
# Reason for This Change

Enable panics to have a consistent kind/way to be built. So far updated only panic that already had the kind embedded directly into the message.
