### PR TITLE
chore: fix performance regression introduced by #788

### DIFF
--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -1417,7 +1417,7 @@ func (c *cli) outputEvalResult(val cty.Value, asJSON bool) {
 
 func (c *cli) setupEvalContext() *eval.Context {
 	ctx := eval.NewContext(stdlib.Functions(c.wd()))
-	runtime := c.cfg().RuntimeValues()
+	runtime := c.cfg().Runtime()
 	if config.IsStack(c.cfg(), c.wd()) {
 		st, err := config.LoadStack(c.cfg(), prj.PrjAbsPath(c.rootdir(), c.wd()))
 		if err != nil {

--- a/generate/generate.go
+++ b/generate/generate.go
@@ -316,7 +316,7 @@ func doRootGeneration(root *config.Root) Report {
 
 	report := Report{}
 	evalctx := eval.NewContext(stdlib.Functions(root.HostDir()))
-	evalctx.SetNamespace("terramate", root.RuntimeValues())
+	evalctx.SetNamespace("terramate", root.Runtime())
 
 	var files []GenFile
 	for _, cfg := range root.Tree().AsList() {

--- a/globals/stack.go
+++ b/globals/stack.go
@@ -25,7 +25,7 @@ func ForStack(root *config.Root, stack *config.Stack) EvalReport {
 	ctx := eval.NewContext(
 		stdlib.Functions(stack.HostDir(root)),
 	)
-	runtime := root.RuntimeValues()
+	runtime := root.Runtime()
 	runtime.Merge(stack.RuntimeValues(root))
 	ctx.SetNamespace("terramate", runtime)
 	return ForDir(root, stack.Dir, ctx)

--- a/stack/eval.go
+++ b/stack/eval.go
@@ -49,7 +49,7 @@ func (e *EvalCtx) SetGlobals(g *eval.Object) {
 
 // SetMetadata sets the given metadata on the stack evaluation context.
 func (e *EvalCtx) SetMetadata(st *config.Stack) {
-	runtime := e.root.RuntimeValues()
+	runtime := e.root.Runtime()
 	runtime.Merge(st.RuntimeValues(e.root))
 	e.SetNamespace("terramate", runtime)
 }


### PR DESCRIPTION
# Reason for This Change

The #788 introduced a subtle change that affected the performance.

Before the project metadata was instantiated by `project.NewMetadata()` which traversed the config tree to fill the `terramate.stacks.list` object, this was done once and the project.Metadata interface was passed over to each stack code generation.

With #788 the `project.Metadata` and `stack.Metadata` interfaces were removed and the runtime objects were constructed when needed, which means config tree was walked over multiple times for the root runtime values.

The root metadata never changes, so it can be safely loaded once when the project config is loaded and then reused.

## Description of Changes

Added a `runtime` field to `config.Root` struct and the method `root.Runtime()` returns a copy of the computed runtime.
So the `root.Stacks()` method is called once during the config loading.
