### PR TITLE
fix: tm_try with only root namespace variable panics

### DIFF
--- a/stack/globals_test.go
+++ b/stack/globals_test.go
@@ -2240,6 +2240,24 @@ func TestLoadGlobals(t *testing.T) {
 			},
 			wantErr: errors.E(globals.ErrEval),
 		},
+		{
+			name:   "tm_try with only root traversal",
+			layout: []string{"s:stack"},
+			configs: []hclconfig{
+				{
+					path: "/stack",
+					add: Globals(
+						Expr("val", `tm_try(global, "default")`),
+					),
+				},
+			},
+			want: map[string]*hclwrite.Block{
+				"/stack": Globals(
+					Str("a", "test"),
+					EvalExpr(t, "val", `{}`),
+				),
+			},
+		},
 	}
 
 	for _, tcase := range tcases {


### PR DESCRIPTION
# Reason for This Change

When using a variable with no traversals in a `tm_try()` call it panics.

Example expression:
```
tm_try(global, "test")
```
bug:

```
panic: runtime error: index out of range [1] with length 1 [recovered]
	panic: runtime error: index out of range [1] with length 1

goroutine 3317 [running]:
testing.tRunner.func1.2({0xb53160, 0xc000174c18})
	/usr/lib/go/src/testing/testing.go:1389 +0x366
testing.tRunner.func1()
	/usr/lib/go/src/testing/testing.go:1392 +0x5d2
panic({0xb53160, 0xc000174c18})
	/usr/lib/go/src/runtime/panic.go:844 +0x258
github.com/mineiros-io/terramate/globals.Exprs.Eval(0xc00045cc30?, 0xc0004942e8)
	/home/i4k/src/mineiros/terramate/globals/globals.go:247 +0x2cc5
github.com/mineiros-io/terramate/globals.Load(0xc00045cc30, {0xc00038ce08, 0x6}, 0x9?)
	/home/i4k/src/mineiros/terramate/globals/globals.go:92 +0x534
github.com/mineiros-io/terramate/stack.LoadStackGlobals(0xc0006add78?, {{0xc000296780, 0x48}, {0xc0002abc70, 0x1, 0x1}}, {0xd3d2f8, 0xc000260540})
	/home/i4k/src/mineiros/terramate/stack/globals.go:50 +0x547
github.com/mineiros-io/terramate/stack_test.TestLoadGlobals.func1(0xc00043a680)
	/home/i4k/src/mineiros/terramate/stack/globals_test.go:2296 +0x685
testing.tRunner(0xc00043a680, 0xc0003b5fe0)
	/usr/lib/go/src/testing/testing.go:1439 +0x214
created by testing.(*T).Run
	/usr/lib/go/src/testing/testing.go:1486 +0x725
FAIL	github.com/mineiros-io/terramate/stack	6.285s
```
