### PR TITLE
fix: rollback change that enforced parenthesis on non-literal keys

### DIFF
--- a/generate/genhcl/partial_eval_test.go
+++ b/generate/genhcl/partial_eval_test.go
@@ -109,7 +109,76 @@ func TestPartialEval(t *testing.T) {
 					global    = global.ref,
 				 }`),
 			),
-			wantErr: errors.E(eval.ErrNonLiteralKey),
+			want: Doc(
+				Expr("obj", `{
+					local = local.ref
+					global = 666	
+				}`),
+			),
+		},
+		{
+			name: "global references in object keys without parenthesis",
+			globals: Doc(
+				Globals(
+					Str("key", "key"),
+					Str("value", "value"),
+				),
+			),
+			config: Doc(
+				Expr("obj", `{
+					global.key    = global.value,
+				 }`),
+			),
+			want: Doc(
+				Expr("obj", `{
+					"key" = "value"	
+				}`),
+			),
+		},
+		{
+			name: "tm funcalls in object keys without parenthesis",
+			globals: Doc(
+				Globals(
+					Str("key", "key"),
+					Str("value", "value"),
+				),
+			),
+			config: Doc(
+				Expr("obj", `{
+					tm_upper(global.key)    = global.value,
+				 }`),
+			),
+			want: Doc(
+				Expr("obj", `{
+					"KEY" = "value"	
+				}`),
+			),
+		},
+		{
+			name: "unknown namespace in object key without parenthesis",
+			config: Doc(
+				Expr("obj", `{
+					aws.vpc = "something"
+				 }`),
+			),
+			want: Doc(
+				Expr("obj", `{
+					aws.vpc = "something"	
+				}`),
+			),
+		},
+		{
+			name: "unknown funcall in object key without parenthesis",
+			config: Doc(
+				Expr("obj", `{
+					anyfunc(local.a) = "something"
+				 }`),
+			),
+			want: Doc(
+				Expr("obj", `{
+					anyfunc(local.a) = "something"
+				}`),
+			),
 		},
 		{
 			name: "mixed references on list",

--- a/hcl/eval/partial_eval.go
+++ b/hcl/eval/partial_eval.go
@@ -226,6 +226,7 @@ func (c *Context) partialEvalObjectKey(key *hclsyntax.ObjectConsKeyExpr) (hhcl.E
 
 	if scope, ok := key.Wrapped.(*hclsyntax.ScopeTraversalExpr); ok {
 		wrapped, err = c.partialEvalScopeTrav(scope, scopeTraversalOption{
+			// This is needed for back-compatibility with old partial evaluator.
 			allowRootEval: false,
 		})
 	} else {

--- a/hcl/eval/partial_eval.go
+++ b/hcl/eval/partial_eval.go
@@ -30,9 +30,6 @@ const (
 	ErrPartial             errors.Kind = "partial evaluation failed"
 	ErrInterpolation       errors.Kind = "interpolation failed"
 	ErrForExprDisallowEval errors.Kind = "`for` expression disallow globals/terramate variables"
-	ErrNonLiteralKey       errors.Kind = ("If this expression is intended to be a reference, wrap it in" +
-		" parentheses. If it's instead intended as a literal name containing periods, wrap it in quotes " +
-		"to create a string literal.")
 )
 
 func (c *Context) partialEval(expr hhcl.Expression) (newexpr hhcl.Expression, err error) {

--- a/hcl/eval/partial_eval_test.go
+++ b/hcl/eval/partial_eval_test.go
@@ -207,6 +207,19 @@ EOT
 			}`,
 		},
 		{
+			expr: `global`,
+			want: `{
+				list   = [0, 1, 2, 3]
+				number = 10
+				obj = {
+				  a = 0
+				  b = ["terramate"]
+				}
+				string  = "terramate"
+				strings = ["terramate", "is", "fun"]
+			}`,
+		},
+		{
 			expr: `{
 				(global.string) = 1
 			}`,

--- a/hcl/eval/partial_eval_test.go
+++ b/hcl/eval/partial_eval_test.go
@@ -184,6 +184,30 @@ EOT
 		},
 		{
 			expr: `{
+				global = 1
+			}`,
+			want: `{
+				global = 1	
+			}`,
+		},
+		{
+			expr: `{
+				(global) = 1
+			}`,
+			want: `{
+				(global) = 1	
+			}`,
+		},
+		{
+			expr: `{
+				(iter) = 1
+			}`,
+			want: `{
+				(iter) = 1	
+			}`,
+		},
+		{
+			expr: `{
 				(global.string) = 1
 			}`,
 			want: `{

--- a/hcl/eval/partial_eval_test.go
+++ b/hcl/eval/partial_eval_test.go
@@ -191,6 +191,30 @@ EOT
 			}`,
 		},
 		{
+			expr: `{
+				(tm_upper(global.string)) = 1
+			}`,
+			want: `{
+				("TERRAMATE") = 1
+			}`,
+		},
+		{
+			expr: `{
+				upper(global.string) = 1
+			}`,
+			want: `{
+				upper("terramate") = 1
+			}`,
+		},
+		{
+			expr: `{
+				upper("a") = 1
+			}`,
+			want: `{
+				upper("a") = 1
+			}`,
+		},
+		{
 			expr: `funcall()`,
 		},
 		{

--- a/hcl/eval/partial_eval_test.go
+++ b/hcl/eval/partial_eval_test.go
@@ -176,6 +176,14 @@ EOT
 		},
 		{
 			expr: `{
+				global.obj.b[0] = 1
+			}`,
+			want: `{
+				"terramate" = 1	
+			}`,
+		},
+		{
+			expr: `{
 				(global.string) = 1
 			}`,
 			want: `{
@@ -212,6 +220,22 @@ EOT
 			}`,
 			want: `{
 				upper("a") = 1
+			}`,
+		},
+		{
+			expr: `{
+				(upper("a")) = 1
+			}`,
+			want: `{
+				(upper("a")) = 1
+			}`,
+		},
+		{
+			expr: `{
+				a.b.c = 1
+			}`,
+			want: `{
+				a.b.c = 1
 			}`,
 		},
 		{


### PR DESCRIPTION
The PR #838 introduced a change that breaks some Terraform use cases.
When using the default HCL evaluator (from hashicorp), it fails if object keys contains a path traversal (a variable reference). Example:
https://go.dev/play/p/wUb09u5E7ls

This was always the case for fully evaluated expressions (like `globals` and `lets`) but partial-evaluator never failed in such cases because it bypassed the HCL evaluator and it did evaluation at the tokens level, ignoring most of the AST structure.

The new partial-evaluator works on top of parsed AST nodes and then the node had this information, if the key was wrapped or not, and then we followed the HCL default evaluator logic for consistency's sake but this break some TF use cases as reported in #861.

Closes #861 