### PR TITLE
fix: generate_hcl: when stack on root generated files get deleted on cleanup

### DIFF
--- a/generate/generate.go
+++ b/generate/generate.go
@@ -365,6 +365,10 @@ processSubdirs:
 // DetectOutdated will verify if the given config has outdated code
 // and return a list of filenames that are outdated, ordered lexicographically.
 func DetectOutdated(cfg *config.Tree) ([]string, error) {
+	logger := log.With().
+		Str("action", "generate.DetectOutdated()").
+		Logger()
+
 	stacks, err := stack.LoadAll(cfg)
 	if err != nil {
 		return nil, err
@@ -374,6 +378,8 @@ func DetectOutdated(cfg *config.Tree) ([]string, error) {
 
 	outdatedFiles := []string{}
 	errs := errors.L()
+
+	logger.Debug().Msg("checking outdated code inside stacks")
 
 	for _, stack := range stacks {
 		outdated, err := stackOutdated(cfg, projmeta, stack)
@@ -394,9 +400,13 @@ func DetectOutdated(cfg *config.Tree) ([]string, error) {
 	// need to check orphaned files. All files are owned by
 	// the parent stack or its children.
 	if cfg.IsStack() {
+		logger.Debug().Msg("project root is stack, no need to check for orphaned files")
+
 		sort.Strings(outdatedFiles)
 		return outdatedFiles, nil
 	}
+
+	logger.Debug().Msg("checking for orphaned files")
 
 	orphanedFiles, err := ListGenFiles(cfg, cfg.RootDir())
 	if err != nil {

--- a/generate/generate.go
+++ b/generate/generate.go
@@ -295,7 +295,8 @@ func Do(cfg *config.Tree, workingDir string) Report {
 //
 // When called with a dir that is not a stack this function will provide a list
 // of all orphaned generated files inside this dir, since it won't search inside any stacks.
-// So calling with dir == rootdir will provide all orphaned files inside a project.
+// So calling with dir == rootdir will provide all orphaned files inside a project if
+// the root of the project is not a stack.
 //
 // When called with a dir that is a stack this function will list all generated
 // files that are owned by the stack, since it won't search inside any child stacks.
@@ -962,6 +963,12 @@ func loadStackCodeCfgs(
 }
 
 func cleanupOrphaned(cfg *config.Tree, report Report) Report {
+	// If the root of the tree is a stack then there is nothing to do
+	// since there can't be any orphans (the root parent stack owns
+	// the entire project).
+	if cfg.IsStack() {
+		return report
+	}
 	orphanedGenFiles, err := ListGenFiles(cfg, cfg.RootDir())
 	if err != nil {
 		report.CleanupErr = err

--- a/generate/generate.go
+++ b/generate/generate.go
@@ -390,6 +390,14 @@ func DetectOutdated(cfg *config.Tree) ([]string, error) {
 		}
 	}
 
+	// If the root of the project is a stack then there is no
+	// need to check orphaned files. All files are owned by
+	// the parent stack or its children.
+	if cfg.IsStack() {
+		sort.Strings(outdatedFiles)
+		return outdatedFiles, nil
+	}
+
 	orphanedFiles, err := ListGenFiles(cfg, cfg.RootDir())
 	if err != nil {
 		errs.Append(err)

--- a/generate/generate.go
+++ b/generate/generate.go
@@ -971,12 +971,19 @@ func loadStackCodeCfgs(
 }
 
 func cleanupOrphaned(cfg *config.Tree, report Report) Report {
+	logger := log.With().
+		Str("action", "generate.cleanupOrphaned()").
+		Logger()
 	// If the root of the tree is a stack then there is nothing to do
 	// since there can't be any orphans (the root parent stack owns
 	// the entire project).
 	if cfg.IsStack() {
+		logger.Debug().Msg("project root is a stack, nothing to do")
 		return report
 	}
+
+	logger.Debug().Msg("listing orphaned generated files")
+
 	orphanedGenFiles, err := ListGenFiles(cfg, cfg.RootDir())
 	if err != nil {
 		report.CleanupErr = err

--- a/generate/generate_file_test.go
+++ b/generate/generate_file_test.go
@@ -168,6 +168,61 @@ func TestGenerateFile(t *testing.T) {
 			},
 		},
 		{
+			name: "generate_file with stack on root and substacks",
+			layout: []string{
+				"s:/",
+				"s:/stack-1",
+				"s:/stack-2",
+			},
+			configs: []hclconfig{
+				{
+					path: "/",
+					add: Doc(
+						GenerateFile(
+							Labels("root.txt"),
+							Expr("content", `"${tm_jsonencode(terramate.stacks.list)}"`),
+						),
+					),
+				},
+			},
+			want: []generatedFile{
+				{
+					stack: "/",
+					files: map[string]fmt.Stringer{
+						"root.txt": stringer(`["/","/stack-1","/stack-2"]`),
+					},
+				},
+				{
+					stack: "/stack-1",
+					files: map[string]fmt.Stringer{
+						"root.txt": stringer(`["/","/stack-1","/stack-2"]`),
+					},
+				},
+				{
+					stack: "/stack-2",
+					files: map[string]fmt.Stringer{
+						"root.txt": stringer(`["/","/stack-1","/stack-2"]`),
+					},
+				},
+			},
+			wantReport: generate.Report{
+				Successes: []generate.Result{
+					{
+						Dir:     "/",
+						Created: []string{"root.txt"},
+					},
+					{
+						Dir:     "/stack-1",
+						Created: []string{"root.txt"},
+					},
+					{
+						Dir:     "/stack-2",
+						Created: []string{"root.txt"},
+					},
+				},
+			},
+		},
+		{
 			name: "terramate.stacks.list with stack workdir",
 			layout: []string{
 				"s:stacks/stack-1",

--- a/generate/generate_file_test.go
+++ b/generate/generate_file_test.go
@@ -135,6 +135,39 @@ func TestGenerateFile(t *testing.T) {
 			},
 		},
 		{
+			name: "generate_file with stack on root",
+			layout: []string{
+				"s:/",
+			},
+			configs: []hclconfig{
+				{
+					path: "/",
+					add: Doc(
+						GenerateFile(
+							Labels("root.txt"),
+							Expr("content", `"${tm_jsonencode(terramate.stacks.list)}"`),
+						),
+					),
+				},
+			},
+			want: []generatedFile{
+				{
+					stack: "/",
+					files: map[string]fmt.Stringer{
+						"root.txt": stringer(`["/"]`),
+					},
+				},
+			},
+			wantReport: generate.Report{
+				Successes: []generate.Result{
+					{
+						Dir:     "/",
+						Created: []string{"root.txt"},
+					},
+				},
+			},
+		},
+		{
 			name: "terramate.stacks.list with stack workdir",
 			layout: []string{
 				"s:stacks/stack-1",

--- a/generate/generate_hcl_test.go
+++ b/generate/generate_hcl_test.go
@@ -207,6 +207,69 @@ func TestGenerateHCL(t *testing.T) {
 			},
 		},
 		{
+			name: "generate HCL with stack on root and substacks",
+			layout: []string{
+				"s:/",
+				"s:/stack-1",
+				"s:/stack-2",
+			},
+			configs: []hclconfig{
+				{
+					path: "/",
+					add: Doc(
+						GenerateHCL(
+							Labels("root.hcl"),
+							Content(
+								Expr("stacks", "terramate.stacks.list"),
+							),
+						),
+					),
+				},
+			},
+			want: []generatedFile{
+				{
+					stack: "/",
+					files: map[string]fmt.Stringer{
+						"root.hcl": Doc(
+							attr("stacks", `["/", "/stack-1", "/stack-2"]`),
+						),
+					},
+				},
+				{
+					stack: "/stack-1",
+					files: map[string]fmt.Stringer{
+						"root.hcl": Doc(
+							attr("stacks", `["/", "/stack-1", "/stack-2"]`),
+						),
+					},
+				},
+				{
+					stack: "/stack-2",
+					files: map[string]fmt.Stringer{
+						"root.hcl": Doc(
+							attr("stacks", `["/", "/stack-1", "/stack-2"]`),
+						),
+					},
+				},
+			},
+			wantReport: generate.Report{
+				Successes: []generate.Result{
+					{
+						Dir:     "/",
+						Created: []string{"root.hcl"},
+					},
+					{
+						Dir:     "/stack-1",
+						Created: []string{"root.hcl"},
+					},
+					{
+						Dir:     "/stack-2",
+						Created: []string{"root.hcl"},
+					},
+				},
+			},
+		},
+		{
 			name: "generate HCL with terramate.stacks.list with workdir on stack",
 			layout: []string{
 				"s:stacks/stack-1",

--- a/generate/generate_hcl_test.go
+++ b/generate/generate_hcl_test.go
@@ -170,6 +170,43 @@ func TestGenerateHCL(t *testing.T) {
 			},
 		},
 		{
+			name: "generate HCL with stack on root",
+			layout: []string{
+				"s:/",
+			},
+			configs: []hclconfig{
+				{
+					path: "/",
+					add: Doc(
+						GenerateHCL(
+							Labels("root.hcl"),
+							Content(
+								Expr("stacks", "terramate.stacks.list"),
+							),
+						),
+					),
+				},
+			},
+			want: []generatedFile{
+				{
+					stack: "/",
+					files: map[string]fmt.Stringer{
+						"root.hcl": Doc(
+							attr("stacks", `["/"]`),
+						),
+					},
+				},
+			},
+			wantReport: generate.Report{
+				Successes: []generate.Result{
+					{
+						Dir:     "/",
+						Created: []string{"root.hcl"},
+					},
+				},
+			},
+		},
+		{
 			name: "generate HCL with terramate.stacks.list with workdir on stack",
 			layout: []string{
 				"s:stacks/stack-1",

--- a/generate/outdated_detection_test.go
+++ b/generate/outdated_detection_test.go
@@ -315,6 +315,72 @@ func TestOutdatedDetection(t *testing.T) {
 			},
 		},
 		{
+			name: "detecting outdated code on root with sub-stacks",
+			steps: []step{
+				{
+					layout: []string{
+						"s:/",
+						"s:/stack-1",
+						"s:/stack-2",
+					},
+					files: []file{
+						{
+							path: "config.tm",
+							body: Doc(
+								GenerateFile(
+									Labels("test.txt"),
+									Str("content", "tm is awesome"),
+								),
+								GenerateHCL(
+									Labels("test.hcl"),
+									Content(
+										Str("content", "tm is awesome"),
+									),
+								),
+							),
+						},
+					},
+					want: []string{
+						"stack-1/test.hcl",
+						"stack-1/test.txt",
+						"stack-2/test.hcl",
+						"stack-2/test.txt",
+						"test.hcl",
+						"test.txt",
+					},
+				},
+				{
+					files: []file{
+						{
+							path: "config.tm",
+							body: Doc(
+								GenerateFile(
+									Labels("test.txt"),
+									Bool("condition", false),
+									Str("content", "tm is awesome"),
+								),
+								GenerateHCL(
+									Labels("test.hcl"),
+									Bool("condition", false),
+									Content(
+										Str("content", "tm is awesome"),
+									),
+								),
+							),
+						},
+					},
+					want: []string{
+						"stack-1/test.hcl",
+						"stack-1/test.txt",
+						"stack-2/test.hcl",
+						"stack-2/test.txt",
+						"test.hcl",
+						"test.txt",
+					},
+				},
+			},
+		},
+		{
 			// TODO(KATCIPIS): when we remove the origin from gen code header
 			// this behavior will change.
 			name: "moving generate blocks to different files is detected on generate_hcl",

--- a/generate/outdated_detection_test.go
+++ b/generate/outdated_detection_test.go
@@ -259,6 +259,62 @@ func TestOutdatedDetection(t *testing.T) {
 			},
 		},
 		{
+			name: "detecting outdated code on root",
+			steps: []step{
+				{
+					layout: []string{
+						"s:/",
+					},
+					files: []file{
+						{
+							path: "config.tm",
+							body: Doc(
+								GenerateFile(
+									Labels("test.txt"),
+									Str("content", "tm is awesome"),
+								),
+								GenerateHCL(
+									Labels("test.hcl"),
+									Content(
+										Str("content", "tm is awesome"),
+									),
+								),
+							),
+						},
+					},
+					want: []string{
+						"test.hcl",
+						"test.txt",
+					},
+				},
+				{
+					files: []file{
+						{
+							path: "config.tm",
+							body: Doc(
+								GenerateFile(
+									Labels("test.txt"),
+									Bool("condition", false),
+									Str("content", "tm is awesome"),
+								),
+								GenerateHCL(
+									Labels("test.hcl"),
+									Bool("condition", false),
+									Content(
+										Str("content", "tm is awesome"),
+									),
+								),
+							),
+						},
+					},
+					want: []string{
+						"test.hcl",
+						"test.txt",
+					},
+				},
+			},
+		},
+		{
 			// TODO(KATCIPIS): when we remove the origin from gen code header
 			// this behavior will change.
 			name: "moving generate blocks to different files is detected on generate_hcl",
@@ -879,9 +935,12 @@ func TestOutdatedDetection(t *testing.T) {
 
 				assertEqualStringList(t, got, step.want)
 
+				t.Log("checking that after generate outdated detection should always return empty")
+
 				s.Generate()
 				got, err = generate.DetectOutdated(s.Config())
 				assert.NoError(t, err)
+
 				assertEqualStringList(t, got, []string{})
 			}
 		})


### PR DESCRIPTION
# Reason for This Change

When the stack is on root we are creating/deleting the file. To reproduce:

```sh
#!/bin/bash

set -o errexit
set -o nounset

cat > terramate.tm.hcl <<- EOM
terramate {
  config {
  }
}
EOM

cat > config.tm.hcl <<- EOM
stack {
  name        = "terraform-google-service-account"
  description = "github.com/mineiros-io/terraform-google-service-account"
}

generate_hcl "versions.tf" {
  content {
  }
}
EOM

terramate generate

```

Outdated detection was also not working properly on this scenario.

## Description of Changes

Fix both outdated detection and generation with regression tests.
