### PR TITLE
chore: upgrade goreleaser to v1.14.0

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -24,12 +24,12 @@ builds:
       - windows
 archives:
   - 
-    replacements:
-      darwin: darwin
-      linux: linux
-      windows: win
-      386: i386
-      amd64: x86_64
+    name_template: >-
+      {{ .ProjectName }}_{{ .Version }}_
+      {{- .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
 
     format_overrides:
       - goos: windows

--- a/makefiles/common.mk
+++ b/makefiles/common.mk
@@ -1,4 +1,4 @@
-GO_RELEASER_VERSION=v1.2.5
+GO_RELEASER_VERSION=v1.14.0
 GOLANGCI_LINT_VERSION ?= v1.49.0
 COVERAGE_REPORT ?= coverage.txt
 RUN_ADD_LICENSE=go run github.com/google/addlicense@v1.0.0 -ignore **/*.yml


### PR DESCRIPTION
# Reason for This Change

The `archive.replacements` option is now deprecated.
The link below explains the change required to achieve the same behavior as before:
https://goreleaser.com/deprecations/#archivesreplacements

The `make release/dry-run` produces:

```
• archives
    • creating                                       archive=dist/terramate_0.2.8-next_linux_arm64.tar.gz
    • creating                                       archive=dist/terramate_0.2.8-next_darwin_arm64.tar.gz
    • creating                                       archive=dist/terramate_0.2.8-next_linux_i386.tar.gz
    • creating                                       archive=dist/terramate_0.2.8-next_linux_x86_64.tar.gz
    • creating                                       archive=dist/terramate_0.2.8-next_windows_arm64.zip
    • creating                                       archive=dist/terramate_0.2.8-next_windows_x86_64.zip
    • creating                                       archive=dist/terramate_0.2.8-next_windows_i386.zip
    • creating                                       archive=dist/terramate_0.2.8-next_darwin_x86_64.tar.gz
```

The only difference is the Windows binary which before generated with `win` but now is `windows`. It's easy to change this but using the proper name seems more consistent with the other OS names.