### PR TITLE
chore: remove the hcl.StackID type.

### DIFF
--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -1283,8 +1283,8 @@ func (c *cli) printMetadata() {
 			Msg("Print metadata for individual stack.")
 
 		c.output.MsgStdOut("\nstack %q:", stack.Dir())
-		if id, ok := stack.ID(); ok {
-			c.output.MsgStdOut("\tterramate.stack.id=%q", id)
+		if stack.ID != "" {
+			c.output.MsgStdOut("\tterramate.stack.id=%q", stack.ID)
 		}
 		c.output.MsgStdOut("\tterramate.stack.name=%q", stack.Name())
 		c.output.MsgStdOut("\tterramate.stack.description=%q", stack.Desc())

--- a/cmd/terramate/e2etests/create_test.go
+++ b/cmd/terramate/e2etests/create_test.go
@@ -97,8 +97,7 @@ func TestCreateStack(t *testing.T) {
 		absStackPath := filepath.Join(s.RootDir(), filepath.FromSlash(stackPath))
 		got := s.LoadStack(project.PrjAbsPath(s.RootDir(), absStackPath))
 
-		gotID, _ := got.ID()
-		assert.EqualStrings(t, stackID, gotID)
+		assert.EqualStrings(t, stackID, got.ID)
 		assert.EqualStrings(t, stackName, got.Name(), "checking stack name")
 		assert.EqualStrings(t, stackDescription, got.Desc(), "checking stack description")
 		test.AssertDiff(t, got.After(), []string{stackAfter1, stackAfter2}, "created stack has invalid after")
@@ -133,9 +132,7 @@ func TestCreateStackDefaults(t *testing.T) {
 		t.Fatalf("want no before, got: %v", got.Before())
 	}
 
-	// By default the CLI generates an id with an UUID
-	gotID, _ := got.ID()
-	_, err := uuid.Parse(gotID)
+	_, err := uuid.Parse(got.ID)
 	assert.NoError(t, err, "validating default UUID")
 
 	test.AssertStackImports(t, s.RootDir(), got.HostDir(s.Config()), []string{})

--- a/cmd/terramate/e2etests/create_test.go
+++ b/cmd/terramate/e2etests/create_test.go
@@ -132,6 +132,7 @@ func TestCreateStackDefaults(t *testing.T) {
 		t.Fatalf("want no before, got: %v", got.Before())
 	}
 
+	// By default the CLI generates an id with an UUID
 	_, err := uuid.Parse(got.ID)
 	assert.NoError(t, err, "validating default UUID")
 

--- a/cmd/terramate/e2etests/exp_clone_test.go
+++ b/cmd/terramate/e2etests/exp_clone_test.go
@@ -77,24 +77,20 @@ generate_hcl "test2.hcl" {
 
 	destdir := filepath.Join(s.RootDir(), destStack)
 	cfg := test.ParseTerramateConfig(t, destdir)
-
 	if cfg.Stack == nil {
 		t.Fatalf("cloned stack has no stack block: %v", cfg)
 	}
-
-	clonedStackID, ok := cfg.Stack.ID.Value()
-	if !ok {
+	if cfg.Stack.ID == "" {
 		t.Fatalf("cloned stack has no ID: %v", cfg.Stack)
 	}
-
-	if clonedStackID == stackID {
-		t.Fatalf("want cloned stack to have different ID, got %s == %s", clonedStackID, stackID)
+	if cfg.Stack.ID == stackID {
+		t.Fatalf("want cloned stack to have different ID, got %s == %s", cfg.Stack.ID, stackID)
 	}
 
 	assert.EqualStrings(t, stackName, cfg.Stack.Name)
 	assert.EqualStrings(t, stackDesc, cfg.Stack.Description)
 
-	want := fmt.Sprintf(stackCfgTemplate, clonedStackID, stackName, stackDesc)
+	want := fmt.Sprintf(stackCfgTemplate, cfg.Stack.ID, stackName, stackDesc)
 
 	clonedStackEntry := s.DirEntry(destStack)
 	got := string(clonedStackEntry.ReadFile(stackCfgFilename))

--- a/hcl/hcl.go
+++ b/hcl/hcl.go
@@ -261,9 +261,7 @@ type TerramateParser struct {
 
 var stackIDRegex = regexp.MustCompile("^[a-zA-Z0-9_-]{1,64}$")
 
-// ValidateStackID creates a new StackID with the given string as its id.
-// It guarantees that the id passed is a valid StackID value,
-// an error is returned otherwise.
+// ValidateStackID validates if the given id is a valid stack id.
 func ValidateStackID(id string) error {
 	if !stackIDRegex.MatchString(id) {
 		return errors.E("Stack ID %q doesn't match %q", id, stackIDRegex)

--- a/hcl/hcl_stack_test.go
+++ b/hcl/hcl_stack_test.go
@@ -53,11 +53,11 @@ func TestHCLParserStackID(t *testing.T) {
 			}
 			`, id)
 	}
-	newStackID := func(id string) hcl.StackID {
+	newStackID := func(id string) string {
 		t.Helper()
-		v, err := hcl.NewStackID(id)
+		err := hcl.ValidateStackID(id)
 		assert.NoError(t, err)
-		return v
+		return id
 	}
 
 	for _, validID := range validIDs {

--- a/hcl/printer.go
+++ b/hcl/printer.go
@@ -106,8 +106,8 @@ func PrintConfig(w io.Writer, cfg Config) error {
 			stackBody.SetAttributeValue("watch", cty.SetVal(listToValue(stack.Watch)))
 		}
 
-		if id, ok := stack.ID.Value(); ok {
-			stackBody.SetAttributeValue("id", cty.StringVal(id))
+		if stack.ID != "" {
+			stackBody.SetAttributeValue("id", cty.StringVal(stack.ID))
 		}
 	}
 

--- a/stack/clone.go
+++ b/stack/clone.go
@@ -78,7 +78,7 @@ func Clone(root *config.Root, destdir, srcdir string) error {
 		return err
 	}
 
-	if _, ok := srcStack.ID(); !ok {
+	if srcStack.ID == "" {
 		logger.Trace().Msg("stack has no ID, nothing else to do")
 		return nil
 	}
@@ -155,7 +155,7 @@ updateStackID:
 		body := block.Body()
 		attrs := body.Attributes()
 		for name := range attrs {
-			if name != hcl.StackIDField {
+			if name != "id" {
 				continue
 			}
 

--- a/stack/clone_test.go
+++ b/stack/clone_test.go
@@ -200,19 +200,18 @@ generate_hcl "test2.hcl" {
 		t.Fatalf("cloned stack has no stack block: %v", cfg)
 	}
 
-	clonedStackID, ok := cfg.Stack.ID.Value()
-	if !ok {
+	if cfg.Stack.ID == "" {
 		t.Fatalf("cloned stack has no ID: %v", cfg.Stack)
 	}
 
-	if clonedStackID == stackID {
-		t.Fatalf("want cloned stack to have different ID, got %s == %s", clonedStackID, stackID)
+	if cfg.Stack.ID == stackID {
+		t.Fatalf("want cloned stack to have different ID, got %s == %s", cfg.Stack.ID, stackID)
 	}
 
 	assert.EqualStrings(t, stackName, cfg.Stack.Name)
 	assert.EqualStrings(t, stackDesc, cfg.Stack.Description)
 
-	want := fmt.Sprintf(stackCfgTemplate, clonedStackID, stackName, stackDesc)
+	want := fmt.Sprintf(stackCfgTemplate, cfg.Stack.ID, stackName, stackDesc)
 
 	clonedStackEntry := s.DirEntry("cloned-stack")
 	got := string(clonedStackEntry.ReadFile(stackCfgFilename))

--- a/stack/create.go
+++ b/stack/create.go
@@ -130,11 +130,11 @@ func Create(root *config.Root, cfg CreateCfg) (err error) {
 	}
 
 	if cfg.ID != "" {
-		stackID, err := hcl.NewStackID(cfg.ID)
+		err := hcl.ValidateStackID(cfg.ID)
 		if err != nil {
 			return errors.E(ErrInvalidStackID, err)
 		}
-		stackCfg.ID = stackID
+		stackCfg.ID = cfg.ID
 	}
 
 	tmCfg, err := hcl.NewConfig(cfg.Dir)

--- a/stack/create_test.go
+++ b/stack/create_test.go
@@ -30,7 +30,7 @@ import (
 
 func TestStackCreation(t *testing.T) {
 	type wantedStack struct {
-		id      hcl.StackID
+		id      string
 		name    string
 		desc    string
 		imports []string
@@ -48,10 +48,10 @@ func TestStackCreation(t *testing.T) {
 		want   want
 	}
 
-	newID := func(id string) hcl.StackID {
-		sid, err := hcl.NewStackID(id)
+	newID := func(id string) string {
+		err := hcl.ValidateStackID(id)
 		assert.NoError(t, err)
-		return sid
+		return id
 	}
 
 	testcases := []testcase{
@@ -239,15 +239,12 @@ func TestStackCreation(t *testing.T) {
 			dir := project.PrjAbsPath(s.RootDir(), tc.create.Dir)
 			got := s.LoadStack(dir)
 
-			if wantID, ok := want.id.Value(); ok {
-				gotID, _ := got.ID()
-				assert.EqualStrings(t, wantID, gotID)
-			} else {
-				gotID, ok := got.ID()
-				if ok {
-					t.Fatalf("got unwanted ID %q", gotID)
-				}
+			if want.id != "" {
+				assert.EqualStrings(t, want.id, got.ID)
+			} else if got.ID != "" {
+				t.Fatalf("got unwanted ID %q", got.ID)
 			}
+
 			assert.EqualStrings(t, want.name, got.Name(), "checking stack name")
 			assert.EqualStrings(t, want.desc, got.Desc(), "checking stack description")
 

--- a/test/sandbox/sandbox.go
+++ b/test/sandbox/sandbox.go
@@ -624,9 +624,9 @@ func buildTree(t testing.TB, root *config.Root, layout []string) {
 			value := parts[1]
 			switch name {
 			case "id":
-				id, err := hcl.NewStackID(value)
+				err := hcl.ValidateStackID(value)
 				assert.NoError(t, err, "invalid stack ID on stack descriptor")
-				cfg.Stack.ID = id
+				cfg.Stack.ID = value
 			case "after":
 				cfg.Stack.After = parseListSpec(t, name, value)
 			case "before":


### PR DESCRIPTION
# Reason for This Change

We can use `stack.ID` as a plain string because the `id` cannot be empty and then we can check if the string is empty to figure out if it was set or not.

## Description of Changes

Remove the hcl.StackID type and use a string for the ID type.
