### PR TITLE
fix: make iterator.old undefined on first iteration of a given key

### DIFF
--- a/mapexpr/map.go
+++ b/mapexpr/map.go
@@ -131,10 +131,11 @@ func (m *MapExpr) Value(ctx *hhcl.EvalContext) (cty.Value, hhcl.Diagnostics) {
 
 	var mapErr error
 	foreach.ForEachElement(func(key, newElement cty.Value) (stop bool) {
-		evaluator.SetNamespace(m.Attrs.Iterator, map[string]cty.Value{
+		iteratorMap := map[string]cty.Value{
 			"new": newElement,
-			"old": cty.NilVal,
-		})
+		}
+
+		evaluator.SetNamespace(m.Attrs.Iterator, iteratorMap)
 
 		keyVal, err := evaluator.Eval(m.Attrs.Key)
 		if err != nil {
@@ -148,13 +149,10 @@ func (m *MapExpr) Value(ctx *hhcl.EvalContext) (cty.Value, hhcl.Diagnostics) {
 		}
 
 		oldElement, ok := objmap[keyVal.AsString()]
-		if !ok {
-			oldElement = cty.NilVal
+		if ok {
+			iteratorMap["old"] = oldElement
+			evaluator.SetNamespace(m.Attrs.Iterator, iteratorMap)
 		}
-		evaluator.SetNamespace(m.Attrs.Iterator, map[string]cty.Value{
-			"new": newElement,
-			"old": oldElement,
-		})
 
 		var valVal cty.Value
 

--- a/stack/globals_test.go
+++ b/stack/globals_test.go
@@ -3089,6 +3089,32 @@ func TestLoadGlobals(t *testing.T) {
 			},
 		},
 		{
+			name:   "element.old is undefined on first iteration of a given key",
+			layout: []string{"s:stack"},
+			configs: []hclconfig{
+				{
+					path: "/",
+					add: Globals(
+						Map(
+							Labels("people_count"),
+							Expr("for_each", `["marius", "tiago", "soeren", "tiago"]`),
+							Expr("key", "element.new"),
+							Expr("value", `tm_try(element.old, 0) + 1`),
+						),
+					),
+				},
+			},
+			want: map[string]*hclwrite.Block{
+				"/stack": Globals(
+					EvalExpr(t, "people_count", `{
+						marius = 1
+  						tiago  = 2
+  						soeren = 1
+					}`),
+				),
+			},
+		},
+		{
 			name:   "using element.old in value attr to count people",
 			layout: []string{"s:stack"},
 			configs: []hclconfig{


### PR DESCRIPTION
# Reason for This Change

The `element.old` was set to `null` on the first iteration for a given key, but then it cannot be used with `tm_try()` in all cases.

## Description of Changes

Make the `element.old` undefined and only ever set when there were a value already set for the given key.
