### PR TITLE
chore: add benchmarks for partial evaluator

### DIFF
--- a/hcl/eval/partial_eval_bench_test.go
+++ b/hcl/eval/partial_eval_bench_test.go
@@ -1,3 +1,17 @@
+// Copyright 2023 Mineiros GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package eval_test
 
 import (

--- a/hcl/eval/partial_eval_bench_test.go
+++ b/hcl/eval/partial_eval_bench_test.go
@@ -1,0 +1,185 @@
+package eval_test
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/mineiros-io/terramate/hcl/eval"
+	"github.com/mineiros-io/terramate/stdlib"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func setupContext(b *testing.B) *eval.Context {
+	ctx := eval.NewContext(stdlib.Functions(os.TempDir()))
+	ctx.SetNamespace("global", map[string]cty.Value{
+		"true":   cty.True,
+		"false":  cty.False,
+		"number": cty.NumberFloatVal(3.141516),
+		"string": cty.StringVal("terramate"),
+		"list": cty.ListVal([]cty.Value{
+			cty.NumberIntVal(0),
+			cty.NumberIntVal(1),
+			cty.NumberIntVal(2),
+			cty.NumberIntVal(3),
+		}),
+		"strings": cty.ListVal([]cty.Value{
+			cty.StringVal("terramate"),
+			cty.StringVal("is"),
+			cty.StringVal("fun"),
+		}),
+		"obj": cty.ObjectVal(map[string]cty.Value{
+			"a": cty.NumberIntVal(0),
+			"b": cty.ListVal([]cty.Value{cty.StringVal("terramate")}),
+		}),
+	})
+	return ctx
+}
+
+func BenchmarkPartialEvalComplex(b *testing.B) {
+	b.StopTimer()
+	ctx := setupContext(b)
+
+	exprBytes := []byte(`[
+		{
+			a = "prefix ${tm_upper(global.string)} ${global.number} suffix"
+			b = [0, 1, global.true, global.false, global.number, global.string, global.list, global.obj]
+			c = {
+				a = tm_floor(global.number) == 3 ? tm_upper(global.string) : tm_title(global.string)
+				b = 10*global.number+global.number / 2+3
+			}
+			e = tm_concat(global.list, [tm_max(21, 8, 13, 3, 1, 5, 1, 2)])
+		},
+		{
+			a = "prefix ${tm_upper(global.string)} ${global.number} suffix"
+			b = [0, 1, global.true, global.false, global.number, global.string, global.list, global.obj]
+			c = {
+				a = tm_floor(global.number) == 3 ? tm_upper(global.string) : tm_title(global.string)
+				b = 10*global.number+global.number / 2+3
+			}
+			e = tm_concat(global.list, [tm_max(21, 8, 13, 3, 1, 5, 1, 2)])
+		},
+		{
+			a = "prefix ${tm_upper(global.string)} ${global.number} suffix"
+			b = [0, 1, global.true, global.false, global.number, global.string, global.list, global.obj]
+			c = {
+				a = tm_floor(global.number) == 3 ? tm_upper(global.string) : tm_title(global.string)
+				b = 10*global.number+global.number / 2+3
+			}
+			e = tm_concat(global.list, [tm_max(21, 8, 13, 3, 1, 5, 1, 2)])
+		},
+		{
+			a = "prefix ${tm_upper(global.string)} ${global.number} suffix"
+			b = [0, 1, global.true, global.false, global.number, global.string, global.list, global.obj]
+			c = {
+				a = tm_floor(global.number) == 3 ? tm_upper(global.string) : tm_title(global.string)
+				b = 10*global.number+global.number / 2+3
+			}
+			e = tm_concat(global.list, [tm_max(21, 8, 13, 3, 1, 5, 1, 2)])
+		},
+		{
+			a = "prefix ${tm_upper(global.string)} ${global.number} suffix"
+			b = [0, 1, global.true, global.false, global.number, global.string, global.list, global.obj]
+			c = {
+				a = tm_floor(global.number) == 3 ? tm_upper(global.string) : tm_title(global.string)
+				b = 10*global.number+global.number / 2+3
+			}
+			e = tm_concat(global.list, [tm_max(21, 8, 13, 3, 1, 5, 1, 2)])
+		},
+	]`)
+
+	b.StartTimer()
+	for n := 0; n < b.N; n++ {
+		expr, diags := hclsyntax.ParseExpression(exprBytes, "<bench>", hcl.InitialPos)
+		if diags.HasErrors() {
+			b.Fatalf(diags.Error())
+		}
+		_, err := ctx.PartialEval(expr)
+		if err != nil {
+			b.Fatal(err.Error())
+		}
+	}
+}
+
+func BenchmarkPartialEvalSmallString(b *testing.B) {
+	b.StopTimer()
+	ctx := setupContext(b)
+
+	exprBytes := []byte(`"terramate is fun"`)
+
+	b.StartTimer()
+	for n := 0; n < b.N; n++ {
+		expr, diags := hclsyntax.ParseExpression(exprBytes, "<bench>", hcl.InitialPos)
+		if diags.HasErrors() {
+			b.Fatalf(diags.Error())
+		}
+		_, err := ctx.PartialEval(expr)
+		if err != nil {
+			b.Fatal(err.Error())
+		}
+	}
+}
+
+func BenchmarkPartialEvalHugeString(b *testing.B) {
+	b.StopTimer()
+	ctx := setupContext(b)
+
+	exprBytes := []byte(`"` + strings.Repeat(`terramate is fun\n`, 1000) + `"`)
+
+	b.StartTimer()
+	for n := 0; n < b.N; n++ {
+		expr, diags := hclsyntax.ParseExpression(exprBytes, "<bench>", hcl.InitialPos)
+		if diags.HasErrors() {
+			b.Fatalf(diags.Error())
+		}
+		_, err := ctx.PartialEval(expr)
+		if err != nil {
+			b.Fatal(err.Error())
+		}
+	}
+}
+
+func BenchmarkPartialEvalHugeInterpolatedString(b *testing.B) {
+	b.StopTimer()
+	ctx := setupContext(b)
+
+	exprBytes := []byte(`"` + strings.Repeat(`${global.string} is fun\n`, 1000) + `"`)
+
+	b.StartTimer()
+	for n := 0; n < b.N; n++ {
+		expr, diags := hclsyntax.ParseExpression(exprBytes, "<bench>", hcl.InitialPos)
+		if diags.HasErrors() {
+			b.Fatalf(diags.Error())
+		}
+		_, err := ctx.PartialEval(expr)
+		if err != nil {
+			b.Fatal(err.Error())
+		}
+	}
+}
+
+func BenchmarkPartialEvalObject(b *testing.B) {
+	b.StopTimer()
+	ctx := setupContext(b)
+
+	exprBytes := []byte(`{
+		a = 1
+		b = [0, 1, 2, 3]
+		c = [global.number, global.string]
+		d = [global.list]	
+	}`)
+
+	b.StartTimer()
+	for n := 0; n < b.N; n++ {
+		expr, diags := hclsyntax.ParseExpression(exprBytes, "<bench>", hcl.InitialPos)
+		if diags.HasErrors() {
+			b.Fatalf(diags.Error())
+		}
+		_, err := ctx.PartialEval(expr)
+		if err != nil {
+			b.Fatal(err.Error())
+		}
+	}
+}

--- a/makefiles/common.mk
+++ b/makefiles/common.mk
@@ -80,7 +80,7 @@ bench/check: pkg=./...
 bench/check: old=main
 bench/check: new?=$(shell git rev-parse HEAD)
 bench/check:
-	@$(BENCH_CHECK) -mod $(name) -pkg $(pkg) -go-test-flags "-benchmem,-count=20" \
+	@$(BENCH_CHECK) -mod $(name) -pkg $(pkg) -go-test-flags "-benchmem,-count=20,-run=Bench" \
 		-old $(old) -new $(new) \
 		-check allocs/op=$(allocdelta) \
 		-check time/op=$(timedelta)

--- a/stdlib/funcs_test.go
+++ b/stdlib/funcs_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/mineiros-io/terramate/stdlib"
 	"github.com/mineiros-io/terramate/test"
 	"github.com/mineiros-io/terramate/tf"
+	"github.com/rs/zerolog"
 )
 
 func TestTmVendor(t *testing.T) {
@@ -211,4 +212,8 @@ func TestStdlibNewFunctionsFailIfBasedirIsNotADirectory(t *testing.T) {
 
 	path := test.WriteFile(t, t.TempDir(), "somefile.txt", ``)
 	_ = stdlib.Functions(path)
+}
+
+func init() {
+	zerolog.SetGlobalLevel(zerolog.Disabled)
 }


### PR DESCRIPTION
# Reason for This Change

Those benchmarks are needed to assess if #838 is a good move.
