### PR TITLE
fix: incorrect globals conflict handling

### DIFF
--- a/globals/eval_report.go
+++ b/globals/eval_report.go
@@ -44,7 +44,7 @@ type (
 // NewEvalReport creates a new globals evaluation report.
 func NewEvalReport() EvalReport {
 	return EvalReport{
-		Globals: eval.NewObject(eval.Origin{
+		Globals: eval.NewObject(eval.Info{
 			DefinedAt: project.NewPath("/"),
 		}),
 		Errors: make(map[GlobalPathKey]EvalError),

--- a/globals/eval_report.go
+++ b/globals/eval_report.go
@@ -44,8 +44,10 @@ type (
 // NewEvalReport creates a new globals evaluation report.
 func NewEvalReport() EvalReport {
 	return EvalReport{
-		Globals: eval.NewObject(project.NewPath("/")),
-		Errors:  make(map[GlobalPathKey]EvalError),
+		Globals: eval.NewObject(eval.Origin{
+			DefinedAt: project.NewPath("/"),
+		}),
+		Errors: make(map[GlobalPathKey]EvalError),
 	}
 }
 

--- a/globals/globals.go
+++ b/globals/globals.go
@@ -348,11 +348,11 @@ func (le loadedExprs) eval(ctx *eval.Context) EvalReport {
 				oldValue, hasOldValue := globals.GetKeyPath(accessor.Path())
 				if hasOldValue &&
 					accessor.isattr &&
-					oldValue.Origin().DefinedAt.Dir().String() == expr.Origin.Dir().String() {
+					oldValue.Info().DefinedAt.Dir().String() == expr.Origin.Dir().String() {
 					pendingExprsErrs[accessor].Append(
 						errors.E(hcl.ErrTerramateSchema, expr.Range(),
 							"global.%s attribute redefined: previously defined at %s",
-							accessor.name(), oldValue.Origin().DefinedAt.String()))
+							accessor.name(), oldValue.Info().DefinedAt.String()))
 
 					continue
 				}
@@ -387,9 +387,9 @@ func (le loadedExprs) eval(ctx *eval.Context) EvalReport {
 					err = globals.SetAt(
 						accessor.Path(),
 						eval.NewValue(val,
-							eval.Origin{
-								DefinedAt:  expr.Origin,
-								ConfigFrom: sortedGlobals.origin,
+							eval.Info{
+								DefinedAt: expr.Origin,
+								Dir:       sortedGlobals.origin,
 							},
 						))
 					if err != nil {

--- a/hcl/eval/object.go
+++ b/hcl/eval/object.go
@@ -116,7 +116,7 @@ func (obj *Object) GetKeyPath(path ObjectPath) (Value, bool) {
 	return v.(*Object).GetKeyPath(next)
 }
 
-// Origin is the [Origin] of the object value.
+// Info provides extra information for the object value.
 func (obj *Object) Info() Info { return obj.origin }
 
 // IsObject returns true for [Object] values.

--- a/hcl/eval/object.go
+++ b/hcl/eval/object.go
@@ -73,10 +73,13 @@ type (
 
 	// Info provides extra information for the configuration value.
 	Info struct {
-		// Dir defines the directory from there the value is being instantiated.
+		// Dir defines the directory from there the value is being instantiated,
+		// which means it's the scope directory (not the file where it's defined).
+		// For values that comes from imports, the Dir will be the directory
+		// which imports the value.
 		Dir project.Path
 
-		// DefinedAt defines the source file where the value is defined.
+		// DefinedAt provides the source file where the value is defined.
 		DefinedAt project.Path
 	}
 

--- a/hcl/eval/object_test.go
+++ b/hcl/eval/object_test.go
@@ -29,9 +29,9 @@ import (
 type strValue string
 
 func (s strValue) IsObject() bool { return false }
-func (s strValue) Origin() eval.Origin {
-	return eval.Origin{
-		ConfigFrom: project.NewPath("/"),
+func (s strValue) Info() eval.Info {
+	return eval.Info{
+		Dir: project.NewPath("/"),
 	}
 }
 
@@ -45,9 +45,9 @@ func TestCtyObjectSetAt(t *testing.T) {
 		wantErr error
 	}
 
-	defaultOrigin := eval.Origin{
-		DefinedAt:  "/file.tm",
-		ConfigFrom: "/",
+	defaultOrigin := eval.Info{
+		DefinedAt: "/file.tm",
+		Dir:       "/",
 	}
 
 	newobj := func(sets ...map[string]eval.Value) *eval.Object {

--- a/hcl/eval/object_test.go
+++ b/hcl/eval/object_test.go
@@ -28,8 +28,12 @@ import (
 
 type strValue string
 
-func (s strValue) IsObject() bool             { return false }
-func (s strValue) ConfigOrigin() project.Path { return project.NewPath("/") }
+func (s strValue) IsObject() bool { return false }
+func (s strValue) Origin() eval.Origin {
+	return eval.Origin{
+		ConfigFrom: project.NewPath("/"),
+	}
+}
 
 func TestCtyObjectSetAt(t *testing.T) {
 	type testcase struct {
@@ -41,8 +45,13 @@ func TestCtyObjectSetAt(t *testing.T) {
 		wantErr error
 	}
 
+	defaultOrigin := eval.Origin{
+		DefinedAt:  "/file.tm",
+		ConfigFrom: "/",
+	}
+
 	newobj := func(sets ...map[string]eval.Value) *eval.Object {
-		obj := eval.NewObject(project.NewPath("/"))
+		obj := eval.NewObject(defaultOrigin)
 		for _, set := range sets {
 			obj.SetFrom(set)
 		}

--- a/stack/globals_test.go
+++ b/stack/globals_test.go
@@ -2327,13 +2327,12 @@ func TestLoadGlobals(t *testing.T) {
 			configs: []hclconfig{
 				{
 					path:     "/modules",
-					filename: "file.tm",
+					filename: "imported.tm",
 					add: Doc(
 						Globals(
-							Labels("hello", "world"),
-							Expr("config", `{
+							Labels("hello"),
+							Expr("world", `{
 								a = 1
-								b = 2	
 							}`),
 						),
 					),
@@ -2342,11 +2341,11 @@ func TestLoadGlobals(t *testing.T) {
 					path: "/",
 					add: Doc(
 						Import(
-							Str("source", `/modules/file.tm`),
+							Str("source", `/modules/imported.tm`),
 						),
 						Globals(
-							Labels("hello", "world", "config"),
-							Number("b", 3),
+							Labels("hello", "world"),
+							Number("a", 2),
 						),
 					),
 				},
@@ -2355,10 +2354,7 @@ func TestLoadGlobals(t *testing.T) {
 				"/stack": Globals(
 					EvalExpr(t, "hello", `{
 							world = {
-								config = {
-									a = 1
-									b = 3
-								}
+								a = 2
 							}
 						}`),
 				),
@@ -2606,22 +2602,5 @@ func TestLoadGlobalsErrors(t *testing.T) {
 				errtest.Assert(t, report.AsError(), tcase.want)
 			}
 		})
-	}
-}
-
-func TestLoadIacGCloud(t *testing.T) {
-	const root = "/home/i4k/src/mineiros/iac-gcloud"
-	cfg, err := config.LoadTree(root, root)
-	assert.NoError(t, err)
-
-	stacks, err := stack.LoadAll(cfg)
-	assert.NoError(t, err)
-	projmeta := stack.NewProjectMetadata(root, stacks)
-
-	for _, st := range stacks {
-		report := stack.LoadStackGlobals(cfg.Root(), projmeta, st)
-		//errl := report.AsError().(*errors.List)
-		//assert.NoError(t, report.AsError(), errl.Detailed())
-		t.Logf("globals: %s", report.Globals)
 	}
 }

--- a/stack/globals_test.go
+++ b/stack/globals_test.go
@@ -2319,7 +2319,7 @@ func TestLoadGlobals(t *testing.T) {
 			},
 		},
 		{
-			name: "redefined bug",
+			name: "regression test for a bug which incorrectly returned ErrRedefined errors",
 			layout: []string{
 				"s:stack",
 				"d:modules",


### PR DESCRIPTION
# Reason for This Change

The fix #738 introduced a bug in the globals conflict checks.
It can be reproduced with the configuration below:

```hcl
# modules/imported.tm
globals hello {
    world = {
       a = 1
    }
}
```

```hcl
# /file.tm
import {
    source = "/modules/imported.tm"
}

globals hello world {
    a = 2
}
```

When running Terramate it gives the error below:
```
global eval: terramate schema error: global.hello.world.a attribute redefined: previously defined at /
```

The reason is that when fixing #738 we switched to store the "config dir" in the eval.Object values because it was needed to solve the problem but the check for conflicting attributes (at runtime) needs the actual source file (not from where it's being imported).

## Description of Changes

The fix just stores both the configuration dir and the origin source path in the eval.Object.
