### PR TITLE
fix: allow relative stacks in experimental trigger

### DIFF
--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -607,6 +607,7 @@ func (c *cli) triggerStack() {
 		stack = filepath.Join(c.rootdir(), filepath.FromSlash(stack))
 	}
 
+	stack = filepath.Clean(stack)
 	if !strings.HasPrefix(stack, c.rootdir()) {
 		errlog.Fatal(logger, errors.E("stack %s is outside project", stack))
 	}

--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -602,11 +602,16 @@ func (c *cli) triggerStack() {
 	logger.Debug().Msg("creating stack trigger")
 
 	if !path.IsAbs(stack) {
-		logger.Fatal().Msg("stack must be a project absolute path, like /stack")
+		stack = filepath.Join(c.wd(), filepath.FromSlash(stack))
+	} else {
+		stack = filepath.Join(c.rootdir(), filepath.FromSlash(stack))
 	}
 
-	stackPath := prj.NewPath(stack)
+	if !strings.HasPrefix(stack, c.rootdir()) {
+		errlog.Fatal(logger, errors.E("stack %s is outside project", stack))
+	}
 
+	stackPath := prj.NewPath(string(prj.PrjAbsPath(c.rootdir(), stack)))
 	if err := trigger.Create(c.rootdir(), stackPath, reason); err != nil {
 		errlog.Fatal(logger, err)
 	}

--- a/cmd/terramate/e2etests/exp_trigger_test.go
+++ b/cmd/terramate/e2etests/exp_trigger_test.go
@@ -16,12 +16,64 @@ package e2etest
 
 import (
 	"fmt"
+	"path/filepath"
 	"testing"
 
+	"github.com/madlambda/spells/assert"
 	"github.com/mineiros-io/terramate/stack/trigger"
 	"github.com/mineiros-io/terramate/test"
 	"github.com/mineiros-io/terramate/test/sandbox"
 )
+
+func TestTriggerWorksWithRelativeStackPath(t *testing.T) {
+	t.Parallel()
+
+	s := sandbox.New(t)
+	s.CreateStack("dir/stacks/stack")
+	git := s.Git()
+	git.CommitAll("all")
+	git.Push("main")
+	git.CheckoutNew("trigger-the-stack")
+
+	// execute terramate from `dir/` directory.
+	cli := newCLI(t, filepath.Join(s.RootDir(), "dir"))
+	assertRunResult(t, cli.triggerStack("stacks/stack"), runExpected{
+		IgnoreStdout: true,
+	})
+
+	git.CommitAll("commit the trigger file")
+	want := runExpected{Stdout: "stacks/stack\n"}
+	assertRunResult(t, cli.listChangedStacks(), want)
+}
+
+func TestTriggerMustNotTriggerStacksOutsideProject(t *testing.T) {
+	t.Parallel()
+
+	project1 := sandbox.New(t)
+	project2 := sandbox.New(t)
+
+	project1.CreateStack("project1-stack")
+	project2.CreateStack("project2-stack")
+
+	git1 := project1.Git()
+	git1.CommitAll("all")
+	git1.Push("main")
+	git1.CheckoutNew("trigger-the-stack")
+
+	relpath, err := filepath.Rel(project1.RootDir(), project2.RootDir())
+	assert.NoError(t, err)
+
+	t.Logf("project1: %s", project1.RootDir())
+	t.Logf("project2: %s", project2.RootDir())
+	t.Logf("relpath: %s", relpath)
+
+	cli := newCLI(t, project1.RootDir())
+	assertRunResult(t, cli.triggerStack(filepath.Join(relpath, "project2-stack")),
+		runExpected{
+			Status:      1,
+			StderrRegex: "outside project",
+		})
+}
 
 func TestListDetectAsChangedTriggeredStack(t *testing.T) {
 	t.Parallel()

--- a/cmd/terramate/e2etests/exp_trigger_test.go
+++ b/cmd/terramate/e2etests/exp_trigger_test.go
@@ -63,10 +63,6 @@ func TestTriggerMustNotTriggerStacksOutsideProject(t *testing.T) {
 	relpath, err := filepath.Rel(project1.RootDir(), project2.RootDir())
 	assert.NoError(t, err)
 
-	t.Logf("project1: %s", project1.RootDir())
-	t.Logf("project2: %s", project2.RootDir())
-	t.Logf("relpath: %s", relpath)
-
 	cli := newCLI(t, project1.RootDir())
 	assertRunResult(t, cli.triggerStack(filepath.Join(relpath, "project2-stack")),
 		runExpected{


### PR DESCRIPTION
# Reason for This Change

Allow the use of relative paths when triggering stacks but fail if the provided directory resolves to a path outside the current project.

Example:

```
$ terramate experimental trigger /some/deep/stack # absolute project path works

$ terramate experimental trigger some/deep/stack # relative path works

$ cd some/deep && terramate experimental trigger stack # works
```

when providing paths with `../`, the resolved path must be inside the current project which Terramate is executing otherwise it fails.
