### PR TITLE
feat: add basic version upgrade check

### DIFF
--- a/cmd/terramate/cli/checkpoint_localhost.go
+++ b/cmd/terramate/cli/checkpoint_localhost.go
@@ -1,3 +1,17 @@
+// Copyright 2023 Mineiros GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //go:build localhostTelemetry
 
 package cli

--- a/cmd/terramate/cli/checkpoint_localhost.go
+++ b/cmd/terramate/cli/checkpoint_localhost.go
@@ -1,0 +1,13 @@
+//go:build localhostTelemetry
+
+package cli
+
+import "net/url"
+
+func defaultTelemetryEndpoint() url.URL {
+	var u url.URL
+	u.Scheme = "http"
+	u.Host = "localhost:3000"
+	u.Path = "/"
+	return u
+}

--- a/cmd/terramate/cli/checkpoint_mineiros.go
+++ b/cmd/terramate/cli/checkpoint_mineiros.go
@@ -1,3 +1,17 @@
+// Copyright 2023 Mineiros GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //go:build !localhostTelemetry
 
 package cli

--- a/cmd/terramate/cli/checkpoint_mineiros.go
+++ b/cmd/terramate/cli/checkpoint_mineiros.go
@@ -1,0 +1,13 @@
+//go:build !localhostTelemetry
+
+package cli
+
+import "net/url"
+
+func defaultTelemetryEndpoint() url.URL {
+	var u url.URL
+	u.Scheme = "https"
+	u.Host = "checkpoint-api.mineiros.io"
+	u.Path = "/"
+	return u
+}

--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -324,12 +324,31 @@ func newCLI(version string, args []string, stdin io.Reader, stdout, stderr io.Wr
 
 		info := <-checkpointResults
 
-		if info != nil && info.Outdated {
-			releaseDate := time.Unix(int64(info.CurrentReleaseDate), 0).UTC()
-			output.MsgStdOut("Your version of Terramate is out of date! The latest version\n"+
-				"is %s (released on %s). You can update by downloading from %s",
-				info.CurrentVersion, releaseDate.Format(time.UnixDate),
-				info.CurrentDownloadURL)
+		if info != nil {
+			if info.Outdated {
+				releaseDate := time.Unix(int64(info.CurrentReleaseDate), 0).UTC()
+				output.MsgStdOut("\nYour version of Terramate is out of date! The latest version\n"+
+					"is %s (released on %s).\nYou can update by downloading from %s",
+					info.CurrentVersion, releaseDate.Format(time.UnixDate),
+					info.CurrentDownloadURL)
+			}
+
+			if len(info.Alerts) > 0 {
+				plural := ""
+				if len(info.Alerts) > 1 {
+					plural = "s"
+				}
+
+				output.MsgStdOut("\nYour version of Terramate has %d alert%s:\n", len(info.Alerts), plural)
+
+				for _, alert := range info.Alerts {
+					urlDesc := ""
+					if alert.URL != "" {
+						urlDesc = stdfmt.Sprintf(" (more information at %s)", alert.URL)
+					}
+					output.MsgStdOut("\t- [%s] %s%s", alert.Level, alert.Message, urlDesc)
+				}
+			}
 		}
 
 		return &cli{exit: true}

--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -325,8 +325,10 @@ func newCLI(version string, args []string, stdin io.Reader, stdout, stderr io.Wr
 		info := <-checkpointResults
 
 		if info != nil && info.Outdated {
+			releaseDate := time.Unix(int64(info.CurrentReleaseDate), 0).UTC()
 			output.MsgStdOut("Your version of Terramate is out of date! The latest version\n"+
-				"is %s. You can update by downloading from %s", info.CurrentVersion,
+				"is %s (released on %s). You can update by downloading from %s",
+				info.CurrentVersion, releaseDate.Format(time.UnixDate),
 				info.CurrentDownloadURL)
 		}
 
@@ -1747,12 +1749,14 @@ func runCheckpoint(version string, result chan *checkpoint.CheckResponse) {
 		logger.Debug().Msg("signature and cache are disabled because user HOME was not detected")
 	}
 
-	resp, err := checkpoint.Check(&checkpoint.CheckParams{
-		Product:       "terramate",
-		Version:       version,
-		SignatureFile: signatureFile,
-		CacheFile:     cacheFile,
-	})
+	resp, err := checkpoint.CheckAt(defaultTelemetryEndpoint(),
+		&checkpoint.CheckParams{
+			Product:       "terramate",
+			Version:       version,
+			SignatureFile: signatureFile,
+			CacheFile:     cacheFile,
+		},
+	)
 
 	if err != nil {
 		logger.Debug().Msgf("checkpoint error: %v", err)

--- a/cmd/terramate/e2etests/run_test.go
+++ b/cmd/terramate/e2etests/run_test.go
@@ -2282,6 +2282,7 @@ func TestRunWitCustomizedEnv(t *testing.T) {
 	}
 
 	wantenv := append(hostenv,
+		"CHECKPOINT_DISABLE=1", // e2e tests have telemetry disabled
 		fmt.Sprintf("FROM_META=%s", stackName),
 		fmt.Sprintf("FROM_GLOBAL=%s", stackGlobal),
 		fmt.Sprintf("FROM_ENV=%s", exportedTerramateTest),

--- a/cmd/terramate/e2etests/runner_test.go
+++ b/cmd/terramate/e2etests/runner_test.go
@@ -16,6 +16,7 @@ package e2etest
 
 import (
 	"bytes"
+	"os"
 	"os/exec"
 	"regexp"
 	"strings"
@@ -148,11 +149,17 @@ func (tm tmcli) newCmd(args ...string) *testCmd {
 
 	allargs = append(allargs, args...)
 
+	env := tm.env
+	if len(env) == 0 {
+		env = os.Environ()
+	}
+	env = append(env, "CHECKPOINT_DISABLE=1")
+
 	cmd := exec.Command(terramateTestBin, allargs...)
 	cmd.Stdout = stdout
 	cmd.Stderr = stderr
 	cmd.Stdin = stdin
-	cmd.Env = tm.env
+	cmd.Env = env
 
 	return &testCmd{
 		t:      t,

--- a/docs/upgrade-check.md
+++ b/docs/upgrade-check.md
@@ -1,0 +1,22 @@
+# Upgrade and Security Bulletin Checks
+
+The Terramate CLI commands interacts with the [Mineiros Checkpoint](https://checkpoint-api.mineiros.io/)
+service to check for the availability of new versions and for critical security 
+bulletins about the current version.
+
+The Checkpoint service is based on Hashicorp's [Checkpoint](https://checkpoint.hashicorp.com/)
+which is used by most of theirs products, including Terraform.
+
+One place where the effect of this can be seen is in `terramate version`, where it 
+is used by default to indicate in the output when a newer version is available.
+
+Only _anonymous information_, which cannot be used to identify the user or host, is
+sent to Checkpoint. An anonymous ID is sent which helps de-duplicate warning
+messages. Both the anonymous id and the use of checkpoint itself are completely 
+optional and can be disabled.
+
+Checkpoint itself can be entirely disabled by setting the environment variable
+`CHECKPOINT_DISABLE` to any non-empty value.
+
+The [Checkpoint client code](https://github.com/mineiros-io/go-checkpoint) used 
+by Terramate is available for review by any interested party.

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/hashicorp/hcl/v2 v2.14.1
 	github.com/hashicorp/terraform v0.15.3
 	github.com/hectane/go-acl v0.0.0-20190604041725-da78bae5fc95
+	github.com/i4ki/go-checkpoint v0.0.0-20230322135254-b728828d7181
 	github.com/madlambda/spells v0.4.2
 	github.com/posener/complete v1.2.3
 	github.com/willabides/kongplete v0.2.0
@@ -26,7 +27,6 @@ require (
 	github.com/go-git/gcfg v1.5.0 // indirect
 	github.com/go-git/go-billy/v5 v5.3.1 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
-	github.com/i4ki/go-checkpoint v0.0.0-20230322135254-b728828d7181 // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
 	github.com/mattn/go-colorable v0.1.12 // indirect
 	github.com/mattn/go-isatty v0.0.14 // indirect

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/hashicorp/hcl/v2 v2.14.1
 	github.com/hashicorp/terraform v0.15.3
 	github.com/hectane/go-acl v0.0.0-20190604041725-da78bae5fc95
-	github.com/i4ki/go-checkpoint v0.0.0-20230322135254-b728828d7181
+	github.com/i4ki/go-checkpoint v0.0.0-20230323112005-d8ee97cebfa8
 	github.com/madlambda/spells v0.4.2
 	github.com/posener/complete v1.2.3
 	github.com/willabides/kongplete v0.2.0

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,8 @@ require (
 	github.com/acomagu/bufpipe v1.0.3 // indirect
 	github.com/go-git/gcfg v1.5.0 // indirect
 	github.com/go-git/go-billy/v5 v5.3.1 // indirect
+	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
+	github.com/i4ki/go-checkpoint v0.0.0-20230322135254-b728828d7181 // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
 	github.com/mattn/go-colorable v0.1.12 // indirect
 	github.com/mattn/go-isatty v0.0.14 // indirect
@@ -40,7 +42,7 @@ require (
 	github.com/google/uuid v1.2.0
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
-	github.com/hashicorp/go-uuid v1.0.1 // indirect
+	github.com/hashicorp/go-uuid v1.0.3 // indirect
 	github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/go-wordwrap v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -285,7 +285,6 @@ github.com/hashicorp/go-slug v0.4.1/go.mod h1:I5tq5Lv0E2xcNXNkmx7BSfzi1PsJ2cNjs3
 github.com/hashicorp/go-sockaddr v0.0.0-20180320115054-6d291a969b86/go.mod h1:7Xibr9yA9JjQq1JpNB2Vw7kxv8xerXegt+ozgdvDeDU=
 github.com/hashicorp/go-tfe v0.14.0/go.mod h1:B71izbwmCZdhEo/GzHopCXN3P74cYv2tsff1mxY4J6c=
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
-github.com/hashicorp/go-uuid v1.0.1 h1:fv1ep09latC32wFoVwnqcnKJGnMSdBanPczbHAYm1BE=
 github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.3 h1:2gKiV6YVmrJ1i2CKKa9obLvRieoRGviZFL26PcT/Co8=
 github.com/hashicorp/go-uuid v1.0.3/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=

--- a/go.sum
+++ b/go.sum
@@ -267,6 +267,8 @@ github.com/hashicorp/go-azure-helpers v0.14.0/go.mod h1:kR7+sTDEb9TOp/O80ss1UEJg
 github.com/hashicorp/go-checkpoint v0.5.0/go.mod h1:7nfLNL10NsxqO4iWuW6tWW0HjZuDrwkBuEQsVcpCOgg=
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
+github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=
+github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
 github.com/hashicorp/go-getter v1.5.1/go.mod h1:a7z7NPPfNQpJWcn4rSWFtdrSldqLdLPEF3d8nFMsSLM=
 github.com/hashicorp/go-hclog v0.14.1/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
 github.com/hashicorp/go-hclog v0.15.0/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
@@ -285,6 +287,8 @@ github.com/hashicorp/go-tfe v0.14.0/go.mod h1:B71izbwmCZdhEo/GzHopCXN3P74cYv2tsf
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.1 h1:fv1ep09latC32wFoVwnqcnKJGnMSdBanPczbHAYm1BE=
 github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
+github.com/hashicorp/go-uuid v1.0.3 h1:2gKiV6YVmrJ1i2CKKa9obLvRieoRGviZFL26PcT/Co8=
+github.com/hashicorp/go-uuid v1.0.3/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-version v1.0.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/go-version v1.1.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/go-version v1.2.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
@@ -313,6 +317,8 @@ github.com/hectane/go-acl v0.0.0-20190604041725-da78bae5fc95/go.mod h1:QiyDdbZLa
 github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/huandu/xstrings v1.3.2/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
+github.com/i4ki/go-checkpoint v0.0.0-20230322135254-b728828d7181 h1:Jg0sgQN0HhJrdQ+eHWYYZmRQf7+60BSgzkiQ903CU9s=
+github.com/i4ki/go-checkpoint v0.0.0-20230322135254-b728828d7181/go.mod h1:dXcVtN65CUCF57j3tim3w8l04evJMbppYnxR3/8cXEg=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=

--- a/go.sum
+++ b/go.sum
@@ -316,8 +316,8 @@ github.com/hectane/go-acl v0.0.0-20190604041725-da78bae5fc95/go.mod h1:QiyDdbZLa
 github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/huandu/xstrings v1.3.2/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
-github.com/i4ki/go-checkpoint v0.0.0-20230322135254-b728828d7181 h1:Jg0sgQN0HhJrdQ+eHWYYZmRQf7+60BSgzkiQ903CU9s=
-github.com/i4ki/go-checkpoint v0.0.0-20230322135254-b728828d7181/go.mod h1:dXcVtN65CUCF57j3tim3w8l04evJMbppYnxR3/8cXEg=
+github.com/i4ki/go-checkpoint v0.0.0-20230323112005-d8ee97cebfa8 h1:+eeTJF9zkMUL2A3VPklatW8TA7tSZVOUBZNXg/XcHg0=
+github.com/i4ki/go-checkpoint v0.0.0-20230323112005-d8ee97cebfa8/go.mod h1:DDcixL160KZwFnyF+NPbfDK+/u3djb9sXsKQIJPQSxU=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=

--- a/makefiles/common.mk
+++ b/makefiles/common.mk
@@ -39,6 +39,11 @@ coverage:
 coverage/show: coverage
 	go tool cover -html=$(COVERAGE_REPORT)
 
+## build a test binary -- not static, telemetry sent to localhost, etc
+.PHONY: test/build
+test/build:
+	go build -tags localhostTelemetry -o bin/test-terramate ./cmd/terramate
+
 ## start fuzzying to generate some new corpus/find errors on partial eval
 .PHONY: test/fuzz/eval
 test/fuzz/eval:


### PR DESCRIPTION
Introduces upgrade checks in the `terramate version` command.
It uses the same technology used by Terraform.
- backend based on: https://checkpoint.hashicorp.com/
- client based on: https://github.com/hashicorp/go-checkpoint

The check can be disabled by exporting the environment variable `CHECKPOINT_DISABLE=1`.
A completely random signature (UUID v4) is generated and stored in `~/.terramate.d/checkpoint_signature`.

The check is cached and invalidated every 48 hours.

The implementation mimicks what Terraform does, the implementation is very similar.