### PR TITLE
chore: remove stack.CreateCfg and simplify tests

### DIFF
--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -855,20 +855,19 @@ func (c *cli) createStack() {
 		stackDescription = stackName
 	}
 
-	err := stack.Create(c.cfg(), config.Stack{
+	stackSpec := config.Stack{
 		Dir:         prj.PrjAbsPath(c.rootdir(), stackHostDir),
 		ID:          stackID,
 		Name:        stackName,
 		Description: stackDescription,
 		After:       c.parsedArgs.Create.After,
 		Before:      c.parsedArgs.Create.Before,
-	}, c.parsedArgs.Create.Import...)
+	}
 
-	stackPath := filepath.ToSlash(strings.TrimPrefix(stackHostDir, c.rootdir()))
-
+	err := stack.Create(c.cfg(), stackSpec, c.parsedArgs.Create.Import...)
 	if err != nil {
 		logger := log.With().
-			Str("stack", stackPath).
+			Stringer("stack", stackSpec.Dir).
 			Logger()
 
 		if c.parsedArgs.Create.IgnoreExisting &&
@@ -887,8 +886,8 @@ func (c *cli) createStack() {
 		errlog.Fatal(logger, err, "can't create stack")
 	}
 
-	log.Info().Msgf("created stack %s", stackPath)
-	c.output.MsgStdOut("Created stack %s", stackPath)
+	log.Info().Msgf("created stack %s", stackSpec.Dir)
+	c.output.MsgStdOut("Created stack %s", stackSpec.Dir)
 
 	if c.parsedArgs.Create.NoGenerate {
 		log.Debug().Msg("code generation on stack creation disabled")

--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -832,7 +832,7 @@ func (c *cli) createStack() {
 
 	logger.Trace().Msg("creating stack")
 
-	stackDir := filepath.Join(c.wd(), c.parsedArgs.Create.Path)
+	stackHostDir := filepath.Join(c.wd(), c.parsedArgs.Create.Path)
 
 	stackID := c.parsedArgs.Create.ID
 	if stackID == "" {
@@ -847,7 +847,7 @@ func (c *cli) createStack() {
 
 	stackName := c.parsedArgs.Create.Name
 	if stackName == "" {
-		stackName = filepath.Base(stackDir)
+		stackName = filepath.Base(stackHostDir)
 	}
 
 	stackDescription := c.parsedArgs.Create.Description
@@ -855,17 +855,16 @@ func (c *cli) createStack() {
 		stackDescription = stackName
 	}
 
-	err := stack.Create(c.cfg(), stack.CreateCfg{
-		Dir:         stackDir,
+	err := stack.Create(c.cfg(), config.Stack{
+		Dir:         prj.PrjAbsPath(c.rootdir(), stackHostDir),
 		ID:          stackID,
 		Name:        stackName,
 		Description: stackDescription,
 		After:       c.parsedArgs.Create.After,
 		Before:      c.parsedArgs.Create.Before,
-		Imports:     c.parsedArgs.Create.Import,
-	})
+	}, c.parsedArgs.Create.Import...)
 
-	stackPath := filepath.ToSlash(strings.TrimPrefix(stackDir, c.rootdir()))
+	stackPath := filepath.ToSlash(strings.TrimPrefix(stackHostDir, c.rootdir()))
 
 	if err != nil {
 		logger := log.With().

--- a/project/project.go
+++ b/project/project.go
@@ -64,6 +64,11 @@ func (p Path) Dir() Path {
 	}
 }
 
+// HostPath computes the absolute host path from the provided rootdir.
+func (p Path) HostPath(rootdir string) string {
+	return filepath.Join(rootdir, filepath.FromSlash(p.path))
+}
+
 // HasPrefix tests whether p begins with s prefix.
 func (p Path) HasPrefix(s string) bool {
 	return strings.HasPrefix(p.String(), s)

--- a/stack/create_test.go
+++ b/stack/create_test.go
@@ -15,6 +15,7 @@
 package stack_test
 
 import (
+	"path"
 	"path/filepath"
 	"testing"
 
@@ -31,7 +32,6 @@ import (
 func TestStackCreation(t *testing.T) {
 	type want struct {
 		err     error
-		stack   config.Stack
 		imports []string
 	}
 	type testcase struct {
@@ -42,34 +42,24 @@ func TestStackCreation(t *testing.T) {
 		want    want
 	}
 
-	newID := func(id string) string {
-		err := hcl.ValidateStackID(id)
-		assert.NoError(t, err)
-		return id
-	}
-
 	testcases := []testcase{
 		{
 			name:  "default create configuration",
 			stack: config.Stack{Dir: project.NewPath("/stack")},
-			want:  want{stack: config.Stack{Name: "stack"}},
 		},
 		{
 			name:  "creates all dirs no stack path",
 			stack: config.Stack{Dir: project.NewPath("/dir1/dir2/dir3/stack")},
-			want:  want{stack: config.Stack{Name: "stack"}},
 		},
 		{
 			name:   "creates configuration when dir already exists",
 			layout: []string{"d:stack"},
 			stack:  config.Stack{Dir: project.NewPath("/stack")},
-			want:   want{stack: config.Stack{Name: "stack"}},
 		},
 		{
 			name:   "creates configuration when dir already exists and has subdirs",
 			layout: []string{"d:stack/subdir"},
 			stack:  config.Stack{Dir: project.NewPath("/stack")},
-			want:   want{stack: config.Stack{Name: "stack"}},
 		},
 		{
 			name: "defining only name",
@@ -77,19 +67,12 @@ func TestStackCreation(t *testing.T) {
 				Dir:  project.NewPath("/another-stack"),
 				Name: "The Name Of The Stack",
 			},
-			want: want{stack: config.Stack{Name: "The Name Of The Stack"}},
 		},
 		{
 			name: "defining only description",
 			stack: config.Stack{
 				Dir:         project.NewPath("/cool-stack"),
 				Description: "Stack Description",
-			},
-			want: want{
-				stack: config.Stack{
-					Name:        "cool-stack",
-					Description: "Stack Description",
-				},
 			},
 		},
 		{
@@ -100,22 +83,12 @@ func TestStackCreation(t *testing.T) {
 				Name:        "Stack Name",
 				Description: "Stack Description",
 			},
-			want: want{
-				stack: config.Stack{
-					ID:          newID("stack-id"),
-					Name:        "Stack Name",
-					Description: "Stack Description",
-				},
-			},
 		},
 		{
 			name:    "defining single import",
 			stack:   config.Stack{Dir: project.NewPath("/stack-imports")},
 			imports: []string{"/common/something.tm.hcl"},
-			want: want{
-				stack:   config.Stack{Name: "stack-imports"},
-				imports: []string{"/common/something.tm.hcl"},
-			},
+			want:    want{imports: []string{"/common/something.tm.hcl"}},
 		},
 		{
 			name:  "defining multiple imports",
@@ -125,7 +98,6 @@ func TestStackCreation(t *testing.T) {
 				"/common/2.tm.hcl",
 			},
 			want: want{
-				stack: config.Stack{Name: "stack-imports"},
 				imports: []string{
 					"/common/1.tm.hcl",
 					"/common/2.tm.hcl",
@@ -138,13 +110,6 @@ func TestStackCreation(t *testing.T) {
 				Dir:    project.NewPath("/stack-after-before"),
 				After:  []string{"stack-1", "stack-2"},
 				Before: []string{"stack-3", "stack-4"},
-			},
-			want: want{
-				stack: config.Stack{
-					Name:   "stack-after-before",
-					After:  []string{"stack-1", "stack-2"},
-					Before: []string{"stack-3", "stack-4"},
-				},
 			},
 		},
 		{
@@ -198,16 +163,13 @@ func TestStackCreation(t *testing.T) {
 				return
 			}
 
-			wantStack := tc.want.stack
+			if tc.stack.Name == "" {
+				tc.stack.Name = path.Base(tc.stack.Dir.String())
+			}
+
 			got := s.LoadStack(tc.stack.Dir)
-
-			assert.EqualStrings(t, wantStack.ID, got.ID)
-			assert.EqualStrings(t, wantStack.Name, got.Name, "checking stack name")
-			assert.EqualStrings(t, wantStack.Description, got.Description, "checking stack description")
-
 			test.AssertStackImports(t, s.RootDir(), got.HostDir(root), tc.want.imports)
-			test.AssertDiff(t, got.After, wantStack.After, "created stack has invalid after")
-			test.AssertDiff(t, got.Before, wantStack.Before, "created stack has invalid before")
+			test.AssertDiff(t, *got, tc.stack, "created stack is invalid")
 		})
 	}
 }

--- a/test/sandbox/sandbox.go
+++ b/test/sandbox/sandbox.go
@@ -315,7 +315,10 @@ func (s S) CreateStack(relpath string) StackEntry {
 	}
 
 	st := newStackEntry(t, s.RootDir(), relpath)
-	assert.NoError(t, stack.Create(s.Config(), stack.CreateCfg{Dir: st.Path()}))
+	assert.NoError(t, stack.Create(
+		s.Config(),
+		config.Stack{Dir: project.PrjAbsPath(s.RootDir(), st.Path())},
+	))
 	return st
 }
 
@@ -669,11 +672,8 @@ func buildTree(t testing.TB, root *config.Root, layout []string) {
 		case "s:":
 			if data == "" {
 				abspath := filepath.Join(rootdir, path)
-				test.MkdirAll(t, abspath)
-				assert.NoError(t, stack.Create(
-					root,
-					stack.CreateCfg{Dir: abspath}),
-				)
+				stackdir := project.PrjAbsPath(rootdir, abspath)
+				assert.NoError(t, stack.Create(root, config.Stack{Dir: stackdir}))
 				continue
 			}
 


### PR DESCRIPTION
# Reason for This Change

In the past, the `config.Stack` fields were not exposed and then a separate structure was needed to configure new stacks. This is not needed anymore and the `config.Stack` is an standalone object.

A good result of this change is that now it's impossible to call `stack.Create()` with invalid paths (relative paths, paths outside rootdir, etc).

## Description of Changes

- Remove `stack.CreateCfg` and use the `config.Stack` object directly.
- refactor tests to use the new API.
- Some tests were removed (or moved to another place) because they are impossible to occur at the `stack.Create()` time.
