### PR TITLE
chore: add language type in the documentation code blocks.

### DIFF
--- a/docs/change-detection.md
+++ b/docs/change-detection.md
@@ -58,7 +58,7 @@ the stacks modified by the last rebase, you first need to identify the base
 commit (the commit before the merge) and then provide this commit hash in the
 `--git-change-base` flag.
 
-```
+```console
 $ git branch
 main
 $ git rev-parse HEAD
@@ -93,7 +93,7 @@ they change.
 
 Example:
 
-```
+```hcl
 stack {
    watch = [
       "/external/file1.txt",

--- a/docs/cmdline.md
+++ b/docs/cmdline.md
@@ -60,7 +60,7 @@ All sub-commands support the `--help` flag as well for specific details.
 Terramate supports autocompletion of commands for `bash`, `zsh` and `fish`. To
 install the completion just run the command below and open a new shell session:
 
-```sh
+```bash
 terramate install-completions
 ```
 
@@ -97,7 +97,7 @@ On _Windows_, the file must be named `terraform.rc` and placed in the user's
 version and system configuration. You can use the command below in _PowerShell_ to 
 find its location:
 
-```sh
+```PowerShell
 $env:APPDATA
 ```
 
@@ -108,6 +108,6 @@ The default location of the Terramate CLI configuration file can also be specifi
 using the `TM_CLI_CONFIG_FILE` environment variable. 
 Example:
 
-```sh
+```bash
 TM_CLI_CONFIG_FILE=/etc/terramaterc terramate run -- <cmd>
 ```

--- a/docs/codegen/generate-hcl.md
+++ b/docs/codegen/generate-hcl.md
@@ -358,7 +358,7 @@ generate_hcl "main.tf" {
 
 And it will generate the following `main.tf` file:
 
-```
+```hcl
 resource "myresource" "name" {
   count = var.enabled ? 1 : 0
   data  = "terramate_data"

--- a/docs/config-overview.md
+++ b/docs/config-overview.md
@@ -19,7 +19,7 @@ whenever possible. See [Config Merging](#config-merging) for details.
 Each configuration can import other configurations using the `import` block.
 See the example below:
 
-```
+```hcl
 # globals.tm
 
 import {
@@ -69,7 +69,7 @@ The [globals](https://github.com/mineiros-io/terramate/blob/main/docs/sharing-da
 
 For example, the configuration below is valid:
 
-```
+```hcl
 terramate {
     required_version = "~> 0.1"
 }
@@ -87,7 +87,7 @@ And the blocks can also be defined in different files.
 
 But the following is invalid:
 
-```
+```hcl
 terramate {
     required_version = "~> 0.1"
 }

--- a/docs/functions.md
+++ b/docs/functions.md
@@ -61,7 +61,7 @@ allowed, which currently is only the `generate_hcl.content` block.
 
 To use `tm_hcl_expression`, lets say we have a global named data defined like this:
 
-```
+```hcl
 globals {
   data = "data"
 }

--- a/docs/map.md
+++ b/docs/map.md
@@ -56,7 +56,7 @@ Now it's time for a more useful example.
 
 Have a look in the `global.orders` list declared below:
 
-```
+```hcl
 globals {
   orders = [
     {name = "Morpheus", product = "sunglass", price = 100.5},
@@ -73,7 +73,7 @@ globals {
 
 Let's aggregate those values by `name`, by using the `map` block as defined below:
 
-```
+```hcl
 globals {
   map totals {
     for_each = global.orders
@@ -89,7 +89,7 @@ globals {
 
 Which will result in the global object below:
 
-```
+```hcl
 totals = {
   Anderson = {
     total_spent = 112.3

--- a/docs/orchestration.md
+++ b/docs/orchestration.md
@@ -245,7 +245,7 @@ on it, it will be ignored when calculating order.
 An example of such a command would be using terramate to run **terraform apply**,
 but only on changes stacks, like this:
 
-```
+```bash
 terramate run --changed terraform apply
 ```
 

--- a/docs/sharing-data.md
+++ b/docs/sharing-data.md
@@ -33,7 +33,7 @@ The **globals** block also supports setting attributes inside an
 existent object. For the globals defined in the above example, the block
 below will set additional properties of the `global.obj` variable:
 
-```
+```hcl
 globals obj {
   number = 10
 }
@@ -52,7 +52,7 @@ In the same way, multiple labels can be provided, and Terramate will
 automatically create the object keys as needed to fulfill the user
 intent. Example:
 
-```
+```hcl
 globals "obj" "child" "grandchild" {
   list = []
 }
@@ -198,7 +198,7 @@ globals {
 
 Now `stacks/stack-1` globals set is:
 
-```
+```hcl
 project_name = "awesome-project"
 useful       = "overriden by stack-1"
 stack_data   = "some specialized stack-1 data"
@@ -206,7 +206,7 @@ stack_data   = "some specialized stack-1 data"
 
 And for `stacks/stack-2` it remains:
 
-```
+```hcl
 project_name = "awesome-project"
 useful       = "useful"
 ```
@@ -235,7 +235,7 @@ globals {
 
 Now `stacks/stack-1` globals set is:
 
-```
+```hcl
 project_name = "awesome-project"
 useful       = "useful"
 object       = { field_a = "overriden_field_a" }
@@ -243,7 +243,7 @@ object       = { field_a = "overriden_field_a" }
 
 And for `stacks/stack-2`:
 
-```
+```hcl
 project_name = "awesome-project"
 useful       = "useful"
 object       = { field_a = "field_a", field_b = "field_b" }
@@ -251,7 +251,7 @@ object       = { field_a = "field_a", field_b = "field_b" }
 
 It is also possible to **unset** a global by setting it to the value `unset`:
 
-```
+```hcl
 globals {
   a = unset
 }

--- a/docs/tag-filter.md
+++ b/docs/tag-filter.md
@@ -34,7 +34,7 @@ Examples:
 
 Below is the formal grammar definition:
 
-```
+```ebnf
 query         ::= or_term {',' or_term}
 or_term       ::= and_term {':' and_term}
 and_term      ::= tagname


### PR DESCRIPTION
# Reason for This Change

The code blocks must have the correct language type in order to be nicely rendered in the website.

## Description of Changes

Add the language in each markdown code block.
