### PR TITLE
feat: add --tags filter to multiple commands

### DIFF
--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -27,6 +27,7 @@ import (
 	hhcl "github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/mineiros-io/terramate/cmd/terramate/cli/out"
+	"github.com/mineiros-io/terramate/config/filter"
 	"github.com/mineiros-io/terramate/errors"
 	"github.com/mineiros-io/terramate/errors/errlog"
 	"github.com/mineiros-io/terramate/event"
@@ -90,6 +91,7 @@ type cliSpec struct {
 	Chdir          string   `short:"C" optional:"true" predictor:"file" help:"Sets working directory"`
 	GitChangeBase  string   `short:"B" optional:"true" help:"Git base ref for computing changes"`
 	Changed        bool     `short:"c" optional:"true" help:"Filter by changed infrastructure"`
+	Tags           []string `short:"c" optional:"true" help:"Filter by tags"`
 	LogLevel       string   `optional:"true" default:"warn" enum:"disabled,trace,debug,info,warn,error,fatal" help:"Log level to use: 'disabled', 'trace', 'debug', 'info', 'warn', 'error', or 'fatal'"`
 	LogFmt         string   `optional:"true" default:"console" enum:"console,text,json" help:"Log format to use: 'console', 'text', or 'json'"`
 	LogDestination string   `optional:"true" default:"stderr" enum:"stderr,stdout" help:"Destination of log messages"`
@@ -966,7 +968,9 @@ func (c *cli) printStacks() {
 
 	c.gitFileSafeguards(report.Checks, false)
 
-	for _, entry := range report.Stacks {
+	stacks := c.filterStacks(report.Stacks)
+
+	for _, entry := range stacks {
 		stack := entry.Stack
 
 		log.Debug().Msgf("printing stack %s", stack.Dir)
@@ -991,7 +995,7 @@ func (c *cli) printRunEnv() {
 		fatal(err, "listing stacks")
 	}
 
-	for _, stackEntry := range c.filterStacksByWorkingDir(report.Stacks) {
+	for _, stackEntry := range c.filterStacks(report.Stacks) {
 		envVars, err := run.LoadEnv(c.cfg(), stackEntry.Stack)
 		if err != nil {
 			fatal(err, "loading stack run environment")
@@ -1230,7 +1234,7 @@ func (c *cli) printStacksGlobals() {
 		fatal(err, "listing stacks globals: listing stacks")
 	}
 
-	for _, stackEntry := range c.filterStacksByWorkingDir(report.Stacks) {
+	for _, stackEntry := range c.filterStacks(report.Stacks) {
 		stack := stackEntry.Stack
 		report := globals.ForStack(c.cfg(), stack)
 		if err := report.AsError(); err != nil {
@@ -1267,8 +1271,7 @@ func (c *cli) printMetadata() {
 		fatal(err, "loading metadata: listing stacks")
 	}
 
-	stackEntries := c.filterStacksByWorkingDir(report.Stacks)
-
+	stackEntries := c.filterStacks(report.Stacks)
 	if len(stackEntries) == 0 {
 		return
 	}
@@ -1606,7 +1609,7 @@ func (c *cli) computeSelectedStacks(ensureCleanRepo bool) (config.List[*config.S
 
 	logger.Trace().Msg("Filter stacks by working directory.")
 
-	entries := c.filterStacksByWorkingDir(report.Stacks)
+	entries := c.filterStacks(report.Stacks)
 	stacks := make(config.List[*config.SortableStack], len(entries))
 	for i, e := range entries {
 		stacks[i] = e.Stack.Sortable()
@@ -1619,17 +1622,12 @@ func (c *cli) computeSelectedStacks(ensureCleanRepo bool) (config.List[*config.S
 	return stacks, nil
 }
 
+func (c *cli) filterStacks(stacks []terramate.Entry) []terramate.Entry {
+	return c.filterStacksByTags(c.filterStacksByWorkingDir(stacks))
+}
+
 func (c *cli) filterStacksByWorkingDir(stacks []terramate.Entry) []terramate.Entry {
-	logger := log.With().
-		Str("action", "filterStacksByWorkingDir()").
-		Str("workingDir", c.wd()).
-		Logger()
-
-	logger.Trace().Msg("Get relative working directory.")
-
 	relwd := prj.PrjAbsPath(c.rootdir(), c.wd())
-
-	logger.Trace().Msg("Get filtered stacks.")
 
 	filtered := []terramate.Entry{}
 	for _, e := range stacks {
@@ -1638,6 +1636,19 @@ func (c *cli) filterStacksByWorkingDir(stacks []terramate.Entry) []terramate.Ent
 		}
 	}
 
+	return filtered
+}
+
+func (c *cli) filterStacksByTags(entries []terramate.Entry) []terramate.Entry {
+	if len(c.parsedArgs.Tags) == 0 {
+		return entries
+	}
+	filtered := []terramate.Entry{}
+	for _, entry := range entries {
+		if filter.MatchTags(c.parsedArgs.Tags, entry.Stack.Tags) {
+			filtered = append(filtered, entry)
+		}
+	}
 	return filtered
 }
 

--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -91,7 +91,7 @@ type cliSpec struct {
 	Chdir          string   `short:"C" optional:"true" predictor:"file" help:"Sets working directory"`
 	GitChangeBase  string   `short:"B" optional:"true" help:"Git base ref for computing changes"`
 	Changed        bool     `short:"c" optional:"true" help:"Filter by changed infrastructure"`
-	Tags           []string `short:"c" optional:"true" help:"Filter by tags"`
+	Tags           []string `optional:"true" sep:"none" help:"Filter stacks by tags. Use \":\" for logical AND and \",\" for logical OR. Example: --tags app:prod filters stacks containing tag \"app\" AND \"prod\". If multiple --tags are provided, an OR expression is created. Example: \"--tags A --tags B\" is the same as \"--tags A,B\""`
 	LogLevel       string   `optional:"true" default:"warn" enum:"disabled,trace,debug,info,warn,error,fatal" help:"Log level to use: 'disabled', 'trace', 'debug', 'info', 'warn', 'error', or 'fatal'"`
 	LogFmt         string   `optional:"true" default:"console" enum:"console,text,json" help:"Log format to use: 'console', 'text', or 'json'"`
 	LogDestination string   `optional:"true" default:"stderr" enum:"stderr,stdout" help:"Destination of log messages"`

--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -1437,7 +1437,7 @@ func envVarIsSet(val string) bool {
 	return val != "0" && val != "false"
 }
 
-func (c *cli) checkOutdatedGeneratedCode(stacks config.List[*config.SortableStack]) {
+func (c *cli) checkOutdatedGeneratedCode() {
 	logger := log.With().
 		Str("action", "checkOutdatedGeneratedCode()").
 		Logger()
@@ -1501,12 +1501,7 @@ func (c *cli) runOnStacks() {
 		logger.Fatal().Msgf("run expects a cmd")
 	}
 
-	allstacks, err := config.LoadAllStacks(c.cfg().Tree())
-	if err != nil {
-		fatal(err, "failed to list stacks")
-	}
-
-	c.checkOutdatedGeneratedCode(allstacks)
+	c.checkOutdatedGeneratedCode()
 
 	var stacks config.List[*config.SortableStack]
 	if c.parsedArgs.Run.NoRecursive {

--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -968,9 +968,7 @@ func (c *cli) printStacks() {
 
 	c.gitFileSafeguards(report.Checks, false)
 
-	stacks := c.filterStacks(report.Stacks)
-
-	for _, entry := range stacks {
+	for _, entry := range c.filterStacks(report.Stacks) {
 		stack := entry.Stack
 
 		log.Debug().Msgf("printing stack %s", stack.Dir)

--- a/cmd/terramate/e2etests/list_git_test.go
+++ b/cmd/terramate/e2etests/list_git_test.go
@@ -34,7 +34,11 @@ func TestE2EListWithGit(t *testing.T) {
 			s.BuildTree(tc.layout)
 
 			cli := newCLI(t, s.RootDir())
-			assertRunResult(t, cli.listStacks(), tc.want)
+			var args []string
+			for _, filter := range tc.filterTags {
+				args = append(args, "--tags", filter)
+			}
+			assertRunResult(t, cli.listStacks(args...), tc.want)
 		})
 	}
 }

--- a/cmd/terramate/e2etests/list_nongit_test.go
+++ b/cmd/terramate/e2etests/list_nongit_test.go
@@ -33,7 +33,11 @@ func TestE2EListNonGit(t *testing.T) {
 			test.WriteRootConfig(t, s.RootDir())
 
 			cli := newCLI(t, s.RootDir())
-			assertRunResult(t, cli.listStacks(), tc.want)
+			var args []string
+			for _, filter := range tc.filterTags {
+				args = append(args, "--tags", filter)
+			}
+			assertRunResult(t, cli.listStacks(args...), tc.want)
 		})
 	}
 }

--- a/cmd/terramate/e2etests/list_test.go
+++ b/cmd/terramate/e2etests/list_test.go
@@ -219,6 +219,16 @@ func listTestcases() []testcase {
 			},
 		},
 		{
+			name: "stack.tags with digit in the end - works",
+			layout: []string{
+				`s:stack:tags=["a1", "b100", "c-1", "d_1"]`,
+			},
+			filterTags: []string{"a1"},
+			want: runExpected{
+				Stdout: listStacks("stack"),
+			},
+		},
+		{
 			name: "all stacks containing the tag `a`",
 			layout: []string{
 				`s:a:tags=["a", "b", "c", "d"]`,

--- a/cmd/terramate/e2etests/list_test.go
+++ b/cmd/terramate/e2etests/list_test.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/mineiros-io/terramate/config"
 	"github.com/mineiros-io/terramate/hcl"
 	"github.com/mineiros-io/terramate/test"
 	"github.com/mineiros-io/terramate/test/sandbox"
@@ -171,6 +172,62 @@ dir/c
 			},
 		},
 		{
+			name:   "invalid stack.tags - starting with number - fails+",
+			layout: []string{`s:stack:tags=["123abc"]`},
+			want: runExpected{
+				StderrRegex: string(config.ErrStackInvalidTag),
+				Status:      1,
+			},
+		},
+		{
+			name:   "invalid stack.tags - starting with uppercase - fails",
+			layout: []string{`s:stack:tags=["Abc"]`},
+			want: runExpected{
+				StderrRegex: string(config.ErrStackInvalidTag),
+				Status:      1,
+			},
+		},
+		{
+			name:   "invalid stack.tags - starting with underscore - fails",
+			layout: []string{`s:stack:tags=["_test"]`},
+			want: runExpected{
+				StderrRegex: string(config.ErrStackInvalidTag),
+				Status:      1,
+			},
+		},
+		{
+			name:   "invalid stack.tags - starting with dash - fails",
+			layout: []string{`s:stack:tags=["-test"]`},
+			want: runExpected{
+				StderrRegex: string(config.ErrStackInvalidTag),
+				Status:      1,
+			},
+		},
+		{
+			name:   "invalid stack.tags - uppercase - fails",
+			layout: []string{`s:stack:tags=["thisIsInvalid"]`},
+			want: runExpected{
+				StderrRegex: string(config.ErrStackInvalidTag),
+				Status:      1,
+			},
+		},
+		{
+			name:   "invalid stack.tags - dash in the end - fails",
+			layout: []string{`s:stack:tags=["invalid-"]`},
+			want: runExpected{
+				StderrRegex: string(config.ErrStackInvalidTag),
+				Status:      1,
+			},
+		},
+		{
+			name:   "invalid stack.tags - underscore in the end - fails",
+			layout: []string{`s:stack:tags=["invalid_"]`},
+			want: runExpected{
+				StderrRegex: string(config.ErrStackInvalidTag),
+				Status:      1,
+			},
+		},
+		{
 			name: "all stacks containing the tag `a`",
 			layout: []string{
 				`s:a:tags=["a", "b", "c", "d"]`,
@@ -249,6 +306,20 @@ dir/c
 				Stdout: `a
 b
 dir/d
+`,
+			},
+		},
+		{
+			name: "filters work with dash and underscore tags",
+			layout: []string{
+				`s:stack-a:tags=["terra-mate", "terra_mate"]`,
+				`s:stack-b:tags=["terra_mate"]`,
+				`s:no-tag-stack`,
+			},
+			filterTags: []string{"terra-mate,terra_mate"},
+			want: runExpected{
+				Stdout: `stack-a
+stack-b
 `,
 			},
 		},

--- a/cmd/terramate/e2etests/list_test.go
+++ b/cmd/terramate/e2etests/list_test.go
@@ -171,7 +171,7 @@ dir/c
 			},
 		},
 		{
-			name: "multiple stacks matches subset of their tags",
+			name: "all stacks containing the tag `a`",
 			layout: []string{
 				`s:a:tags=["a", "b", "c", "d"]`,
 				`s:b:tags=["a", "b"]`,
@@ -188,7 +188,7 @@ dir/c
 			},
 		},
 		{
-			name: "matching stacks with AND operation",
+			name: "all stacks containing tags `a && b`",
 			layout: []string{
 				`s:a:tags=["a", "b", "c", "d"]`,
 				`s:b:tags=["a", "b"]`,
@@ -204,7 +204,7 @@ b
 			},
 		},
 		{
-			name: "matching stacks with a:b:c operation",
+			name: "all stacks containing the tags `a && b && c`",
 			layout: []string{
 				`s:a:tags=["a", "b", "c", "d"]`,
 				`s:b:tags=["a", "b"]`,
@@ -219,7 +219,7 @@ b
 			},
 		},
 		{
-			name: "matching stacks with a,b",
+			name: "all stacks containing tag `a || b`",
 			layout: []string{
 				`s:a:tags=["a", "b", "c", "d"]`,
 				`s:b:tags=["a", "b"]`,
@@ -236,7 +236,7 @@ dir/c
 			},
 		},
 		{
-			name: "matching stacks with a:b,c:d",
+			name: "all stacks containing tags `a && b || c && d`",
 			layout: []string{
 				`s:a:tags=["a", "b", "c", "d"]`,
 				`s:b:tags=["a", "b"]`,

--- a/cmd/terramate/e2etests/list_test.go
+++ b/cmd/terramate/e2etests/list_test.go
@@ -323,6 +323,23 @@ stack-b
 `,
 			},
 		},
+		{
+			name: "multiple --tags makes an OR clause with all flag values",
+			layout: []string{
+				`s:stack-a:tags=["terra-mate", "terra_mate"]`,
+				`s:stack-b:tags=["terra_mate"]`,
+				`s:no-tag-stack`,
+			},
+			filterTags: []string{
+				"terra-mate",
+				"terra_mate",
+			},
+			want: runExpected{
+				Stdout: `stack-a
+stack-b
+`,
+			},
+		},
 	}
 }
 

--- a/cmd/terramate/e2etests/list_test.go
+++ b/cmd/terramate/e2etests/list_test.go
@@ -15,7 +15,6 @@
 package e2etest
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/mineiros-io/terramate/config"
@@ -70,7 +69,7 @@ func listTestcases() []testcase {
 			name:   "single stack",
 			layout: []string{"s:stack"},
 			want: runExpected{
-				Stdout: "stack\n",
+				Stdout: listStacks("stack"),
 			},
 		},
 		{
@@ -87,7 +86,7 @@ func listTestcases() []testcase {
 				"d:waste/directories",
 			},
 			want: runExpected{
-				Stdout: "there/is/a/very/deep/hidden/stack/here\n",
+				Stdout: listStacks("there/is/a/very/deep/hidden/stack/here"),
 			},
 		},
 		{
@@ -96,7 +95,7 @@ func listTestcases() []testcase {
 				"s:1", "s:2", "s:3",
 			},
 			want: runExpected{
-				Stdout: "1\n2\n3\n",
+				Stdout: listStacks("1", "2", "3"),
 			},
 		},
 		{
@@ -106,7 +105,7 @@ func listTestcases() []testcase {
 				"s:stack/child-stack",
 			},
 			want: runExpected{
-				Stdout: "stack\nstack/child-stack\n",
+				Stdout: listStacks("stack", "stack/child-stack"),
 			},
 		},
 		{
@@ -123,7 +122,7 @@ func listTestcases() []testcase {
 				"s:mineiros.io/departments/engineering/tests/e2e",
 			},
 			want: runExpected{
-				Stdout: strings.Join([]string{
+				Stdout: listStacks(
 					"mineiros.io",
 					"mineiros.io/departments",
 					"mineiros.io/departments/accounting",
@@ -131,7 +130,7 @@ func listTestcases() []testcase {
 					"mineiros.io/departments/engineering/terraform-modules",
 					"mineiros.io/departments/engineering/terramate",
 					"mineiros.io/departments/engineering/tests/e2e",
-				}, "\n") + "\n",
+				),
 			},
 		},
 		{
@@ -146,12 +145,7 @@ func listTestcases() []testcase {
 				"s:3/x/y/z",
 			},
 			want: runExpected{
-				Stdout: `1
-2
-3/x/y/z
-x/b
-z/a
-`,
+				Stdout: listStacks("1", "2", "3/x/y/z", "x/b", "z/a"),
 			},
 		},
 		{
@@ -165,10 +159,7 @@ z/a
 			},
 			filterTags: []string{"abc"},
 			want: runExpected{
-				Stdout: `a
-b
-dir/c
-`,
+				Stdout: listStacks("a", "b", "dir/c"),
 			},
 		},
 		{
@@ -238,10 +229,7 @@ dir/c
 			},
 			filterTags: []string{"a"},
 			want: runExpected{
-				Stdout: `a
-b
-dir/c
-`,
+				Stdout: listStacks("a", "b", "dir/c"),
 			},
 		},
 		{
@@ -255,9 +243,7 @@ dir/c
 			},
 			filterTags: []string{"a:b"},
 			want: runExpected{
-				Stdout: `a
-b
-`,
+				Stdout: listStacks("a", "b"),
 			},
 		},
 		{
@@ -271,8 +257,7 @@ b
 			},
 			filterTags: []string{"a:b:c"},
 			want: runExpected{
-				Stdout: `a
-`,
+				Stdout: listStacks("a"),
 			},
 		},
 		{
@@ -286,10 +271,7 @@ b
 			},
 			filterTags: []string{"a,b"},
 			want: runExpected{
-				Stdout: `a
-b
-dir/c
-`,
+				Stdout: listStacks("a", "b", "dir/c"),
 			},
 		},
 		{
@@ -303,10 +285,7 @@ dir/c
 			},
 			filterTags: []string{"a:b,c:d"},
 			want: runExpected{
-				Stdout: `a
-b
-dir/d
-`,
+				Stdout: listStacks("a", "b", "dir/d"),
 			},
 		},
 		{
@@ -318,9 +297,7 @@ dir/d
 			},
 			filterTags: []string{"terra-mate,terra_mate"},
 			want: runExpected{
-				Stdout: `stack-a
-stack-b
-`,
+				Stdout: listStacks("stack-a", "stack-b"),
 			},
 		},
 		{
@@ -335,9 +312,7 @@ stack-b
 				"terra_mate",
 			},
 			want: runExpected{
-				Stdout: `stack-a
-stack-b
-`,
+				Stdout: listStacks("stack-a", "stack-b"),
 			},
 		},
 	}

--- a/cmd/terramate/e2etests/list_test.go
+++ b/cmd/terramate/e2etests/list_test.go
@@ -24,9 +24,10 @@ import (
 )
 
 type testcase struct {
-	name   string
-	layout []string
-	want   runExpected
+	name       string
+	layout     []string
+	filterTags []string
+	want       runExpected
 }
 
 func listTestcases() []testcase {
@@ -149,6 +150,105 @@ func listTestcases() []testcase {
 3/x/y/z
 x/b
 z/a
+`,
+			},
+		},
+		{
+			name: "multiple stacks filtered by same tag",
+			layout: []string{
+				`s:a:tags=["abc"]`,
+				`s:b:tags=["abc"]`,
+				`s:dir/c:tags=["abc"]`,
+				`s:dir/d`,
+				`s:dir/subdir/e`,
+			},
+			filterTags: []string{"abc"},
+			want: runExpected{
+				Stdout: `a
+b
+dir/c
+`,
+			},
+		},
+		{
+			name: "multiple stacks matches subset of their tags",
+			layout: []string{
+				`s:a:tags=["a", "b", "c", "d"]`,
+				`s:b:tags=["a", "b"]`,
+				`s:dir/c:tags=["a"]`,
+				`s:dir/d`,
+				`s:dir/subdir/e`,
+			},
+			filterTags: []string{"a"},
+			want: runExpected{
+				Stdout: `a
+b
+dir/c
+`,
+			},
+		},
+		{
+			name: "matching stacks with AND operation",
+			layout: []string{
+				`s:a:tags=["a", "b", "c", "d"]`,
+				`s:b:tags=["a", "b"]`,
+				`s:dir/c:tags=["a"]`,
+				`s:dir/d:tags=["c", "d"]`,
+				`s:dir/subdir/e`,
+			},
+			filterTags: []string{"a:b"},
+			want: runExpected{
+				Stdout: `a
+b
+`,
+			},
+		},
+		{
+			name: "matching stacks with a:b:c operation",
+			layout: []string{
+				`s:a:tags=["a", "b", "c", "d"]`,
+				`s:b:tags=["a", "b"]`,
+				`s:dir/c:tags=["a"]`,
+				`s:dir/d:tags=["c", "d"]`,
+				`s:dir/subdir/e`,
+			},
+			filterTags: []string{"a:b:c"},
+			want: runExpected{
+				Stdout: `a
+`,
+			},
+		},
+		{
+			name: "matching stacks with a,b",
+			layout: []string{
+				`s:a:tags=["a", "b", "c", "d"]`,
+				`s:b:tags=["a", "b"]`,
+				`s:dir/c:tags=["a"]`,
+				`s:dir/d:tags=["c", "d"]`,
+				`s:dir/subdir/e`,
+			},
+			filterTags: []string{"a,b"},
+			want: runExpected{
+				Stdout: `a
+b
+dir/c
+`,
+			},
+		},
+		{
+			name: "matching stacks with a:b,c:d",
+			layout: []string{
+				`s:a:tags=["a", "b", "c", "d"]`,
+				`s:b:tags=["a", "b"]`,
+				`s:dir/c:tags=["a"]`,
+				`s:dir/d:tags=["c", "d"]`,
+				`s:dir/subdir/e`,
+			},
+			filterTags: []string{"a:b,c:d"},
+			want: runExpected{
+				Stdout: `a
+b
+dir/d
 `,
 			},
 		},

--- a/cmd/terramate/e2etests/run_test.go
+++ b/cmd/terramate/e2etests/run_test.go
@@ -1151,6 +1151,50 @@ func TestRunWantedBy(t *testing.T) {
 				),
 			},
 		},
+		{
+			name: "selected wantedBy stacks not filtered by tags",
+			layout: []string{
+				`s:stack:tags=["dev"];wanted_by=["/all"]`,
+				`s:all/test/1:tags=["prod"]`,
+				`s:all/test2/2`,
+				`s:all/something/3`,
+			},
+			wd:         "/all/test/1",
+			filterTags: []string{"prod"},
+			want: runExpected{
+				Stdout: listStacks(
+					"/all/test/1",
+					"/stack",
+				),
+			},
+		},
+		{
+			name: "wantedBy computed after stack filtering",
+			layout: []string{
+				`s:stack:tags=["prod"];wanted_by=["/other-stack"]`,
+				`s:other-stack`,
+			},
+			wd:         "/other-stack",
+			filterTags: []string{"prod"},
+			want: runExpected{
+				Stdout: "",
+			},
+		},
+		{
+			name: "wantedBy computed after -C and tag filtering",
+			layout: []string{
+				`s:stacks/stack-a:tags=["dev"];wanted_by=["/other-stack"]`,
+				`s:stacks/stack-b:tags=["prod"]`,
+				`s:stack-c:tags=["prod"]`,
+			},
+			wd:         "/stacks",
+			filterTags: []string{"prod"},
+			want: runExpected{
+				Stdout: listStacks(
+					"/stacks/stack-b",
+				),
+			},
+		},
 	} {
 		testRunSelection(t, tc)
 	}

--- a/config/filter/filter.go
+++ b/config/filter/filter.go
@@ -109,14 +109,15 @@ func parseTagClauses(filters ...string) (TagClause, bool) {
 
 // parseTagClause parses the tag-filter syntax defined below:
 //
-//   EXPR    = TAGNAME [ OP EXPR]
-//   TAGNAME = <string>
-//   OP      = ":" | ","
+//	EXPR    = TAGNAME [ OP EXPR]
+//	TAGNAME = <string>
+//	OP      = ":" | ","
 //
 // Semantically, the `:` operation has precedence over `,`.
 // Examples:
-//   a:b,c 		-> (A&&B)||c
-//   a,b:c,d	-> A||(B&&C)||d
+//
+//	a:b,c 		-> (A&&B)||c
+//	a,b:c,d	-> A||(B&&C)||d
 func parseTagClause(filter string) TagClause {
 	rootNode := TagClause{
 		Op: OR,

--- a/config/filter/filter.go
+++ b/config/filter/filter.go
@@ -1,0 +1,147 @@
+// Copyright 2023 Mineiros GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package filter provides helpers for filtering objects.
+package filter
+
+import (
+	"strings"
+
+	"github.com/mineiros-io/terramate/errors"
+)
+
+// Operation is the binary logic operation (OR, AND).
+type Operation int
+
+// TagClause represents a tag filter clause.
+type TagClause struct {
+	// Op is the clause operation logic.
+	Op Operation
+	// Tag is the tag name if this is a leaf node.
+	Tag string
+	// Children is the list of children branches (if any)
+	Children []TagClause
+}
+
+const (
+	// EQ is the equal operation.
+	EQ Operation = iota
+	// AND is the and operation.
+	AND
+	// OR is the or operation.
+	OR
+)
+
+const andSymbol = ":"
+const orSymbol = ","
+
+// MatchTags tells if the filters match the provided tags list.
+func MatchTags(filters []string, tags []string) bool {
+	filter, found := parseTagClauses(filters...)
+	if !found {
+		return false
+	}
+	return matchTags(filter, tags)
+}
+
+func matchTags(filter TagClause, tags []string) bool {
+	index := tomap(tags)
+	switch filter.Op {
+	case EQ:
+		return index[filter.Tag]
+	case OR:
+		for _, clause := range filter.Children {
+			if matchTags(clause, tags) {
+				return true
+			}
+		}
+		return false
+	case AND:
+		for _, clause := range filter.Children {
+			if !matchTags(clause, tags) {
+				return false
+			}
+		}
+		return true
+	default:
+		panic(errors.E(errors.ErrInternal, "unreachable"))
+	}
+}
+
+func tomap(tags []string) map[string]bool {
+	m := map[string]bool{}
+	for _, t := range tags {
+		m[t] = true
+	}
+	return m
+}
+
+func parseTagClauses(filters ...string) (TagClause, bool) {
+	var clauses []TagClause
+	for _, filter := range filters {
+		if filter != "" {
+			clauses = append(clauses, parseTagClause(filter))
+		}
+	}
+	if len(clauses) == 0 {
+		return TagClause{}, false
+	}
+	if len(clauses) == 1 {
+		return clauses[0], true
+	}
+
+	return TagClause{
+		Op:       OR,
+		Children: clauses,
+	}, true
+}
+
+// parseTagClause parses the tag-filter syntax defined below:
+//   EXPR    = TAGNAME [ OP EXPR]
+//   TAGNAME = <string>
+//   OP      = ":" | ","
+//
+// Semantically, the `:` operation has precedence over `,`.
+// Examples:
+//   a:b,c 		-> (A&&B)||c
+//   a,b:c,d	-> A||(B&&C)||d
+func parseTagClause(filter string) TagClause {
+	rootNode := TagClause{
+		Op: OR,
+	}
+	orBranches := strings.Split(filter, orSymbol)
+	for _, orNode := range orBranches {
+		andNodes := strings.Split(orNode, andSymbol)
+		if len(andNodes) == 1 {
+			rootNode.Children = append(rootNode.Children, TagClause{
+				Op:  EQ,
+				Tag: andNodes[0],
+			})
+		} else {
+			branch := TagClause{
+				Op: AND,
+			}
+			for _, leaf := range andNodes {
+				branch.Children = append(branch.Children, parseTagClause(leaf))
+			}
+			rootNode.Children = append(rootNode.Children, branch)
+		}
+
+	}
+	if len(rootNode.Children) == 1 {
+		// simplify
+		rootNode = rootNode.Children[0]
+	}
+	return rootNode
+}

--- a/config/filter/filter.go
+++ b/config/filter/filter.go
@@ -108,6 +108,7 @@ func parseTagClauses(filters ...string) (TagClause, bool) {
 }
 
 // parseTagClause parses the tag-filter syntax defined below:
+//
 //   EXPR    = TAGNAME [ OP EXPR]
 //   TAGNAME = <string>
 //   OP      = ":" | ","

--- a/config/filter/filter_test.go
+++ b/config/filter/filter_test.go
@@ -1,0 +1,178 @@
+// Copyright 2023 Mineiros GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filter
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestFilterParserTags(t *testing.T) {
+	type testcase struct {
+		filters []string
+		want    TagClause
+		empty   bool
+	}
+
+	for _, tc := range []testcase{
+		{
+			filters: []string{
+				"a",
+			},
+			want: TagClause{
+				Tag: "a",
+			},
+		},
+		{
+			filters: []string{
+				"a,b",
+			},
+			want: TagClause{
+				Op: OR,
+				Children: []TagClause{
+					{
+						Tag: "a",
+					},
+					{
+						Tag: "b",
+					},
+				},
+			},
+		},
+		{
+			filters: []string{
+				"a,b:c",
+			},
+			want: TagClause{
+				Op: OR,
+				Children: []TagClause{
+					{
+						Tag: "a",
+					},
+					{
+						Op: AND,
+						Children: []TagClause{
+							{
+								Tag: "b",
+							},
+							{
+								Tag: "c",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			filters: []string{
+				"a,b:c,d",
+			},
+			want: TagClause{
+
+				Op: OR,
+				Children: []TagClause{
+					{
+						Tag: "a",
+					},
+					{
+						Op: AND,
+						Children: []TagClause{
+							{
+								Tag: "b",
+							},
+							{
+								Tag: "c",
+							},
+						},
+					},
+					{
+						Tag: "d",
+					},
+				},
+			},
+		},
+		{
+			filters: []string{
+				"a:b:c,d:e:f,g:h:i",
+			},
+			want: TagClause{
+
+				Op: OR,
+				Children: []TagClause{
+					{
+						Op: AND,
+						Children: []TagClause{
+							{
+								Tag: "a",
+							},
+							{
+								Tag: "b",
+							},
+							{
+								Tag: "c",
+							},
+						},
+					},
+					{
+						Op: AND,
+						Children: []TagClause{
+							{
+								Tag: "d",
+							},
+							{
+								Tag: "e",
+							},
+							{
+								Tag: "f",
+							},
+						},
+					},
+					{
+						Op: AND,
+						Children: []TagClause{
+							{
+								Tag: "g",
+							},
+							{
+								Tag: "h",
+							},
+							{
+								Tag: "i",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			filters: []string{
+				"",
+			},
+			empty: true,
+		},
+	} {
+		t.Run(fmt.Sprintf("filters:%v", tc.filters), func(t *testing.T) {
+			got, isEmpty := parseTagClauses(tc.filters...)
+			if !isEmpty != tc.empty {
+				t.Fatalf("filter emptiness mismatch: %t != %t", !isEmpty, tc.empty)
+			}
+			if diff := cmp.Diff(got, tc.want); diff != "" {
+				t.Fatalf("got[-], want[+], diff = %s", diff)
+			}
+		})
+	}
+}

--- a/config/stack.go
+++ b/config/stack.go
@@ -79,6 +79,9 @@ const (
 
 	// ErrStackInvalidWatch indicates the stack.watch attribute contains invalid values.
 	ErrStackInvalidWatch errors.Kind = "invalid stack.watch attribute"
+
+	// ErrStackInvalidTag indicates the stack.tags is invalid.
+	ErrStackInvalidTag errors.Kind = "invalid stack.tags entry"
 )
 
 // NewStackFromHCL creates a new stack from raw configuration cfg.
@@ -124,19 +127,22 @@ func (s Stack) validateTags() error {
 			case 0:
 				if !isLowerAlpha(r) {
 					return errors.E(
-						"invalid tag %q: tags must start with lowercase alphabetic character ([a-z])",
+						ErrStackInvalidTag,
+						"%q: tags must start with lowercase alphabetic character ([a-z])",
 						tag)
 				}
 			case len(tag) - 1: // last rune
 				if !isLowerAlnum(r) {
 					return errors.E(
-						"invalid tag %q: tags must end with lowercase alphanumeric ([0-9a-z]+)",
+						ErrStackInvalidTag,
+						"%q: tags must end with lowercase alphanumeric ([0-9a-z]+)",
 						tag)
 				}
 			default:
-				if !isLowerAlnum(r) || r == '-' || r == '_' {
+				if !isLowerAlnum(r) && r != '-' && r != '_' {
 					return errors.E(
-						"invalid tag %q: [a-z_-] are the only permitted characters in tags",
+						ErrStackInvalidTag,
+						"%q: [a-z_-] are the only permitted characters in tags",
 						tag)
 				}
 			}

--- a/config/stack.go
+++ b/config/stack.go
@@ -43,6 +43,7 @@ type (
 		Description string
 
 		// Tags is the list of tags of the stack.
+		// A tag
 		Tags []string
 
 		// After is a list of stack paths that must run before this stack.
@@ -92,7 +93,7 @@ func NewStackFromHCL(root string, cfg hcl.Config) (*Stack, error) {
 		return nil, errors.E(err, ErrStackInvalidWatch)
 	}
 
-	return &Stack{
+	stack := &Stack{
 		Name:        name,
 		ID:          cfg.Stack.ID,
 		Description: cfg.Stack.Description,
@@ -103,7 +104,56 @@ func NewStackFromHCL(root string, cfg hcl.Config) (*Stack, error) {
 		WantedBy:    cfg.Stack.WantedBy,
 		Watch:       watchFiles,
 		Dir:         project.PrjAbsPath(root, cfg.AbsDir()),
-	}, nil
+	}
+	err = stack.Validate()
+	if err != nil {
+		return nil, err
+	}
+	return stack, nil
+}
+
+// Validate if all stack fields are correct.
+func (s Stack) Validate() error {
+	return s.validateTags()
+}
+
+func (s Stack) validateTags() error {
+	for _, tag := range s.Tags {
+		for i, r := range tag {
+			switch i {
+			case 0:
+				if !isLowerAlpha(r) {
+					return errors.E(
+						"invalid tag %q: tags must start with lowercase alphabetic character ([a-z])",
+						tag)
+				}
+			case len(tag) - 1: // last rune
+				if !isLowerAlnum(r) {
+					return errors.E(
+						"invalid tag %q: tags must end with lowercase alphanumeric ([0-9a-z]+)",
+						tag)
+				}
+			default:
+				if !isLowerAlnum(r) || r == '-' || r == '_' {
+					return errors.E(
+						"invalid tag %q: [a-z_-] are the only permitted characters in tags",
+						tag)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func isDigit(r rune) bool {
+	return r >= '0' && r <= '9'
+}
+
+func isLowerAlpha(r rune) bool {
+	return (r >= 'a' && r <= 'z')
+}
+func isLowerAlnum(r rune) bool {
+	return isLowerAlpha(r) || isDigit(r)
 }
 
 // AppendBefore appends the path to the list of stacks that must run after this


### PR DESCRIPTION
This PR introduces the `--tags` flag for filtering stacks by tags.

The tags filter uses the syntax below:

```
EXPR    = TAGNAME [ OP EXPR]
TAGNAME = <string>
OP      = ":" | ","
```
Where `:` and `,` are used for `AND` and `OR` logical operations, respectively.

Examples:

```
--tags "app:prod"           # selects all stacks with app AND prod tag.
--tags "k8s,nomad,docker"   # selects all stacks with k8s OR nomad OR docker tag.
```

The `:` has precedence over `,` so if multiple are provided, the `:` are grouped first:

```
--tags A:B,C    # (A && B) || C
--tags A,B:C:D  # A || (B && C && D)
```

If multiple `--tags` are provided, then they are grouped in a `OR` query:

```
--tags app --tags prod            # is the same as: --tags app,prod
--tags app:prod --tags infra:prod # is the same as: --tags app:prod,infra:prod
```