### PR TITLE
feat: add --global flag to experimental eval

### DIFF
--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -179,18 +179,18 @@ type cliSpec struct {
 		} `cmd:"" help:"Manages vendored Terraform modules"`
 
 		Eval struct {
-			Global map[string]string `short:"g" help:"set/override globals. eg.: --global name=value"`
+			Global map[string]string `short:"g" help:"set/override globals. eg.: --global name=<expr>"`
 			AsJSON bool              `help:"Outputs the result as a JSON value"`
 			Exprs  []string          `arg:"" help:"expressions to be evaluated" name:"expr" passthrough:""`
 		} `cmd:"" help:"Eval expression"`
 
 		PartialEval struct {
-			Global map[string]string `short:"g" help:"set/override globals. eg.: --global name=value"`
+			Global map[string]string `short:"g" help:"set/override globals. eg.: --global name=<expr>"`
 			Exprs  []string          `arg:"" help:"expressions to be partially evaluated" name:"expr" passthrough:""`
 		} `cmd:"" help:"Partial evaluate the expressions"`
 
 		GetConfigValue struct {
-			Global map[string]string `short:"g" help:"set/override globals. eg.: --global name=value"`
+			Global map[string]string `short:"g" help:"set/override globals. eg.: --global name=<expr>"`
 			AsJSON bool              `help:"Outputs the result as a JSON value"`
 			Vars   []string          `arg:"" help:"variable to be retrieved" name:"var" passthrough:""`
 		} `cmd:"" help:"Get configuration value"`

--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -178,18 +178,18 @@ type cliSpec struct {
 		} `cmd:"" help:"Manages vendored Terraform modules"`
 
 		Eval struct {
-			Global map[string]string `short:"g" help:"set global. eg.: --global name=value"`
+			Global map[string]string `short:"g" help:"set/override globals. eg.: --global name=value"`
 			AsJSON bool              `help:"Outputs the result as a JSON value"`
 			Exprs  []string          `arg:"" help:"expressions to be evaluated" name:"expr" passthrough:""`
 		} `cmd:"" help:"Eval expression"`
 
 		PartialEval struct {
-			Global map[string]string `short:"g" help:"set global. eg.: --global name=value"`
+			Global map[string]string `short:"g" help:"set/override globals. eg.: --global name=value"`
 			Exprs  []string          `arg:"" help:"expressions to be partially evaluated" name:"expr" passthrough:""`
 		} `cmd:"" help:"Partial evaluate the expressions"`
 
 		GetConfigValue struct {
-			Global map[string]string `short:"g" help:"set global. eg.: --global name=value"`
+			Global map[string]string `short:"g" help:"set/override globals. eg.: --global name=value"`
 			AsJSON bool              `help:"Outputs the result as a JSON value"`
 			Vars   []string          `arg:"" help:"variable to be retrieved" name:"var" passthrough:""`
 		} `cmd:"" help:"Get configuration value"`

--- a/cmd/terramate/e2etests/exp_eval_test.go
+++ b/cmd/terramate/e2etests/exp_eval_test.go
@@ -429,7 +429,7 @@ func TestGetConfigValue(t *testing.T) {
 			},
 		},
 		{
-			name: "get-config-value with overriden globals",
+			name: "get-config-value with overridden globals",
 			globals: []globalsBlock{
 				{
 					path: "/",

--- a/cmd/terramate/e2etests/exp_eval_test.go
+++ b/cmd/terramate/e2etests/exp_eval_test.go
@@ -15,9 +15,11 @@
 package e2etest
 
 import (
+	"fmt"
 	"path/filepath"
 	"testing"
 
+	"github.com/mineiros-io/terramate/globals"
 	"github.com/mineiros-io/terramate/hcl/eval"
 	"github.com/mineiros-io/terramate/test"
 	"github.com/mineiros-io/terramate/test/hclwrite"
@@ -34,13 +36,14 @@ func TestExpEval(t *testing.T) {
 			add  *hclwrite.Block
 		}
 		testcase struct {
-			name        string
-			layout      []string
-			wd          string
-			globals     []globalsBlock
-			expr        string
-			wantEval    runExpected
-			wantPartial runExpected
+			name            string
+			layout          []string
+			wd              string
+			globals         []globalsBlock
+			overrideGlobals map[string]string
+			expr            string
+			wantEval        runExpected
+			wantPartial     runExpected
 		}
 	)
 
@@ -133,25 +136,6 @@ func TestExpEval(t *testing.T) {
 			},
 		},
 		{
-			name: "partially successfully globals - not a stack, evaluating the defined global",
-			globals: []globalsBlock{
-				{
-					path: "/",
-					add: Globals(
-						Str("val", "global string"),
-						Expr("unknown", "terramate.stack.name"),
-					),
-				},
-			},
-			expr: `global.val`,
-			wantEval: runExpected{
-				Stdout: addnl(`global string`),
-			},
-			wantPartial: runExpected{
-				Stdout: addnl(`"global string"`),
-			},
-		},
-		{
 			name: "partially successfully globals - not a stack, evaluating the undefined global",
 			globals: []globalsBlock{
 				{
@@ -213,6 +197,102 @@ func TestExpEval(t *testing.T) {
 				Stdout: addnl(`unknown.num + 1000`),
 			},
 		},
+		{
+			name: "set-global + eval",
+			overrideGlobals: map[string]string{
+				"value": `tm_upper("value")`,
+			},
+			expr: `global.value`,
+			wantEval: runExpected{
+				Stdout: addnl("VALUE"),
+			},
+			wantPartial: runExpected{
+				Stdout: addnl(`"VALUE"`),
+			},
+		},
+		{
+			name: "setting multiple globals with dependency",
+			overrideGlobals: map[string]string{
+				"leaf": `tm_upper("leaf")`,
+				"mid":  `"mid-${global.leaf}"`,
+				"root": `"root-${global.mid}"`,
+			},
+			expr: `global.root`,
+			wantEval: runExpected{
+				Stdout: addnl("root-mid-LEAF"),
+			},
+			wantPartial: runExpected{
+				Stdout: addnl(`"root-mid-LEAF"`),
+			},
+		},
+		{
+			name: "override defined global",
+			overrideGlobals: map[string]string{
+				"value": `"BBB"`,
+			},
+			globals: []globalsBlock{
+				{
+					path: "/",
+					add: Globals(
+						Str("value", "AAA"),
+					),
+				},
+			},
+			expr: `global.value`,
+			wantEval: runExpected{
+				Stdout: addnl("BBB"),
+			},
+			wantPartial: runExpected{
+				Stdout: addnl(`"BBB"`),
+			},
+		},
+		{
+			name: "override underspecified global",
+			overrideGlobals: map[string]string{
+				"value": `"AAA"`,
+			},
+			globals: []globalsBlock{
+				{
+					path: "/",
+					add: Globals(
+						// this would be a hard fail if the --global is not provided
+						Expr("value", `something.that.does.not.exists`),
+					),
+				},
+			},
+			expr: `global.value`,
+			wantEval: runExpected{
+				Stdout: addnl("AAA"),
+			},
+			wantPartial: runExpected{
+				Stdout: addnl(`"AAA"`),
+			},
+		},
+		{
+			name: "underspecified globals still fail",
+			overrideGlobals: map[string]string{
+				"value": `"AAA"`,
+			},
+			globals: []globalsBlock{
+				{
+					path: "/",
+					add: Globals(
+						// this would be a hard fail if the --global is not provided
+						Expr("value", `something.that.does.not.exists`),
+						Expr("another_value", `something.that.does.not.exists`),
+					),
+				},
+			},
+			expr: `global.value`,
+			wantEval: runExpected{
+				StderrRegex: string(globals.ErrEval),
+				Status:      1,
+			},
+			wantPartial: runExpected{
+				StderrRegex: string(globals.ErrEval),
+				Status:      1,
+			},
+		},
 	}
 
 	for _, tcase := range testcases {
@@ -221,9 +301,7 @@ func TestExpEval(t *testing.T) {
 			t.Parallel()
 
 			s := sandbox.New(t)
-
 			s.BuildTree(tc.layout)
-
 			for _, globalBlock := range tc.globals {
 				path := filepath.Join(s.RootDir(), globalBlock.path)
 				test.AppendFile(t, path, "globals.tm",
@@ -232,8 +310,17 @@ func TestExpEval(t *testing.T) {
 
 			test.WriteRootConfig(t, s.RootDir())
 			ts := newCLI(t, filepath.Join(s.RootDir(), tc.wd))
-			assertRunResult(t, ts.run("experimental", "eval", tc.expr), tc.wantEval)
-			assertRunResult(t, ts.run("experimental", "partial-eval", tc.expr), tc.wantPartial)
+			globalArgs := []string{}
+			for globalName, globalExpr := range tc.overrideGlobals {
+				globalArgs = append(globalArgs, "--global")
+				globalArgs = append(globalArgs, fmt.Sprintf("%s=%s", globalName, globalExpr))
+			}
+			evalArgs := append([]string{"experimental", "eval"}, globalArgs...)
+			partialArgs := append([]string{"experimental", "partial-eval"}, globalArgs...)
+			evalArgs = append(evalArgs, tc.expr)
+			partialArgs = append(partialArgs, tc.expr)
+			assertRunResult(t, ts.run(evalArgs...), tc.wantEval)
+			assertRunResult(t, ts.run(partialArgs...), tc.wantPartial)
 		})
 	}
 }

--- a/errors/error.go
+++ b/errors/error.go
@@ -156,7 +156,7 @@ func E(args ...interface{}) *Error {
 		case Kind:
 			e.Kind = arg
 		case hcl.Range:
-			e.FileRange = fixupRange(arg)
+			e.FileRange = dynrange.Fixup(arg)
 		case info.Range:
 			start := arg.Start()
 			end := arg.End()
@@ -250,7 +250,7 @@ func E(args ...interface{}) *Error {
 	switch prev := e.Err.(type) {
 	case *hcl.Diagnostic:
 		if prev.Subject != nil && e.FileRange.Empty() {
-			e.FileRange = fixupRange(*prev.Subject)
+			e.FileRange = dynrange.Fixup(*prev.Subject)
 		}
 
 		if e.Description == "" {
@@ -458,16 +458,6 @@ func fixupFilename(fname string) string {
 		return "<generated-code>"
 	}
 	return fname
-}
-
-func fixupRange(r hcl.Range) hcl.Range {
-	cleaned := hcl.Range{
-		Start: r.Start,
-		End:   r.End,
-	}
-
-	cleaned.Filename = dynrange.HideInjectedExpr(r.Filename)
-	return cleaned
 }
 
 func checkDeprecatedUsage(arg interface{}) {

--- a/errors/error.go
+++ b/errors/error.go
@@ -26,6 +26,7 @@ import (
 	"syscall"
 
 	"github.com/hashicorp/hcl/v2"
+	"github.com/mineiros-io/terramate/hcl/dynexpr/dynrange"
 	"github.com/mineiros-io/terramate/hcl/info"
 )
 
@@ -155,7 +156,7 @@ func E(args ...interface{}) *Error {
 		case Kind:
 			e.Kind = arg
 		case hcl.Range:
-			e.FileRange = arg
+			e.FileRange = fixupRange(arg)
 		case info.Range:
 			start := arg.Start()
 			end := arg.End()
@@ -249,7 +250,7 @@ func E(args ...interface{}) *Error {
 	switch prev := e.Err.(type) {
 	case *hcl.Diagnostic:
 		if prev.Subject != nil && e.FileRange.Empty() {
-			e.FileRange = *prev.Subject
+			e.FileRange = fixupRange(*prev.Subject)
 		}
 
 		if e.Description == "" {
@@ -304,13 +305,13 @@ func (e *Error) error(fields []interface{}, verbose bool) string {
 					errParts = append(errParts,
 						fmt.Sprintf("filename=%q, start line=%d, start col=%d, "+
 							"start byte=%d, end line=%d, end col=%d, end byte=%d",
-							cleanFilename(v.Filename),
+							fixupFilename(v.Filename),
 							v.Start.Line, v.Start.Column, v.Start.Byte,
 							v.End.Line, v.End.Column, v.End.Byte),
 					)
 				} else {
 					copiedRange := v
-					copiedRange.Filename = cleanFilename(copiedRange.Filename)
+					copiedRange.Filename = fixupFilename(copiedRange.Filename)
 					errParts = append(errParts, copiedRange.String())
 				}
 			}
@@ -445,18 +446,28 @@ func As(err error, target interface{}) bool {
 	return errors.As(err, target)
 }
 
-// cleanFilename will clean the given filename returning a placeholder if
+// fixupFilename will clean the given filename returning a placeholder if
 // it is not a valid unix/win path. This is necessary since we use some
 // hacks on partial evaluation like adding a Filename on expressions that
 // is not a valid path but that includes information required by terramate
 // embedded on them, like the expression raw bytes.
-func cleanFilename(fname string) string {
+func fixupFilename(fname string) string {
 	// One of the few restrictions for paths to be valid is to not
 	// have any NUL bytes in the middle of the string.
 	if _, err := syscall.BytePtrFromString(fname); err != nil {
 		return "<generated-code>"
 	}
 	return fname
+}
+
+func fixupRange(r hcl.Range) hcl.Range {
+	cleaned := hcl.Range{
+		Start: r.Start,
+		End:   r.End,
+	}
+
+	cleaned.Filename = dynrange.HideInjectedExpr(r.Filename)
+	return cleaned
 }
 
 func checkDeprecatedUsage(arg interface{}) {

--- a/globals/globals.go
+++ b/globals/globals.go
@@ -25,6 +25,7 @@ import (
 	"github.com/mineiros-io/terramate/hcl"
 	"github.com/mineiros-io/terramate/mapexpr"
 
+	"github.com/mineiros-io/terramate/hcl/dynexpr"
 	"github.com/mineiros-io/terramate/hcl/eval"
 	"github.com/mineiros-io/terramate/hcl/info"
 	"github.com/mineiros-io/terramate/project"
@@ -153,7 +154,7 @@ func LoadExprs(root *config.Root, cfgdir project.Path) (HierarchicalExprs, error
 
 		attrs := block.Attributes.SortedList()
 		if len(block.Labels) > 0 && len(attrs) == 0 {
-			expr, _ := eval.ParseExpressionBytes([]byte(`{}`))
+			expr, _ := dynexpr.ParseExpressionBytes([]byte(`{}`))
 			key := NewGlobalExtendPath(block.Labels)
 			exprs.expressions[key] = Expr{
 				Origin:     block.RawOrigins[0].Range,

--- a/globals/globals.go
+++ b/globals/globals.go
@@ -224,16 +224,16 @@ func LoadExprs(root *config.Root, cfgdir project.Path) (HierarchicalExprs, error
 
 // SetOverride sets a custom global at the specified directory, using the given
 // global path and expr. The origin is only used for debugging purposes.
-func (le HierarchicalExprs) SetOverride(
+func (dirExprs HierarchicalExprs) SetOverride(
 	dir project.Path,
 	path GlobalPathKey,
 	expr hhcl.Expression,
 	origin info.Range,
 ) {
-	exprSet, ok := le[dir]
+	exprSet, ok := dirExprs[dir]
 	if !ok {
 		exprSet = newExprSet(origin.Path())
-		le[dir] = exprSet
+		dirExprs[dir] = exprSet
 	}
 	exprSet.expressions[path] = Expr{
 		Origin:     origin,
@@ -249,9 +249,9 @@ func (le HierarchicalExprs) SetOverride(
 // - /
 // - /dir
 // - /dir/stack
-func (le HierarchicalExprs) sort() []*ExprSet {
+func (dirExprs HierarchicalExprs) sort() []*ExprSet {
 	cfgdirs := []project.Path{}
-	for cfgdir := range le {
+	for cfgdir := range dirExprs {
 		cfgdirs = append(cfgdirs, cfgdir)
 	}
 
@@ -261,7 +261,7 @@ func (le HierarchicalExprs) sort() []*ExprSet {
 
 	res := []*ExprSet{}
 	for _, cfgdir := range cfgdirs {
-		res = append(res, le[cfgdir])
+		res = append(res, dirExprs[cfgdir])
 	}
 	return res
 }
@@ -271,9 +271,9 @@ func (le HierarchicalExprs) sort() []*ExprSet {
 // - global.a
 // - global.a.b
 // - global.a.b.c
-func (es ExprSet) sort() []GlobalPathKey {
+func (dirExprs ExprSet) sort() []GlobalPathKey {
 	res := []GlobalPathKey{}
-	for globalPath := range es.expressions {
+	for globalPath := range dirExprs.expressions {
 		res = append(res, globalPath)
 	}
 
@@ -533,10 +533,10 @@ func (dirExprs HierarchicalExprs) Eval(ctx *eval.Context) EvalReport {
 	return report
 }
 
-func (exprs HierarchicalExprs) merge(other HierarchicalExprs) {
+func (dirExprs HierarchicalExprs) merge(other HierarchicalExprs) {
 	for k, v := range other {
-		if _, ok := exprs[k]; !ok {
-			exprs[k] = v
+		if _, ok := dirExprs[k]; !ok {
+			dirExprs[k] = v
 		} else {
 			panic(errors.E(
 				errors.ErrInternal,

--- a/hcl/dynexpr/dynexpr.go
+++ b/hcl/dynexpr/dynexpr.go
@@ -35,7 +35,7 @@ import (
 
 // ParseExpressionBytes parses the exprBytes into a hcl.Expression and stores
 // the original tokens inside the expression.Range().Filename. For details
-// about this craziness, see the TokensForExpression() function.
+// about this craziness, see the [eval.TokensForExpression()] function.
 func ParseExpressionBytes(exprBytes []byte) (hcl.Expression, error) {
 	expr, diags := hclsyntax.ParseExpression(
 		exprBytes,

--- a/hcl/dynexpr/dynexpr.go
+++ b/hcl/dynexpr/dynexpr.go
@@ -1,0 +1,53 @@
+// Copyright 2023 Mineiros GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package dynexpr provides helper functions for dealing with dynamically
+// generated expressions.
+//
+// Those helpers are needed because Terramate has a very low-level Partial
+// Evaluation feature which works at the token level. It loads the tokens for
+// each expression from the file range defined in the expression but the
+// resulting evaluated expression tokens doesn't match the original tokens
+// anymore and in the case of recursive evaluation (tm_ternary, etc) the
+// Hashicorp library doesn't provide any place to obtain the evaluated tokens.
+// So the hack here is to inject them inside the expr.Range.Filename and extract
+// the tokens when needed, but the injection *must* be cleaned up before returning
+// to the user.
+package dynexpr
+
+import (
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/mineiros-io/terramate/errors"
+	"github.com/mineiros-io/terramate/hcl/dynexpr/dynrange"
+)
+
+// ParseExpressionBytes parses the exprBytes into a hcl.Expression and stores
+// the original tokens inside the expression.Range().Filename. For details
+// about this craziness, see the TokensForExpression() function.
+func ParseExpressionBytes(exprBytes []byte) (hcl.Expression, error) {
+	expr, diags := hclsyntax.ParseExpression(
+		exprBytes,
+		dynrange.WrapExprBytes(exprBytes),
+		hcl.Pos{
+			Line:   1,
+			Column: 1,
+			Byte:   0,
+		})
+
+	if diags.HasErrors() {
+		return nil, errors.E(diags, "parsing expression bytes")
+	}
+	return expr, nil
+}

--- a/hcl/dynexpr/dynrange/dynrange.go
+++ b/hcl/dynexpr/dynrange/dynrange.go
@@ -17,6 +17,8 @@ package dynrange
 import (
 	"bytes"
 	"fmt"
+
+	"github.com/hashicorp/hcl/v2"
 )
 
 // WrapExprBytes wraps the exprBytes provided in a string suited for a dynamically
@@ -74,6 +76,17 @@ func ReplaceInjectedExpr(content, replace string) string {
 func HideInjectedExpr(content string) string {
 	const dynfilename = "<generated expression>"
 	return ReplaceInjectedExpr(content, dynfilename)
+}
+
+// Fixup cleans the provided range by hiding any injected bytes.
+func Fixup(r hcl.Range) hcl.Range {
+	cleaned := hcl.Range{
+		Start: r.Start,
+		End:   r.End,
+	}
+
+	cleaned.Filename = HideInjectedExpr(r.Filename)
+	return cleaned
 }
 
 func injectedTokensPrefix() []byte {

--- a/hcl/dynexpr/dynrange/dynrange.go
+++ b/hcl/dynexpr/dynrange/dynrange.go
@@ -12,6 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package dynrange provides helper functions for dealing with dynamic generated
+// range for expressions.
+// Note: This is package must not import other Terramate packages because it's
+// imported by the "errors" package, which makes this package now the leaf of the
+// import tree of Terramate.
+// This package must be deleted when we remove the need for injection expression
+// bytes in hcl.Expression.
 package dynrange
 
 import (

--- a/hcl/dynexpr/dynrange/dynrange.go
+++ b/hcl/dynexpr/dynrange/dynrange.go
@@ -1,0 +1,92 @@
+// Copyright 2023 Mineiros GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dynrange
+
+import (
+	"bytes"
+	"fmt"
+)
+
+// WrapExprBytes wraps the exprBytes provided in a string suited for a dynamically
+// generated expression.
+func WrapExprBytes(exprBytes []byte) string {
+	fnameBytes := append(injectedTokensPrefix(), exprBytes...)
+	fnameBytes = append(fnameBytes, injectedTokenSuffix()...)
+	return string(fnameBytes)
+}
+
+// UnwrapExprBytes unwraps the expression bytes from the input.
+func UnwrapExprBytes(input string) ([]byte, bool) {
+	if !HasExprBytesWrapped(input) {
+		return nil, false
+	}
+
+	content := []byte(input)
+	exprStartPos := len(injectedTokensPrefix())
+	endEndPos := bytes.Index(content[exprStartPos:], injectedTokenSuffix())
+	return content[exprStartPos : exprStartPos+endEndPos], true
+}
+
+// HasExprBytesWrapped tells if the content is a dynamic expression wrapper buffer.
+func HasExprBytesWrapped(content string) bool {
+	return bytes.Contains([]byte(content), injectedTokensPrefix())
+}
+
+// ReplaceInjectedExpr replaces all occurrences of injected bytes with replace.
+func ReplaceInjectedExpr(content, replace string) string {
+	target := []byte(content)
+	startPos := bytes.Index([]byte(target), injectedTokensPrefix())
+	if startPos == -1 {
+		return content
+	}
+
+	before := target[0:startPos]
+	injection := target[startPos:]
+	endPos := len(injectedTokensPrefix()) - 1
+	exprBegin := injection[endPos+1:]
+	endPos = bytes.Index(exprBegin, injectedTokenSuffix())
+	res := []byte{}
+	res = append(res, before...)
+	res = append(res, []byte(replace)...)
+	res = append(res, exprBegin[endPos+1:]...)
+
+	content = string(res)
+	if bytes.Contains(res, injectedTokensPrefix()) {
+		return ReplaceInjectedExpr(content, replace)
+	}
+	return content
+}
+
+// HideInjectedExpr returns a placeholder for the injected bytes. This is useful when
+// presenting strings which could have generated expressions.
+func HideInjectedExpr(content string) string {
+	const dynfilename = "<generated expression>"
+	return ReplaceInjectedExpr(content, dynfilename)
+}
+
+func injectedTokensPrefix() []byte {
+	const bugMessage = `
+If you are seeing this, it means Terramate has a bug.
+It's harmless but please report it at https://github.com/mineiros-io/terramate/issues
+`
+	prefix := []byte{0}
+	prefix = append(prefix, []byte(fmt.Sprintf("<%s>", bugMessage))...)
+	prefix = append(prefix, 0)
+	return prefix
+}
+
+func injectedTokenSuffix() []byte {
+	return []byte{0}
+}

--- a/hcl/dynexpr/dynrange/dynrange_test.go
+++ b/hcl/dynexpr/dynrange/dynrange_test.go
@@ -1,0 +1,73 @@
+// Copyright 2023 Mineiros GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dynrange_test
+
+import (
+	"testing"
+
+	"github.com/madlambda/spells/assert"
+	"github.com/mineiros-io/terramate/hcl/dynexpr/dynrange"
+)
+
+func TestInjectionReplace(t *testing.T) {
+	for _, tc := range []struct {
+		before  string
+		after   string
+		expr    string
+		replace string
+		want    string
+	}{
+		{
+			before: "",
+			after:  "",
+			expr:   "a",
+			want:   "",
+		},
+		{
+			before: "AAA",
+			after:  "",
+			expr:   "a",
+			want:   "AAA",
+		},
+		{
+			before: "",
+			after:  "AAA",
+			expr:   "a",
+			want:   "AAA",
+		},
+		{
+			before: "AAA",
+			after:  "BBB",
+			expr:   "a",
+			want:   "AAABBB",
+		},
+		{
+			before:  "AAA",
+			after:   "BBB",
+			expr:    "a",
+			replace: "CCC",
+			want:    "AAACCCBBB",
+		},
+	} {
+		wrapped := dynrange.WrapExprBytes([]byte(tc.expr))
+		if !dynrange.HasExprBytesWrapped(wrapped) {
+			t.Fatal("has no injection")
+		}
+		got, _ := dynrange.UnwrapExprBytes(wrapped)
+		assert.EqualStrings(t, tc.expr, string(got))
+		intertwined := tc.before + wrapped + tc.after
+		assert.EqualStrings(t, tc.want, dynrange.ReplaceInjectedExpr(intertwined, tc.replace))
+	}
+}

--- a/hcl/eval/partial.go
+++ b/hcl/eval/partial.go
@@ -21,6 +21,7 @@ import (
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/mineiros-io/terramate/errors"
+	"github.com/mineiros-io/terramate/hcl/dynexpr"
 )
 
 // Errors returned when doing partial evaluation.
@@ -807,7 +808,7 @@ func (e *engine) evalTmFuncall() error {
 		expr = append(expr, part.Bytes...)
 	}
 
-	exprParsed, err := ParseExpressionBytes(expr)
+	exprParsed, err := dynexpr.ParseExpressionBytes(expr)
 	if err != nil {
 		return errors.E(err, "evaluating expression: %s", expr)
 	}
@@ -888,7 +889,7 @@ func (e *engine) evalVar() error {
 		expr = append(expr, part.Bytes...)
 	}
 
-	exprParsed, err := ParseExpressionBytes(expr)
+	exprParsed, err := dynexpr.ParseExpressionBytes(expr)
 	if err != nil {
 		return err
 	}

--- a/stdlib/funcs.go
+++ b/stdlib/funcs.go
@@ -22,7 +22,7 @@ import (
 	tflang "github.com/hashicorp/terraform/lang"
 	"github.com/mineiros-io/terramate/errors"
 	"github.com/mineiros-io/terramate/event"
-	"github.com/mineiros-io/terramate/hcl/eval"
+	"github.com/mineiros-io/terramate/hcl/dynexpr"
 	"github.com/mineiros-io/terramate/modvendor"
 	"github.com/mineiros-io/terramate/project"
 	"github.com/mineiros-io/terramate/tf"
@@ -164,7 +164,7 @@ func HCLExpressionFunc() function.Function {
 }
 
 func hclExpr(arg cty.Value) (cty.Value, error) {
-	exprParsed, err := eval.ParseExpressionBytes([]byte(arg.AsString()))
+	exprParsed, err := dynexpr.ParseExpressionBytes([]byte(arg.AsString()))
 	if err != nil {
 		return cty.NilVal, errors.E(err, "argument is not valid HCL expression")
 	}

--- a/stdlib/ternary.go
+++ b/stdlib/ternary.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/ext/customdecode"
 	"github.com/mineiros-io/terramate/errors"
+	"github.com/mineiros-io/terramate/hcl/dynexpr"
 	"github.com/mineiros-io/terramate/hcl/eval"
 	"github.com/zclconf/go-cty/cty"
 	"github.com/zclconf/go-cty/cty/function"
@@ -71,7 +72,7 @@ func evalTernaryBranch(arg cty.Value) (cty.Value, error) {
 		return cty.NilVal, errors.E(err, "evaluating tm_ternary branch")
 	}
 
-	exprParsed, err := eval.ParseExpressionBytes(newtokens.Bytes())
+	exprParsed, err := dynexpr.ParseExpressionBytes(newtokens.Bytes())
 	if err != nil {
 		return cty.NilVal, errors.E(err, "parsing partial evaluated bytes")
 	}

--- a/test/hcl.go
+++ b/test/hcl.go
@@ -27,6 +27,7 @@ import (
 	"github.com/mineiros-io/terramate/config"
 	"github.com/mineiros-io/terramate/hcl"
 	"github.com/mineiros-io/terramate/hcl/ast"
+	"github.com/mineiros-io/terramate/hcl/dynexpr"
 	"github.com/mineiros-io/terramate/hcl/eval"
 	"github.com/mineiros-io/terramate/hcl/info"
 	"github.com/mineiros-io/terramate/project"
@@ -102,7 +103,7 @@ func AssertDiff(t *testing.T, got, want interface{}, msg ...interface{}) {
 func NewExpr(t *testing.T, expr string) hhcl.Expression {
 	t.Helper()
 
-	res, err := eval.ParseExpressionBytes([]byte(expr))
+	res, err := dynexpr.ParseExpressionBytes([]byte(expr))
 	assert.NoError(t, err)
 	return res
 }


### PR DESCRIPTION
Introduces the `--global <name>=<val>` flag to the commands `get-config-value`, `eval` and `partial-eval`.

The provided list of global flags can be used to override the values from the configuration or set new ones before handling the command.

Example:

```
$ cat config.tm
globals {
    config = {
        name = "my project"
    }
}
$ terramate experimental eval --global config={} global.config
{}
```

It's possible to set just a specific part of an existent global value, if needed.

```
$ terramate experimental eval --global 'config.name="other value"' global.config
{
    name = "other value"
}
```

It also supports a syntax sugar to extend objects dynamically using a `dot notation`.
So if the object path does not exist, the object is dynamically created.

For the same configuration specified before, the command below works:

```
$ terramate experimental eval --global 'config.firewall.rules=[{allow = "*"}]' global.config
{
  name = "my project"
  firewall = {
    rules = [{
      allow = "*"
    }]
  }
}
```

