### PR TITLE
feat: support tm_dynamic.attributes together with tm_dynamic.content

### DIFF
--- a/docs/codegen/generate-hcl.md
+++ b/docs/codegen/generate-hcl.md
@@ -123,14 +123,10 @@ The `tm_dynamic` is a special block type that can only be used inside the
 It's similar to [Terraform dynamic blocks](https://www.terraform.io/language/expressions/dynamic-blocks)
 but supports partial evaluation of the expanded code.
 
-There are two ways to define a `tm_dynamic` block. One is using a `content` block that
-will define how to generate the blocks dynamically.
-
-Another one is to define an `attributes` object, where each field inside the object
-will become an attribute inside the dynamically generated blocks.
-
-A `tm_dynamic` block may have only one `content` block **OR** one `attributes` object,
-having both defined is not allowed.
+The generate block's attributes can be provided by a `content` block, an
+`attributes` attribute, or even both if they don't conflict.
+When using the `content` block, additional sub-blocks can be generated and 
+nested `tm_dynamic` blocks can be defined.
 
 Example using the `content` block:
 
@@ -216,6 +212,7 @@ block {
   attr2 = not_evaluated.attr
 }
 ```
+
 
 The `for_each` attribute is optional. If it is not defined then only a single block
 will be generated and no iterator will be available on block generation.

--- a/docs/codegen/generate-hcl.md
+++ b/docs/codegen/generate-hcl.md
@@ -213,7 +213,6 @@ block {
 }
 ```
 
-
 The `for_each` attribute is optional. If it is not defined then only a single block
 will be generated and no iterator will be available on block generation.
 

--- a/generate/genhcl/genhcl.go
+++ b/generate/genhcl/genhcl.go
@@ -478,6 +478,7 @@ func appendDynamicBlock(
 					ErrDynamicAttrsConflict,
 					attr.Range(),
 					"attribute %s already set by tm_dynamic.attributes",
+					attr.Name,
 				)
 			}
 		}

--- a/generate/genhcl/genhcl.go
+++ b/generate/genhcl/genhcl.go
@@ -86,6 +86,7 @@ const (
 	// ErrDynamicConditionEval indicates that the condition of a tm_dynamic cant be evaluated.
 	ErrDynamicConditionEval errors.Kind = "evaluating tm_dynamic.condition"
 
+	// ErrDynamicAttrsConflict indicates fields of tm_dynamic conflicts.
 	ErrDynamicAttrsConflict errors.Kind = "tm_dynamic.attributes and tm_dynamic.content have conflicting fields"
 )
 


### PR DESCRIPTION
Add support for both `tm_dynamic.attributes` and `tm_dynamic.content` block in the same `tm_dynamic` block, given that they don't conflict. A conflict would be having a `attributes` field also defined in the `content` block.

The result is a merge of both configuration types.
