### PR TITLE
chore: create signed tags

### DIFF
--- a/makefiles/unix.mk
+++ b/makefiles/unix.mk
@@ -32,7 +32,7 @@ mod/check:
 .PHONY: release/tag
 release/tag: VERSION?=v$(shell cat VERSION)
 release/tag:
-	git tag -a $(VERSION) -m "Release $(VERSION)"
+	git tag -s -a $(VERSION) -m "Release $(VERSION)"
 	git push origin $(VERSION)
 
 ## remove build artifacts


### PR DESCRIPTION
our release tags are not signed (and then not marked as `verified` by GH):
https://github.com/mineiros-io/terramate/tags