### PR TITLE
fix: panic when using tm_hcl_expression() on invalid contexts

### DIFF
--- a/docs/functions.md
+++ b/docs/functions.md
@@ -55,7 +55,14 @@ contents as an expression. It is particularly useful to circumvent some
 limitations on HCL and Terraform when building complex expressions from
 dynamic data.
 
-For example, given a global named data defined like this:
+Since this function produces an expression, not a final evaluated value,
+it is only allowed to be used on contexts where partial evaluation is
+allowed, which currently are:
+
+* `generate_hcl.content` block
+* `generate_file.content` attribute
+
+To use `tm_hcl_expression`, lets say we have a global named data defined like this:
 
 ```
 globals {
@@ -67,13 +74,17 @@ You can use this global to build a complex expression when generation code,
 like this:
 
 ```hcl
-tm_hcl_expression("data.google_active_folder._parent_id.id.${global.data}")
+generate_hcl "test.hcl" {
+    content {
+        expr = tm_hcl_expression("data.google_active_folder._parent_id.id.${global.data}")
+    }
+}
 ```
 
-Which will produce the expression:
+Which will generate:
 
 ```hcl
-data.google_active_folder._parent_id.id.data
+expr = data.google_active_folder._parent_id.id.data
 ```
 
 ## Experimental Functions

--- a/docs/functions.md
+++ b/docs/functions.md
@@ -57,10 +57,7 @@ dynamic data.
 
 Since this function produces an expression, not a final evaluated value,
 it is only allowed to be used on contexts where partial evaluation is
-allowed, which currently are:
-
-* `generate_hcl.content` block
-* `generate_file.content` attribute
+allowed, which currently is only the `generate_hcl.content` block.
 
 To use `tm_hcl_expression`, lets say we have a global named data defined like this:
 

--- a/generate/genfile/genfile.go
+++ b/generate/genfile/genfile.go
@@ -152,7 +152,7 @@ func Load(
 		vendorTargetDir := project.NewPath(path.Join(
 			sm.Path().String(),
 			path.Dir(name)))
-		evalctx.SetTmVendor(vendorTargetDir, vendorDir, vendorRequests)
+		evalctx.AddTmVendor(vendorTargetDir, vendorDir, vendorRequests)
 
 		file, err := Eval(genFileBlock, evalctx.Context)
 		if err != nil {

--- a/generate/genhcl/genhcl.go
+++ b/generate/genhcl/genhcl.go
@@ -170,7 +170,7 @@ func Load(
 		vendorTargetDir := project.NewPath(path.Join(
 			sm.Path().String(),
 			path.Dir(name)))
-		evalctx.SetTmVendor(vendorTargetDir, vendorDir, vendorRequests)
+		evalctx.AddTmVendor(vendorTargetDir, vendorDir, vendorRequests)
 
 		err := lets.Load(hclBlock.Lets, evalctx.Context)
 		if err != nil {
@@ -232,6 +232,8 @@ func Load(
 			})
 			continue
 		}
+
+		evalctx.AddTmHCLExpression()
 
 		gen := hclwrite.NewEmptyFile()
 		if err := copyBody(gen.Body(), hclBlock.Content.Body, evalctx); err != nil {

--- a/generate/hcl_expr_func_test.go
+++ b/generate/hcl_expr_func_test.go
@@ -29,7 +29,7 @@ func TestHCLExpressionFunc(t *testing.T) {
 	// In the future tests could be moved here.
 	testCodeGeneration(t, []testcase{
 		{
-			name: "tm_hcl_expression is not available",
+			name: "not available on lets block",
 			layout: []string{
 				"s:stack",
 			},

--- a/generate/hcl_expr_func_test.go
+++ b/generate/hcl_expr_func_test.go
@@ -1,0 +1,74 @@
+// Copyright 2022 Mineiros GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package generate_test
+
+import (
+	"testing"
+
+	"github.com/mineiros-io/terramate/errors"
+	"github.com/mineiros-io/terramate/generate"
+	"github.com/mineiros-io/terramate/hcl/eval"
+
+	. "github.com/mineiros-io/terramate/test/hclwrite/hclutils"
+)
+
+func TestHCLExpressionFunc(t *testing.T) {
+	// TODO(KATCIPIS): currently most behavior is tested on the genhcl pkg.
+	// In the future tests could be moved here.
+	testCodeGeneration(t, []testcase{
+		{
+			name: "tm_hcl_expression is not available",
+			layout: []string{
+				"s:stack",
+			},
+			configs: []hclconfig{
+				{
+					path: "/stack",
+					add: Doc(
+						GenerateHCL(
+							Labels("test.hcl"),
+							Lets(
+								Expr("expr", `tm_hcl_expression("test")`),
+							),
+							Content(
+								Expr("value", `let.expr`),
+							),
+						),
+						GenerateFile(
+							Labels("test.txt"),
+							Lets(
+								Expr("content", `tm_hcl_expression("test")`),
+							),
+							Expr("content", "let.content"),
+						),
+					),
+				},
+			},
+			wantReport: generate.Report{
+				Failures: []generate.FailureResult{
+					{
+						Result: generate.Result{
+							Dir: "/stack",
+						},
+						Error: errors.L(
+							errors.E(eval.ErrEval),
+							errors.E(eval.ErrEval),
+						),
+					},
+				},
+			},
+		},
+	})
+}

--- a/generate/hcl_expr_func_test.go
+++ b/generate/hcl_expr_func_test.go
@@ -29,7 +29,7 @@ func TestHCLExpressionFunc(t *testing.T) {
 	// In the future tests could be moved here.
 	testCodeGeneration(t, []testcase{
 		{
-			name: "not available on lets block",
+			name: "not available on generate_hcl lets block",
 			layout: []string{
 				"s:stack",
 			},
@@ -46,6 +46,29 @@ func TestHCLExpressionFunc(t *testing.T) {
 								Expr("value", `let.expr`),
 							),
 						),
+					),
+				},
+			},
+			wantReport: generate.Report{
+				Failures: []generate.FailureResult{
+					{
+						Result: generate.Result{
+							Dir: "/stack",
+						},
+						Error: errors.E(eval.ErrEval),
+					},
+				},
+			},
+		},
+		{
+			name: "not available on generate_file lets block",
+			layout: []string{
+				"s:stack",
+			},
+			configs: []hclconfig{
+				{
+					path: "/stack",
+					add: Doc(
 						GenerateFile(
 							Labels("test.txt"),
 							Lets(
@@ -62,10 +85,7 @@ func TestHCLExpressionFunc(t *testing.T) {
 						Result: generate.Result{
 							Dir: "/stack",
 						},
-						Error: errors.L(
-							errors.E(eval.ErrEval),
-							errors.E(eval.ErrEval),
-						),
+						Error: errors.E(eval.ErrEval),
 					},
 				},
 			},

--- a/generate/hcl_expr_func_test.go
+++ b/generate/hcl_expr_func_test.go
@@ -61,6 +61,124 @@ func TestHCLExpressionFunc(t *testing.T) {
 			},
 		},
 		{
+			name: "not available on generate_hcl condition",
+			layout: []string{
+				"s:stack",
+			},
+			configs: []hclconfig{
+				{
+					path: "/stack",
+					add: Doc(
+						GenerateHCL(
+							Labels("test.hcl"),
+							Expr("condition", `tm_hcl_expression("test")`),
+							Content(),
+						),
+					),
+				},
+			},
+			wantReport: generate.Report{
+				Failures: []generate.FailureResult{
+					{
+						Result: generate.Result{
+							Dir: "/stack",
+						},
+						Error: errors.E(eval.ErrEval),
+					},
+				},
+			},
+		},
+		{
+			name: "not available on generate_hcl assert",
+			layout: []string{
+				"s:stack",
+			},
+			configs: []hclconfig{
+				{
+					path: "/stack",
+					add: Doc(
+						GenerateHCL(
+							Labels("test.hcl"),
+							Assert(
+								Expr("assertion", `tm_hcl_expression("true")`),
+								Str("message", "msg"),
+							),
+							Content(),
+						),
+					),
+				},
+			},
+			wantReport: generate.Report{
+				Failures: []generate.FailureResult{
+					{
+						Result: generate.Result{
+							Dir: "/stack",
+						},
+						Error: errors.E(eval.ErrEval),
+					},
+				},
+			},
+		},
+		{
+			name: "not available on generate_file condition",
+			layout: []string{
+				"s:stack",
+			},
+			configs: []hclconfig{
+				{
+					path: "/stack",
+					add: Doc(
+						GenerateFile(
+							Labels("test.txt"),
+							Expr("condition", `tm_hcl_expression("test")`),
+							Str("content", "content"),
+						),
+					),
+				},
+			},
+			wantReport: generate.Report{
+				Failures: []generate.FailureResult{
+					{
+						Result: generate.Result{
+							Dir: "/stack",
+						},
+						Error: errors.E(eval.ErrEval),
+					},
+				},
+			},
+		},
+		{
+			name: "not available on generate_file assert",
+			layout: []string{
+				"s:stack",
+			},
+			configs: []hclconfig{
+				{
+					path: "/stack",
+					add: Doc(
+						GenerateFile(
+							Labels("test.txt"),
+							Assert(
+								Expr("assertion", `tm_hcl_expression("true")`),
+								Str("message", "msg"),
+							),
+							Str("content", "content"),
+						),
+					),
+				},
+			},
+			wantReport: generate.Report{
+				Failures: []generate.FailureResult{
+					{
+						Result: generate.Result{
+							Dir: "/stack",
+						},
+						Error: errors.E(eval.ErrEval),
+					},
+				},
+			},
+		},
+		{
 			name: "not available on generate_file lets block",
 			layout: []string{
 				"s:stack",
@@ -76,6 +194,32 @@ func TestHCLExpressionFunc(t *testing.T) {
 							),
 							Expr("content", "let.content"),
 						),
+					),
+				},
+			},
+			wantReport: generate.Report{
+				Failures: []generate.FailureResult{
+					{
+						Result: generate.Result{
+							Dir: "/stack",
+						},
+						Error: errors.E(eval.ErrEval),
+					},
+				},
+			},
+		},
+		{
+			// There is no way to interpolate the expression on a string template
+			name: "not available on generate_file content",
+			layout: []string{
+				"s:stack",
+			},
+			configs: []hclconfig{
+				{
+					path: "/stack",
+					add: GenerateFile(
+						Labels("expr.txt"),
+						Str("content", `generated: ${tm_hcl_expression("data")}`),
 					),
 				},
 			},

--- a/hcl/eval/eval.go
+++ b/hcl/eval/eval.go
@@ -57,7 +57,7 @@ func NewContext(basedir string) (*Context, error) {
 	}
 
 	hclctx := &hhcl.EvalContext{
-		Functions: newTmFunctions(basedir),
+		Functions: newDefaultFunctions(basedir),
 		Variables: map[string]cty.Value{},
 	}
 	return &Context{
@@ -65,18 +65,23 @@ func NewContext(basedir string) (*Context, error) {
 	}, nil
 }
 
-// SetTmVendor sets the tm_vendor function on this evaluation context.
+// AddTmVendor adds the tm_vendor function on this evaluation context.
 // The targetdir defines what tm_vendor will use to define the relative paths
 // of vendored dependencies.
 // The vendordir defines where modules are vendored inside the project.
 // The stream defines the event stream for tm_vendor, one event is produced
 // per successful function call.
-func (c *Context) SetTmVendor(
+func (c *Context) AddTmVendor(
 	targetdir project.Path,
 	vendordir project.Path,
 	stream chan<- event.VendorRequest,
 ) {
 	c.hclctx.Functions["tm_vendor"] = tmVendor(targetdir, vendordir, stream)
+}
+
+// AddTmHCLExpression adds the tm_hcl_expression function on this evaluation context.
+func (c *Context) AddTmHCLExpression() {
+	c.hclctx.Functions["tm_hcl_expression"] = tmHCLExpression()
 }
 
 // SetNamespace will set the given values inside the given namespace on the

--- a/hcl/eval/functions.go
+++ b/hcl/eval/functions.go
@@ -30,7 +30,7 @@ import (
 	"github.com/zclconf/go-cty/cty/function"
 )
 
-func newTmFunctions(basedir string) map[string]function.Function {
+func newDefaultFunctions(basedir string) map[string]function.Function {
 	scope := &tflang.Scope{BaseDir: basedir}
 	tffuncs := scope.Functions()
 
@@ -44,7 +44,6 @@ func newTmFunctions(basedir string) map[string]function.Function {
 
 	// sane ternary
 	tmfuncs["tm_ternary"] = tmTernary()
-	tmfuncs["tm_hcl_expression"] = tmHCLExpression()
 	return tmfuncs
 }
 

--- a/hcl/eval/functions_test.go
+++ b/hcl/eval/functions_test.go
@@ -136,7 +136,7 @@ func TestTmVendor(t *testing.T) {
 			ctx, err := eval.NewContext(rootdir)
 			assert.NoError(t, err)
 
-			ctx.SetTmVendor(targetdir, vendordir, events)
+			ctx.AddTmVendor(targetdir, vendordir, events)
 
 			gotEvents := []event.VendorRequest{}
 			done := make(chan struct{})
@@ -170,7 +170,7 @@ func TestTmVendor(t *testing.T) {
 				ctx, err := eval.NewContext(rootdir)
 				assert.NoError(t, err)
 
-				ctx.SetTmVendor(targetdir, vendordir, nil)
+				ctx.AddTmVendor(targetdir, vendordir, nil)
 
 				val, err := ctx.Eval(test.NewExpr(t, tcase.expr))
 				assert.NoError(t, err)

--- a/hcl/hcl_stack_test.go
+++ b/hcl/hcl_stack_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/madlambda/spells/assert"
 	"github.com/mineiros-io/terramate/errors"
 	"github.com/mineiros-io/terramate/hcl"
+	"github.com/mineiros-io/terramate/hcl/eval"
 	. "github.com/mineiros-io/terramate/test/hclutils"
 )
 
@@ -161,6 +162,42 @@ func TestHCLParserStack(t *testing.T) {
 				errs: []error{
 					errors.E(hcl.ErrTerramateSchema),
 					errors.E(hcl.ErrTerramateSchema),
+				},
+			},
+		},
+		{
+			name: "tm_vendor is not available on stack block",
+			input: []cfgfile{
+				{
+					filename: "stack.tm",
+					body: `
+						stack{
+						  name = tm_vendor("github.com/mineiros-io/terramate?ref=v2")
+						}
+					`,
+				},
+			},
+			want: want{
+				errs: []error{
+					errors.E(eval.ErrEval),
+				},
+			},
+		},
+		{
+			name: "tm_hcl_expression is not available on stack block",
+			input: []cfgfile{
+				{
+					filename: "stack.tm",
+					body: `
+						stack{
+						  name = tm_hcl_expression("ref")
+						}
+					`,
+				},
+			},
+			want: want{
+				errs: []error{
+					errors.E(eval.ErrEval),
 				},
 			},
 		},

--- a/stack/globals_test.go
+++ b/stack/globals_test.go
@@ -1445,6 +1445,19 @@ func TestLoadGlobals(t *testing.T) {
 			},
 		},
 		{
+			name:   "tm_hcl_expression is not available on globals",
+			layout: []string{"s:stack"},
+			configs: []hclconfig{
+				{
+					path: "/stack",
+					add: Globals(
+						Expr("data", `tm_hcl_expression("test")`),
+					),
+				},
+			},
+			wantErr: errors.E(globals.ErrEval),
+		},
+		{
 			name:   "global interpolating multiple lists fails",
 			layout: []string{"s:stack"},
 			configs: []hclconfig{

--- a/stack/globals_test.go
+++ b/stack/globals_test.go
@@ -54,6 +54,8 @@ func TestLoadGlobals(t *testing.T) {
 		}
 	)
 
+	t.Parallel()
+
 	tcases := []testcase{
 		{
 			name:   "no stacks no globals",
@@ -1458,6 +1460,19 @@ func TestLoadGlobals(t *testing.T) {
 			wantErr: errors.E(globals.ErrEval),
 		},
 		{
+			name:   "tm_vendor is not available on globals",
+			layout: []string{"s:stack"},
+			configs: []hclconfig{
+				{
+					path: "/stack",
+					add: Globals(
+						Expr("data", `tm_vendor("github.com/mineiros-io/terramate?ref=test")`),
+					),
+				},
+			},
+			wantErr: errors.E(globals.ErrEval),
+		},
+		{
 			name:   "global interpolating multiple lists fails",
 			layout: []string{"s:stack"},
 			configs: []hclconfig{
@@ -2435,8 +2450,11 @@ func TestLoadGlobalsErrors(t *testing.T) {
 		},
 	}
 
-	for _, tcase := range tcases {
+	for _, tc := range tcases {
+		tcase := tc
 		t.Run(tcase.name, func(t *testing.T) {
+			t.Parallel()
+
 			s := sandbox.New(t)
 			s.BuildTree(tcase.layout)
 


### PR DESCRIPTION
# Reason for This Change

It was not documented clearly and handled gracefully the fact that the function `tm_hcl_expression` is not available on all contexts where other tm_ functions are available.

Closes #724 