### PR TITLE
fix: multiple trigger parser issues (panics, errors ignored, etc)

### DIFF
--- a/stack/trigger/trigger.go
+++ b/stack/trigger/trigger.go
@@ -87,8 +87,8 @@ func ParseFile(path string) (Info, error) {
 		return Info{}, errors.E(ErrParsing, diags, "checking trigger block schema")
 	}
 
-	if len(rootContent.Blocks) == 0 {
-		return Info{}, errors.E(ErrParsing, "trigger block not found")
+	if len(rootContent.Blocks) != 1 {
+		return Info{}, errors.E(ErrParsing, "found %d blocks but expected 1")
 	}
 
 	triggerBlock := rootContent.Blocks[0]

--- a/stack/trigger/trigger_test.go
+++ b/stack/trigger/trigger_test.go
@@ -143,11 +143,33 @@ func TestTriggerParser(t *testing.T) {
 			err:  errors.E(trigger.ErrParsing),
 		},
 		{
-			name: "works",
+			name: "valid file",
 			body: Trigger(
 				Number("ctime", 1000000),
 				Str("reason", "something"),
 			),
+		},
+		{
+			name: "multiple trigger blocks - fails",
+			body: Doc(
+				Trigger(
+					Number("ctime", 1000000),
+					Str("reason", "1"),
+				),
+				Trigger(
+					Number("ctime", 2000000),
+					Str("reason", "2"),
+				),
+			),
+			err: errors.E(trigger.ErrParsing),
+		},
+		{
+			name: "unexpected block",
+			body: Block("strange",
+				Number("ctime", 1000000),
+				Str("reason", "something"),
+			),
+			err: errors.E(trigger.ErrParsing),
 		},
 		{
 			name: "invalid attribute",

--- a/stack/trigger/trigger_test.go
+++ b/stack/trigger/trigger_test.go
@@ -15,6 +15,7 @@
 package trigger_test
 
 import (
+	"fmt"
 	"math"
 	"path/filepath"
 	"testing"
@@ -26,6 +27,8 @@ import (
 	"github.com/mineiros-io/terramate/stack/trigger"
 	"github.com/mineiros-io/terramate/test"
 	errtest "github.com/mineiros-io/terramate/test/errors"
+	. "github.com/mineiros-io/terramate/test/hclwrite/hclutils"
+
 	"github.com/mineiros-io/terramate/test/sandbox"
 	"github.com/rs/zerolog"
 )
@@ -119,6 +122,71 @@ func testTrigger(t *testing.T, tc testcase) {
 
 	assert.IsTrue(t, ok)
 	assert.EqualStrings(t, tc.path, gotPath.String())
+}
+
+func TestTriggerParser(t *testing.T) {
+	t.Parallel()
+	type testcase struct {
+		name string
+		body fmt.Stringer
+		err  error
+	}
+	for _, tc := range []testcase{
+		{
+			name: "no config",
+			body: Doc(),
+			err:  errors.E(trigger.ErrParsing),
+		},
+		{
+			name: "missing required attributes",
+			body: Trigger(),
+			err:  errors.E(trigger.ErrParsing),
+		},
+		{
+			name: "works",
+			body: Trigger(
+				Number("ctime", 1000000),
+				Str("reason", "something"),
+			),
+		},
+		{
+			name: "invalid attribute",
+			body: Trigger(
+				Number("ctime", 1000000),
+				Str("reason", "something"),
+				Str("invalid", "value"),
+			),
+			err: errors.E(trigger.ErrParsing),
+		},
+		{
+			name: "ctime not number",
+			body: Trigger(
+				Str("ctime", "1000000"),
+				Str("reason", "something"),
+			),
+			err: errors.E(trigger.ErrParsing),
+		},
+		{
+			name: "funcall not supported",
+			body: Trigger(
+				Str("ctime", "1000000"),
+				Expr("reason", `tm_title("something")`),
+			),
+			err: errors.E(trigger.ErrParsing),
+		},
+		{
+			name: "reason not string",
+			body: Trigger(
+				Str("ctime", "1000000"),
+				Expr("reason", `["wrong"]`),
+			),
+			err: errors.E(trigger.ErrParsing),
+		},
+	} {
+		file := test.WriteFile(t, t.TempDir(), "test-trigger.hcl", tc.body.String())
+		_, err := trigger.ParseFile(file)
+		errtest.Assert(t, err, tc.err, "when parsing: %s", tc.body)
+	}
 }
 
 func init() {

--- a/test/errors/errors.go
+++ b/test/errors/errors.go
@@ -16,6 +16,7 @@
 package errors
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/mineiros-io/terramate/errors"
@@ -52,10 +53,16 @@ func AssertIsKind(t *testing.T, err error, k errors.Kind) {
 }
 
 // Assert err is (contains, wraps, etc) target.
-func Assert(t *testing.T, err, target error) {
+func Assert(t *testing.T, err, target error, args ...interface{}) {
 	t.Helper()
+	fmtctx := ""
+
+	if len(args) > 0 {
+		fmtctx = fmt.Sprintf(args[0].(string), args[1:]...)
+	}
+
 	if !errors.Is(err, target) {
-		t.Fatalf("error[%s] is not target[%s]", errstr(err), errstr(target))
+		t.Fatalf("error[%s] is not target[%s]%s", errstr(err), errstr(target), fmtctx)
 	}
 }
 

--- a/test/hclwrite/hclutils/utils.go
+++ b/test/hclwrite/hclutils/utils.go
@@ -172,6 +172,11 @@ func Assert(builders ...hclwrite.BlockBuilder) *hclwrite.Block {
 	return Block("assert", builders...)
 }
 
+// Trigger is a helper for a "trigger" block.
+func Trigger(builders ...hclwrite.BlockBuilder) *hclwrite.Block {
+	return Block("trigger", builders...)
+}
+
 // EvalExpr accepts an expr as the attribute value, similar to Expr,
 // but will evaluate the expr and store the resulting value so
 // it will be available as an attribute value instead of as an


### PR DESCRIPTION
# Reason for This Change

The Terramate panics (no trigger block) or ignores errors (wrong attribute types) with malformed trigger files.

## Description of Changes

Fixed the parser and added tests.
