### PR TITLE
fix: heredoc expressions not partial evaluated

### DIFF
--- a/generate/genhcl/genhcl.go
+++ b/generate/genhcl/genhcl.go
@@ -246,7 +246,7 @@ func Load(
 
 		formatted, err := fmt.FormatMultiline(string(gen.Bytes()), hclBlock.Range.HostPath())
 		if err != nil {
-			panic(errors.E(st, err,
+			panic(errors.E(err,
 				"internal error: formatting generated code for generate_hcl %q:%s", name, string(gen.Bytes()),
 			))
 		}

--- a/generate/genhcl/partial_eval_test.go
+++ b/generate/genhcl/partial_eval_test.go
@@ -1301,6 +1301,42 @@ func TestPartialEval(t *testing.T) {
 			),
 		},
 		{
+			name: "HEREDOCs partial evaluated to single token",
+			globals: Globals(
+				Str("value", "test"),
+			),
+			config: Doc(
+				Expr("test", `<<-EOT
+${global.value}
+EOT
+`),
+			),
+			want: Doc(
+				Expr("test", `<<-EOT
+test
+EOT
+`),
+			),
+		},
+		{
+			name: "HEREDOCs partial evaluated between tokens",
+			globals: Globals(
+				Str("value", "test"),
+			),
+			config: Doc(
+				Expr("test", `<<-EOT
+				BEFORE ${global.value} AFTER
+EOT
+`),
+			),
+			want: Doc(
+				Expr("test", `<<-EOT
+				BEFORE test AFTER
+EOT
+`),
+			),
+		},
+		{
 			name: "tm_hcl_expression from string",
 			config: Doc(
 				Expr("a", `tm_hcl_expression("{ a = b }")`),


### PR DESCRIPTION
# Reason for This Change

Heredoc templates were not partially evaluated.

Closes #803

## Description of Changes

The heredoc template must be partially evaluated in the same way of plain quoted strings.
The code was generalized to treat them the same.
