### PR TITLE
feat: add --no-tags flag

### DIFF
--- a/cmd/terramate/e2etests/list_git_test.go
+++ b/cmd/terramate/e2etests/list_git_test.go
@@ -38,6 +38,9 @@ func TestE2EListWithGit(t *testing.T) {
 			for _, filter := range tc.filterTags {
 				args = append(args, "--tags", filter)
 			}
+			for _, filter := range tc.filterNoTags {
+				args = append(args, "--no-tags", filter)
+			}
 			assertRunResult(t, cli.listStacks(args...), tc.want)
 		})
 	}

--- a/cmd/terramate/e2etests/list_nongit_test.go
+++ b/cmd/terramate/e2etests/list_nongit_test.go
@@ -37,6 +37,9 @@ func TestE2EListNonGit(t *testing.T) {
 			for _, filter := range tc.filterTags {
 				args = append(args, "--tags", filter)
 			}
+			for _, filter := range tc.filterNoTags {
+				args = append(args, "--no-tags", filter)
+			}
 			assertRunResult(t, cli.listStacks(args...), tc.want)
 		})
 	}

--- a/cmd/terramate/e2etests/list_test.go
+++ b/cmd/terramate/e2etests/list_test.go
@@ -24,10 +24,11 @@ import (
 )
 
 type testcase struct {
-	name       string
-	layout     []string
-	filterTags []string
-	want       runExpected
+	name         string
+	layout       []string
+	filterTags   []string
+	filterNoTags []string
+	want         runExpected
 }
 
 func listTestcases() []testcase {
@@ -160,6 +161,20 @@ func listTestcases() []testcase {
 			filterTags: []string{"abc"},
 			want: runExpected{
 				Stdout: listStacks("a", "b", "dir/c"),
+			},
+		},
+		{
+			name: "multiple stacks filtered by not having abc tag",
+			layout: []string{
+				`s:a:tags=["abc"]`,
+				`s:b:tags=["abc"]`,
+				`s:dir/c:tags=["abc"]`,
+				`s:dir/d`,
+				`s:dir/subdir/e`,
+			},
+			filterNoTags: []string{"abc"},
+			want: runExpected{
+				Stdout: listStacks("dir/d", "dir/subdir/e"),
 			},
 		},
 		{

--- a/cmd/terramate/e2etests/run_test.go
+++ b/cmd/terramate/e2etests/run_test.go
@@ -44,12 +44,11 @@ func TestCLIRunOrder(t *testing.T) {
 	t.Parallel()
 
 	type testcase struct {
-		name         string
-		layout       []string
-		filterTags   []string
-		filterNoTags []string
-		workingDir   string
-		want         runExpected
+		name       string
+		layout     []string
+		filterTags []string
+		workingDir string
+		want       runExpected
 	}
 
 	for _, tc := range []testcase{

--- a/cmd/terramate/e2etests/run_test.go
+++ b/cmd/terramate/e2etests/run_test.go
@@ -749,6 +749,20 @@ func TestCLIRunOrder(t *testing.T) {
 			},
 		},
 		{
+			name: "combining --tags and --no-tags",
+			layout: []string{
+				`s:stack-a:tags=["a", "b", "c"]`,
+				`s:stack-b:tags=["a", "b"]`,
+			},
+			filterTags:   []string{"a", "b"},
+			filterNoTags: []string{"c"},
+			want: runExpected{
+				Stdout: listStacks(
+					"/stack-b",
+				),
+			},
+		},
+		{
 			name: "stack before unknown tag - ignored",
 			layout: []string{
 				`s:stack1`,

--- a/cmd/terramate/e2etests/run_test.go
+++ b/cmd/terramate/e2etests/run_test.go
@@ -44,11 +44,12 @@ func TestCLIRunOrder(t *testing.T) {
 	t.Parallel()
 
 	type testcase struct {
-		name       string
-		layout     []string
-		filterTags []string
-		workingDir string
-		want       runExpected
+		name         string
+		layout       []string
+		filterTags   []string
+		filterNoTags []string
+		workingDir   string
+		want         runExpected
 	}
 
 	for _, tc := range []testcase{

--- a/cmd/terramate/e2etests/run_test.go
+++ b/cmd/terramate/e2etests/run_test.go
@@ -1378,6 +1378,19 @@ func TestRunWantedBy(t *testing.T) {
 				StderrRegex: string(tag.ErrInvalidTag),
 			},
 		},
+		{
+			name: "is not permitted to use internal filter syntax - advanced case",
+			layout: []string{
+				`s:stack-a:tags=["prod"]`,
+			},
+			filterTags: []string{
+				"prod:~experimental",
+			},
+			want: runExpected{
+				Status:      1,
+				StderrRegex: string(tag.ErrInvalidTag),
+			},
+		},
 	} {
 		testRunSelection(t, tc)
 	}

--- a/cmd/terramate/e2etests/run_test.go
+++ b/cmd/terramate/e2etests/run_test.go
@@ -1299,6 +1299,23 @@ func TestRunWantedBy(t *testing.T) {
 			},
 		},
 		{
+			name: "selected wantedBy stacks not filtered by --no-tags",
+			layout: []string{
+				`s:stack:tags=["dev"];wanted_by=["/all"]`,
+				`s:all/test/1:tags=["prod"]`,
+				`s:all/test2/2:tags=["dev"]`,
+				`s:all/something/3:tags=["dev"]`,
+			},
+			wd:           "/all/test/1",
+			filterNoTags: []string{"dev"},
+			want: runExpected{
+				Stdout: listStacks(
+					"/all/test/1",
+					"/stack",
+				),
+			},
+		},
+		{
 			name: "wantedBy computed after stack filtering",
 			layout: []string{
 				`s:stack:tags=["prod"];wanted_by=["/other-stack"]`,

--- a/config/filter/filter.go
+++ b/config/filter/filter.go
@@ -107,6 +107,20 @@ func tomap(tags []string) map[string]bool {
 // ParseTagClauses parses the list of filters provided into a [TagClause] matcher.
 // It returns a boolean telling if the clauses are not empty.
 func ParseTagClauses(filters ...string) (TagClause, bool, error) {
+	for _, filter := range filters {
+		for _, orClause := range strings.Split(filter, ",") {
+			for _, andClause := range strings.Split(orClause, ":") {
+				err := tag.Validate(andClause)
+				if err != nil {
+					return TagClause{}, false, err
+				}
+			}
+		}
+	}
+	return parseInternalTagClauses(filters...)
+}
+
+func parseInternalTagClauses(filters ...string) (TagClause, bool, error) {
 	var clauses []TagClause
 	for _, filter := range filters {
 		if filter != "" {

--- a/config/filter/filter_test.go
+++ b/config/filter/filter_test.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/madlambda/spells/assert"
 	"github.com/mineiros-io/terramate/config/tag"
 	"github.com/mineiros-io/terramate/errors"
 	errtest "github.com/mineiros-io/terramate/test/errors"
@@ -26,6 +27,8 @@ import (
 )
 
 func TestFilterParserTags(t *testing.T) {
+	t.Parallel()
+
 	type testcase struct {
 		filters   []string
 		want      TagClause
@@ -39,6 +42,16 @@ func TestFilterParserTags(t *testing.T) {
 				"a",
 			},
 			want: TagClause{
+				Op:  EQ,
+				Tag: "a",
+			},
+		},
+		{
+			filters: []string{
+				"~a",
+			},
+			want: TagClause{
+				Op:  NEQ,
 				Tag: "a",
 			},
 		},
@@ -50,9 +63,29 @@ func TestFilterParserTags(t *testing.T) {
 				Op: OR,
 				Children: []TagClause{
 					{
+						Op:  EQ,
 						Tag: "a",
 					},
 					{
+						Op:  EQ,
+						Tag: "b",
+					},
+				},
+			},
+		},
+		{
+			filters: []string{
+				"~a,~b",
+			},
+			want: TagClause{
+				Op: OR,
+				Children: []TagClause{
+					{
+						Op:  NEQ,
+						Tag: "a",
+					},
+					{
+						Op:  NEQ,
 						Tag: "b",
 					},
 				},
@@ -66,15 +99,45 @@ func TestFilterParserTags(t *testing.T) {
 				Op: OR,
 				Children: []TagClause{
 					{
+						Op:  EQ,
 						Tag: "a",
 					},
 					{
 						Op: AND,
 						Children: []TagClause{
 							{
+								Op:  EQ,
 								Tag: "b",
 							},
 							{
+								Op:  EQ,
+								Tag: "c",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			filters: []string{
+				"~a,~b:~c",
+			},
+			want: TagClause{
+				Op: OR,
+				Children: []TagClause{
+					{
+						Op:  NEQ,
+						Tag: "a",
+					},
+					{
+						Op: AND,
+						Children: []TagClause{
+							{
+								Op:  NEQ,
+								Tag: "b",
+							},
+							{
+								Op:  NEQ,
 								Tag: "c",
 							},
 						},
@@ -91,20 +154,56 @@ func TestFilterParserTags(t *testing.T) {
 				Op: OR,
 				Children: []TagClause{
 					{
+						Op:  EQ,
 						Tag: "a",
 					},
 					{
 						Op: AND,
 						Children: []TagClause{
 							{
+								Op:  EQ,
 								Tag: "b",
 							},
 							{
+								Op:  EQ,
 								Tag: "c",
 							},
 						},
 					},
 					{
+						Op:  EQ,
+						Tag: "d",
+					},
+				},
+			},
+		},
+		{
+			filters: []string{
+				"~a,b:c,~d",
+			},
+			want: TagClause{
+
+				Op: OR,
+				Children: []TagClause{
+					{
+						Op:  NEQ,
+						Tag: "a",
+					},
+					{
+						Op: AND,
+						Children: []TagClause{
+							{
+								Op:  EQ,
+								Tag: "b",
+							},
+							{
+								Op:  EQ,
+								Tag: "c",
+							},
+						},
+					},
+					{
+						Op:  NEQ,
 						Tag: "d",
 					},
 				},
@@ -115,19 +214,21 @@ func TestFilterParserTags(t *testing.T) {
 				"a:b:c,d:e:f,g:h:i",
 			},
 			want: TagClause{
-
 				Op: OR,
 				Children: []TagClause{
 					{
 						Op: AND,
 						Children: []TagClause{
 							{
+								Op:  EQ,
 								Tag: "a",
 							},
 							{
+								Op:  EQ,
 								Tag: "b",
 							},
 							{
+								Op:  EQ,
 								Tag: "c",
 							},
 						},
@@ -136,12 +237,15 @@ func TestFilterParserTags(t *testing.T) {
 						Op: AND,
 						Children: []TagClause{
 							{
+								Op:  EQ,
 								Tag: "d",
 							},
 							{
+								Op:  EQ,
 								Tag: "e",
 							},
 							{
+								Op:  EQ,
 								Tag: "f",
 							},
 						},
@@ -150,12 +254,15 @@ func TestFilterParserTags(t *testing.T) {
 						Op: AND,
 						Children: []TagClause{
 							{
+								Op:  EQ,
 								Tag: "g",
 							},
 							{
+								Op:  EQ,
 								Tag: "h",
 							},
 							{
+								Op:  EQ,
 								Tag: "i",
 							},
 						},
@@ -171,15 +278,18 @@ func TestFilterParserTags(t *testing.T) {
 				Op: OR,
 				Children: []TagClause{
 					{
+						Op:  EQ,
 						Tag: "a",
 					},
 					{
 						Op: AND,
 						Children: []TagClause{
 							{
+								Op:  EQ,
 								Tag: "b",
 							},
 							{
+								Op:  EQ,
 								Tag: "c",
 							},
 						},
@@ -188,9 +298,11 @@ func TestFilterParserTags(t *testing.T) {
 						Op: AND,
 						Children: []TagClause{
 							{
+								Op:  EQ,
 								Tag: "d",
 							},
 							{
+								Op:  EQ,
 								Tag: "e",
 							},
 						},
@@ -206,15 +318,18 @@ func TestFilterParserTags(t *testing.T) {
 				Op: OR,
 				Children: []TagClause{
 					{
+						Op:  EQ,
 						Tag: "a",
 					},
 					{
 						Op: AND,
 						Children: []TagClause{
 							{
+								Op:  EQ,
 								Tag: "b",
 							},
 							{
+								Op:  EQ,
 								Tag: "c",
 							},
 						},
@@ -223,12 +338,15 @@ func TestFilterParserTags(t *testing.T) {
 						Op: AND,
 						Children: []TagClause{
 							{
+								Op:  EQ,
 								Tag: "d",
 							},
 							{
+								Op:  EQ,
 								Tag: "e",
 							},
 							{
+								Op:  EQ,
 								Tag: "f",
 							},
 						},
@@ -247,17 +365,19 @@ func TestFilterParserTags(t *testing.T) {
 						Op: AND,
 						Children: []TagClause{
 							{
+								Op:  EQ,
 								Tag: "a",
 							},
-
 							{
+								Op:  EQ,
 								Tag: "b",
 							},
-
 							{
+								Op:  EQ,
 								Tag: "c",
 							},
 							{
+								Op:  EQ,
 								Tag: "d",
 							},
 						},
@@ -266,17 +386,19 @@ func TestFilterParserTags(t *testing.T) {
 						Op: AND,
 						Children: []TagClause{
 							{
+								Op:  EQ,
 								Tag: "e",
 							},
-
 							{
+								Op:  EQ,
 								Tag: "f",
 							},
-
 							{
+								Op:  EQ,
 								Tag: "g",
 							},
 							{
+								Op:  EQ,
 								Tag: "h",
 							},
 						},
@@ -310,6 +432,91 @@ func TestFilterParserTags(t *testing.T) {
 			if diff := cmp.Diff(got, tc.want); diff != "" {
 				t.Fatalf("got[-], want[+], diff = %s", diff)
 			}
+		})
+	}
+}
+
+func TestFilterMatchTags(t *testing.T) {
+	t.Parallel()
+
+	type testcase struct {
+		filters []string
+		target  []string // target tags
+		want    bool
+	}
+
+	for _, tc := range []testcase{
+		{
+			target: []string{"a", "b"},
+			filters: []string{
+				"a",
+			},
+			want: true,
+		},
+		{
+			target: []string{"a", "b"},
+			filters: []string{
+				"~a",
+			},
+			want: false,
+		},
+		{
+			target: []string{"a", "b"},
+			filters: []string{
+				"~a,b",
+			},
+			want: true,
+		},
+		{
+			target: []string{"a", "b"},
+			filters: []string{
+				"a,~b",
+			},
+			want: true,
+		},
+		{
+			target: []string{"a", "b"},
+			filters: []string{
+				"~a,~b",
+			},
+			want: false,
+		},
+		{
+			target: []string{"a", "b"},
+			filters: []string{
+				"~c",
+			},
+			want: true,
+		},
+		{
+			target: []string{"a", "b"},
+			filters: []string{
+				"~c",
+			},
+			want: true,
+		},
+		{
+			target: []string{"a", "b"},
+			filters: []string{
+				"~c:~a",
+			},
+			want: false,
+		},
+		{
+			target: []string{"a", "b"},
+			filters: []string{
+				"a:b:~a",
+			},
+			want: false,
+		},
+	} {
+		name := fmt.Sprintf("test if filters:%v match:%v", tc.filters, tc.target)
+		t.Run(name, func(t *testing.T) {
+			clauses, _, err := ParseTagClauses(tc.filters...)
+			assert.NoError(t, err) // only valid clauses tested here
+			res := MatchTags(clauses, tc.target)
+			assert.IsTrue(t, res == tc.want,
+				"filter %v doesnt match tags %v", tc.filters, tc.target)
 		})
 	}
 }

--- a/config/filter/filter_test.go
+++ b/config/filter/filter_test.go
@@ -424,7 +424,7 @@ func TestFilterParserTags(t *testing.T) {
 		},
 	} {
 		t.Run(fmt.Sprintf("filters:%v", tc.filters), func(t *testing.T) {
-			got, hasClauses, err := ParseTagClauses(tc.filters...)
+			got, hasClauses, err := parseInternalTagClauses(tc.filters...)
 			errtest.Assert(t, err, tc.err)
 			if !hasClauses != tc.noClauses {
 				t.Fatalf("filter emptiness mismatch: %t != %t", !hasClauses, tc.noClauses)
@@ -512,7 +512,7 @@ func TestFilterMatchTags(t *testing.T) {
 	} {
 		name := fmt.Sprintf("test if filters:%v match:%v", tc.filters, tc.target)
 		t.Run(name, func(t *testing.T) {
-			clauses, _, err := ParseTagClauses(tc.filters...)
+			clauses, _, err := parseInternalTagClauses(tc.filters...)
 			assert.NoError(t, err) // only valid clauses tested here
 			res := MatchTags(clauses, tc.target)
 			assert.IsTrue(t, res == tc.want,


### PR DESCRIPTION
# Reason for This Change

Add `--no-tags` flag which filter by stacks not having the provided list of tags.
It could be combined with `--tags` and in such case a `AND` condition is generated.
Then `--tags prod --no-tags k8s` will return all stacks which have `prod` tag and not `k8s` tag.

## Description of Changes

The internal tag filter was updated to support tag inequality but the syntax is not exposed to users.
