### PR TITLE
chore: bench/check against main

### DIFF
--- a/makefiles/common.mk
+++ b/makefiles/common.mk
@@ -77,7 +77,7 @@ bench/check: allocdelta="+20%"
 bench/check: timedelta="+20%"
 bench/check: name=github.com/mineiros-io/terramate
 bench/check: pkg=./hcl/ast
-bench/check: old=i4k-add-benchmarks
+bench/check: old=main
 bench/check: new?=$(shell git rev-parse HEAD)
 bench/check:
 	@$(BENCH_CHECK) -mod $(name) -pkg $(pkg) -go-test-flags "-benchmem,-count=20" \


### PR DESCRIPTION
# Reason for This Change

When the benchmarks were added, the TokensForExpression benchmark functions were not merged then the bench/check was added to check against the #822 branch.

This PR points the checks against `main`. This fixes the wrong bench results being sent to PRs.


