### PR TITLE
chore: add additional fields to trigger file

### DIFF
--- a/stack/trigger/trigger.go
+++ b/stack/trigger/trigger.go
@@ -225,7 +225,7 @@ func Create(root *config.Root, path project.Path, reason string) error {
 	triggerBody := gen.Body().AppendNewBlock("trigger", nil).Body()
 	triggerBody.SetAttributeValue("ctime", cty.NumberIntVal(ctime))
 	triggerBody.SetAttributeValue("reason", cty.StringVal(reason))
-	triggerBody.SetAttributeRaw("type", hclwrite.TokensForIdentifier(DefaultContext))
+	triggerBody.SetAttributeRaw("type", hclwrite.TokensForIdentifier(DefaultType))
 	triggerBody.SetAttributeRaw("context", hclwrite.TokensForIdentifier(DefaultContext))
 
 	triggerPath := filepath.Join(triggerDir, filename)

--- a/stack/trigger/trigger.go
+++ b/stack/trigger/trigger.go
@@ -52,10 +52,15 @@ type Info struct {
 }
 
 const (
-	triggersDir    = ".tmtriggers"
-	DefaultType    = "changed"
+	// DefaultType is the default trigger type when not specified.
+	DefaultType = "changed"
+
+	// DefaultContext is the default context for the trigger file when not
+	// specified.
 	DefaultContext = "stack"
 )
+
+const triggersDir = ".tmtriggers"
 
 // StackPath accepts a trigger file path and returns the path of the stack
 // that is triggered by the given file. If the given file is not a stack trigger

--- a/stack/trigger/trigger.go
+++ b/stack/trigger/trigger.go
@@ -117,11 +117,11 @@ func ParseFile(path string) (Info, error) {
 			},
 			{
 				Name:     "type",
-				Required: true,
+				Required: false,
 			},
 			{
 				Name:     "context",
-				Required: true,
+				Required: false,
 			},
 		},
 	})

--- a/stack/trigger/trigger_test.go
+++ b/stack/trigger/trigger_test.go
@@ -115,6 +115,9 @@ func testTrigger(t *testing.T, tc testcase) {
 	assert.IsTrue(t, triggerInfo.Ctime > 0)
 	assert.IsTrue(t, triggerInfo.Ctime < math.MaxInt64)
 
+	assert.EqualStrings(t, trigger.DefaultContext, triggerInfo.Context)
+	assert.EqualStrings(t, trigger.DefaultType, triggerInfo.Type)
+
 	gotPath, ok := trigger.StackPath(project.PrjAbsPath(root.Dir(), triggerFile))
 
 	assert.IsTrue(t, ok)

--- a/stack/trigger/trigger_test.go
+++ b/stack/trigger/trigger_test.go
@@ -155,6 +155,13 @@ func TestTriggerParser(t *testing.T) {
 			),
 		},
 		{
+			name: "valid file (backward compatibility)",
+			body: Trigger(
+				Number("ctime", 1000000),
+				Str("reason", "something"),
+			),
+		},
+		{
 			name: "multiple trigger blocks - fails",
 			body: Doc(
 				Trigger(


### PR DESCRIPTION
# Reason for This Change

Introduce the fields `type` and `context` to the trigger file. They don't change any functionality but make room for future trigger features.

## Description of Changes

Added two fields to the trigger file and update tests.
