### PR TITLE
chore: introduces the globals2 package.

### DIFF
--- a/globals2/README.md
+++ b/globals2/README.md
@@ -1,0 +1,397 @@
+# Globals Architecture
+
+Nomenclature:
+
+- `reference` (or `ref`)
+
+A `ref` is a value acessor or query, and it can appear in both sides of a 
+globals declaration statement.
+
+The code below:
+
+```
+globals {
+    a = global.b.c
+}
+```
+
+has two _references_:
+
+1. `global.a`     (in the left-hand-side)
+2. `global.b.c`   (in the right-hand-side)
+
+- Globals statement
+
+A _statement_ is a global value definition and it has two parts, the left-hand-side
+(lhs) _ref_ and the right-hand-side (rhs) expression.
+
+```
+<ref> = <expression>
+```
+
+A `globals` block is interpreted as 0 or more statements.
+Example:
+
+```hcl
+globals "a" "b" {
+    c = {
+        d = 1
+    }
+    z = 2
+}
+```
+is interpreted as the list of statements below:
+
+```
+global.a.b.c.d = 1
+global.z = 2
+```
+
+- The _origin reference_
+
+The _origin_ of a reference is the `globals` attribute that originated the 
+statement. Very often it's the same _ref_ as the statement lhs _ref_ itself but
+that's not always the case:
+
+Example:
+
+```
+globals "a" {
+    b = 1
+}
+```
+
+In this case, it generates the statement below:
+```
+global.a.b = 1
+```
+and the _origin reference_ (the attribute that creates it) is `global.a.b`.
+But have a look at the example below:
+
+```
+globals a {
+    b = {
+        c = {
+            d = 1
+        }
+    }
+}
+```
+In this case it generates the statements below:
+
+```
+global.a.b.c.d = 1
+```
+but the _origin reference_ is `global.a.b` because that's the attribute that 
+originated the internal refs.
+
+## Properties
+
+- The `globals` are blocks that define the single runtime `global` object.
+- There could be multiple syntactic `globals` blocks defined in the same directory
+as long as their LHS _refs_ are unique.
+
+The configuration below:
+
+```hcl
+globals {
+    a = 1
+}
+
+globals {
+    b = 2
+    c = 3
+}
+
+globals {
+    z = 4
+}
+```
+
+is interpreted as:
+
+```
+# ref = value
+global.a = 1
+global.b = 2
+global.c = 3
+global.z = 4
+```
+
+The literal objects are also constructed as ref based assignments:
+
+
+```hcl
+# /globals.tm
+globals "a" "b" {
+    c = {
+        d = 1
+    }
+}
+
+globals {
+    a = {
+        b = {
+            c = {
+                e = 1
+                z = 1
+            }
+        }
+    }
+}
+```
+
+interpreted as:
+
+```
+global.a.b.c.e = 1
+global.a.b.c.z = 1
+global.a.b.c.d = 1
+```
+
+- The labels in the `globals` block is a syntax sugar for building a nested _LHS_
+`ref`, automatically building the intermediate object keys.
+
+```hcl
+globals a b c {
+    val = 1
+}
+```
+
+is interpreted as:
+
+```js
+if (!global.a) {
+    global.a = {}
+}
+if (!global.a.b) {
+    global.a.b = {}
+}
+if (!global.a.b.c) {
+    global.a.b.c = {}
+}
+
+global.a.b.c.val = 1
+```
+
+By the same definition above, a labeled globals block without any attributes
+just build the intermediate refs:
+
+```hcl
+globals "a" "b" {}
+```
+
+is interpreted as:
+
+```js
+if (!global.a) {
+    global.a = {}
+}
+if (!global.a.b) {
+    global.a.b = {}
+}
+```
+
+- scopes are defined by the directory hierarchy
+
+Each directory defines a new global scope which inherits parent globals.
+
+```hcl
+# /root.tm
+globals {
+    a = 1
+}
+```
+and
+```hcl
+# /child/globals.tm
+globals {
+    b = global.a
+}
+```
+and
+```hcl
+# /child/grand-child/globals.tm
+globals {
+    c = global.b
+}
+```
+
+The code above defines the scope tree below:
+
+```hcl
+scope = {
+    global = {
+        a = 1
+    }
+    scopes = {
+        child = {
+            global = {
+                b = global.a
+            },
+            scopes = {
+                "grand-child": {
+                    global = {
+                        c = global.b
+                    }
+                }
+            }
+        }
+    }
+}
+```
+
+The `grand-child` scope inherits the `child` and `root` scopes.
+The `child` scope inherits the `root` scope.
+
+- implicit order of evaluation 
+
+The order of evaluation of global values are implicitly defined by their dependencies and _origin ref_ size (ie `global.a` evaluates before `global.a.b`).
+
+Case 1:
+
+```hcl
+# /globals.tm
+globals {
+    b = global.a
+    a = 1
+}
+```
+
+As `global.b` depends on `global.a`, then the order of evaluation is:
+
+```
+global.a = 1
+global.b = global.a
+```
+
+When multiple global lhs _references_ target the same object tree, then
+statements with smaller _origin reference_ evaluates first:
+
+Example:
+
+```hcl
+# /globals.tm
+globals "a" "b" {
+    c = {
+        d = 1
+    }
+}
+
+globals {
+    a = {
+        b = {
+            c = {
+                e = 1
+                z = 1
+            }
+        }
+    }
+}
+```
+
+interpreted as:
+
+```
+global.a.b.c.e = 1  # origin reference is global.a
+global.a.b.c.z = 1  # origin reference is global.a
+global.a.b.c.d = 1  # origin reference is global.a.b.c
+```
+
+ # Evaluation
+
+When evaluating an expression, just the _referenced_ globals are evaluated.
+If a target _ref_ is not found in the current scope, then it's looked up in the 
+parent scope until root is reached or a _origin reference_ is found which is a 
+subpath of the target _ref_.
+
+Case 1: _ref_ is in the same scope (no dependency).
+
+target ref: `global.a.b` in `/child` scope
+
+```hcl
+# /root.tm
+globals {
+    a = {
+        b = 1
+    }
+    b = 1
+    c = {
+        b = 1
+    }
+}
+```
+
+```hcl
+# /child/globals.tm
+globals a {
+    b = 2
+}
+```
+
+evaluates to `2` and only the statement `global.a.b = 2` from the `/child` scope is evaluated.
+
+Case 2: _ref_ is in the same scope (with dependencies).
+
+target ref: `global.a.b` in `/child` scope
+
+```hcl
+# /root.tm
+globals "a" {
+    b = 1
+}
+
+globals {
+    c = 2
+}
+```
+
+```hcl
+# /child/globals.tm
+globals "a" {
+    b = global.c
+}
+```
+evaluates to `2` because _origin ref_ `global.a.b` is found in the same scope,
+then `global.c` is lookup in parent scope.
+
+Case 3: _ref_ is in the parent scope (no deps)
+
+target ref: `global.a.b` in `/child` scope
+
+```hcl
+# /root.tm
+globals "a" {
+    b = 1
+}
+```
+
+```hcl
+# /child/globals.tm
+```
+
+evaluates to `1` and only the `global.a.b = 1` from `/` is evaluated.
+
+Case 4: lazy evaluation
+
+target ref: `global.a.b` from `/child`.
+
+```hcl
+# /root.tm
+globals "a" {
+    b = global.c
+}
+
+globals {
+    c = 1
+}
+```
+
+```hcl
+# /child/globals.tm
+globals {
+    c = 2
+}
+```
+
+It evaluates to `2` and only `global.a.b = global.c` from `/` and `global.c` from `/child` are evaluated.

--- a/globals2/doc.go
+++ b/globals2/doc.go
@@ -1,0 +1,2 @@
+// Package globals2 implements the globals v2.
+package globals2

--- a/globals2/doc.go
+++ b/globals2/doc.go
@@ -1,2 +1,16 @@
+// Copyright 2023 Mineiros GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Package globals2 implements the globals v2.
 package globals2

--- a/globals2/globals.go
+++ b/globals2/globals.go
@@ -1,0 +1,338 @@
+// Copyright 2023 Mineiros GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package globals2
+
+import (
+	"fmt"
+	"sort"
+
+	hhcl "github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/mineiros-io/terramate/config"
+	"github.com/mineiros-io/terramate/errors"
+	"github.com/mineiros-io/terramate/hcl"
+	"github.com/mineiros-io/terramate/hcl/ast"
+	"github.com/mineiros-io/terramate/hcl/eval"
+	"github.com/mineiros-io/terramate/project"
+	orderedmap "github.com/wk8/go-ordered-map/v2"
+	"github.com/zclconf/go-cty/cty"
+)
+
+// Errors returned when parsing and evaluating globals.
+const (
+	ErrEval errors.Kind = "global eval"
+)
+
+type (
+	// G is the globals evaluator.
+	G struct {
+		ctx     *eval.Context
+		tree    *config.Tree
+		globals globals
+
+		// Scopes is a cache of scoped statements.
+		Scopes map[project.Path]Stmts
+	}
+
+	globals struct {
+		byref map[RefStr]cty.Value
+		bykey *orderedmap.OrderedMap[string, any]
+	}
+
+	// Stmt represents a `var-decl` stmt.
+	Stmt struct {
+		LHS   Ref
+		RHS   hhcl.Expression
+		Scope project.Path
+
+		Special bool
+
+		// Origin is the *origin ref*. If it's nil, then it's the same as LHS.
+		Origin Ref
+	}
+
+	Stmts []Stmt
+)
+
+// New globals evaluator.
+// TODO(i4k): better document.
+func New(ctx *eval.Context, tree *config.Tree) *G {
+	ctx.SetNamespace("global", map[string]cty.Value{})
+	return &G{
+		ctx:    ctx,
+		tree:   tree,
+		Scopes: make(map[project.Path]Stmts),
+		globals: globals{
+			byref: make(map[RefStr]cty.Value),
+			bykey: orderedmap.New[string, any](),
+		},
+	}
+}
+
+// Context returns the internal globals context.
+func (g *G) Context() *eval.Context { return g.ctx }
+
+// Eval the given expr.
+func (g *G) Eval(expr hhcl.Expression) (cty.Value, error) {
+	return g.eval(expr, map[RefStr]Ref{})
+}
+
+func (g *G) eval(expr hhcl.Expression, visited map[RefStr]Ref) (cty.Value, error) {
+	refs := refsOf(expr)
+	for _, dep := range refs {
+		if _, ok := visited[dep.AsKey()]; ok {
+			return cty.NilVal, errors.E(ErrEval, "cycle detected") // TODO(i4k): improve error msg
+
+		}
+		visited[dep.AsKey()] = dep
+		if _, ok := g.globals.byref[dep.AsKey()]; ok {
+			// dep already evaluated.
+			continue
+		}
+
+		stmts, err := g.lookupStmts(dep)
+		if err != nil {
+			return cty.NilVal, err
+		}
+		if len(stmts) == 0 {
+			return cty.NilVal, errors.E(
+				ErrEval,
+				"evaluating %s: no global declaration found for %s",
+				ast.TokensForExpression(expr).Bytes(), dep)
+		}
+		for _, stmt := range stmts {
+			if _, ok := g.globals.byref[stmt.LHS.AsKey()]; ok {
+				// stmt already evaluated.
+				// This can happen when the current scope is overriding the parent
+				// object but still the target expr is looking for the entire object
+				// so we still have to ascent into parent scope and then the "already
+				// overriden" refs show up here.
+				continue
+			}
+			if stmt.Special {
+				err := g.set(stmt.LHS, cty.ObjectVal(map[string]cty.Value{}))
+				if err != nil {
+					return cty.NilVal, errors.E(ErrEval, err)
+				}
+			} else {
+				val, err := g.eval(stmt.RHS, visited)
+				if err != nil {
+					return cty.NilVal, errors.E(err, ErrEval, "evaluating %s from %s scope", stmt.LHS, stmt.Scope)
+				}
+
+				g.set(stmt.LHS, val)
+			}
+		}
+	}
+
+	g.ctx.SetNamespace("global", tocty(g.globals.bykey).AsValueMap())
+
+	val, err := g.ctx.Eval(expr)
+	if err != nil {
+		return cty.NilVal, errors.E(err, ErrEval, "failed to evaluate: %s", ast.TokensForExpression(expr).Bytes())
+	}
+	return val, nil
+}
+
+func (g *G) loadStmtsAt(tree *config.Tree) (Stmts, error) {
+	stmts, ok := g.Scopes[tree.Dir()]
+	if ok {
+		return stmts, nil
+	}
+	for _, block := range tree.Node.Globals.AsList() {
+		if len(block.Labels) > 0 && !hclsyntax.ValidIdentifier(block.Labels[0]) {
+			return nil, errors.E(
+				hcl.ErrTerramateSchema,
+				"first global label must be a valid identifier but got %s",
+				block.Labels[0],
+			)
+		}
+
+		if len(block.Labels) > 0 && len(block.Attributes) == 0 {
+			stmts = append(stmts, Stmt{
+				Origin: Ref{
+					Object: "global",
+					Path:   block.Labels,
+				},
+				LHS: Ref{
+					Object: "global",
+					Path:   block.Labels,
+				},
+				Special: true,
+				Scope:   tree.Dir(),
+			})
+			continue
+		}
+
+		for _, attr := range block.Attributes.SortedList() {
+			origin := Ref{
+				Object: "global",
+				Path:   make([]string, len(block.Labels)+1),
+			}
+			copy(origin.Path, block.Labels)
+			origin.Path[len(block.Labels)] = attr.Name
+			blockStmts, err := g.stmtsOf(tree.Dir(), origin, origin.Path, attr.Expr)
+			if err != nil {
+				return nil, err
+			}
+			stmts = append(stmts, blockStmts...)
+		}
+	}
+
+	// bigger refs -> smaller refs
+	sort.Slice(stmts, func(i, j int) bool {
+		return len(stmts[i].Origin.Path) > len(stmts[j].Origin.Path)
+	})
+
+	g.Scopes[tree.Dir()] = stmts
+	return stmts, nil
+}
+
+func (g *G) lookupStmts(ref Ref) (Stmts, error) {
+	return g.lookupStmtsAt(ref, g.tree)
+}
+
+func (g *G) lookupStmtsAt(ref Ref, tree *config.Tree) (Stmts, error) {
+	stmts, err := g.loadStmtsAt(tree)
+	if err != nil {
+		return nil, err
+	}
+	filtered, found := stmts.filter(ref)
+	if found || tree.Parent == nil {
+		return filtered, nil
+	}
+	parentStmts, err := g.lookupStmtsAt(ref, tree.Parent)
+	if err != nil {
+		return nil, err
+	}
+	filtered = append(filtered, parentStmts...)
+	return filtered, nil
+}
+
+func (g *G) stmtsOf(scope project.Path, origin Ref, base []string, expr hhcl.Expression) (Stmts, error) {
+	stmts := Stmts{}
+	newbase := make([]string, len(base)+1)
+	copy(newbase, base)
+	last := len(newbase) - 1
+	switch e := expr.(type) {
+	case *hclsyntax.ObjectConsExpr:
+		for _, item := range e.Items {
+			val, err := g.Eval(item.KeyExpr)
+			if err != nil {
+				return nil, err
+			}
+
+			if !val.Type().Equals(cty.String) {
+				panic(errors.E("unexpected key type %s", val.Type().FriendlyName()))
+			}
+
+			newbase[last] = val.AsString()
+			newStmts, err := g.stmtsOf(scope, origin, newbase, item.ValueExpr)
+			if err != nil {
+				return nil, err
+			}
+			stmts = append(stmts, newStmts...)
+		}
+	default:
+		lhs := Ref{
+			Object: "global",
+			Path:   newbase[0:last],
+		}
+		stmts = append(stmts, Stmt{
+			Origin: origin,
+			LHS:    lhs,
+			RHS:    expr,
+			Scope:  scope,
+		})
+	}
+
+	return stmts, nil
+}
+
+func (g *G) set(ref Ref, val cty.Value) error {
+	g.globals.byref[ref.AsKey()] = val
+	// bykey
+	obj := g.globals.bykey
+
+	// len(path) >= 1
+
+	lastIndex := len(ref.Path) - 1
+	for _, path := range ref.Path[:lastIndex] {
+		v, ok := obj.Get(path)
+		if ok {
+			switch vv := v.(type) {
+			case *orderedmap.OrderedMap[string, any]:
+				obj = vv
+			case cty.Value:
+				return errors.E("%s points to a %s type but expects an object", ref, vv.Type().FriendlyName())
+			default:
+				panic("unexpected")
+			}
+		} else {
+			tempMap := orderedmap.New[string, any]()
+			obj.Set(path, tempMap)
+			obj = tempMap
+		}
+	}
+
+	obj.Set(ref.Path[lastIndex], val)
+	return nil
+}
+
+func (stmts Stmts) filter(ref Ref) (Stmts, bool) {
+	filtered := Stmts{}
+	found := false
+	for _, stmt := range stmts {
+		if stmt.LHS.has(ref) {
+			filtered = append(filtered, stmt)
+			if stmt.Origin.equal(ref) || stmt.LHS.equal(ref) {
+				found = true
+			}
+		} else {
+			if found {
+				break
+			}
+		}
+	}
+	return filtered, found
+}
+
+func (stmt Stmt) String() string {
+	var rhs string
+	if stmt.Special {
+		rhs = "{}"
+	} else {
+		rhs = string(ast.TokensForExpression(stmt.RHS).Bytes())
+	}
+	return fmt.Sprintf("%s = %s (defined at %s)",
+		stmt.LHS,
+		rhs,
+		stmt.Scope)
+}
+
+func tocty(globals *orderedmap.OrderedMap[string, any]) cty.Value {
+	ret := map[string]cty.Value{}
+	for pair := globals.Oldest(); pair != nil; pair = pair.Next() {
+		switch vv := pair.Value.(type) {
+		case *orderedmap.OrderedMap[string, any]:
+			ret[pair.Key] = tocty(vv)
+		case cty.Value:
+			ret[pair.Key] = vv
+		default:
+			panic("unexpected")
+		}
+	}
+	return cty.ObjectVal(ret)
+}

--- a/globals2/globals_test.go
+++ b/globals2/globals_test.go
@@ -1,0 +1,484 @@
+// Copyright 2023 Mineiros GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package globals2_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	hhclwrite "github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/madlambda/spells/assert"
+	"github.com/mineiros-io/terramate/config"
+	"github.com/mineiros-io/terramate/globals2"
+	"github.com/mineiros-io/terramate/hcl/ast"
+	"github.com/mineiros-io/terramate/hcl/eval"
+	"github.com/mineiros-io/terramate/project"
+	"github.com/mineiros-io/terramate/stdlib"
+	"github.com/mineiros-io/terramate/test"
+	errtest "github.com/mineiros-io/terramate/test/errors"
+	"github.com/mineiros-io/terramate/test/hclwrite"
+	. "github.com/mineiros-io/terramate/test/hclwrite/hclutils"
+	"github.com/mineiros-io/terramate/test/sandbox"
+	"github.com/rs/zerolog"
+)
+
+type (
+	hclconfig struct {
+		path     string
+		filename string
+		add      *hclwrite.Block
+	}
+	testcase struct {
+		name    string
+		layout  []string
+		configs []hclconfig
+		expr    string
+		evalDir string
+		want    string
+		wantErr error
+	}
+)
+
+func TestGlobals3(t *testing.T) {
+	for _, tc := range []testcase{
+		{
+			name:    "no globals",
+			expr:    "1",
+			evalDir: "/",
+			want:    "1",
+		},
+		{
+			name:    "no globals but with funcalls",
+			expr:    `tm_upper("terramate is fun")`,
+			evalDir: "/",
+			want:    `"TERRAMATE IS FUN"`,
+		},
+		{
+			name: "empty labeled globals creates objects",
+			configs: []hclconfig{
+				{
+					path: "/",
+					add: Globals(
+						Labels("obj"),
+					),
+				},
+			},
+			expr:    `global.obj`,
+			evalDir: "/",
+			want:    `{}`,
+		},
+		{
+			name: "empty labeled globals creates objects - multiple labels",
+			configs: []hclconfig{
+				{
+					path: "/",
+					add: Globals(
+						Labels("obj", "a", "b", "c"),
+					),
+				},
+			},
+			expr:    `global.obj`,
+			evalDir: "/",
+			want: `{
+				a = {
+					b = {
+						c = {}
+					}
+				}
+			}`,
+		},
+		{
+			name:   "single stack with a single global",
+			layout: []string{"s:stack"},
+			configs: []hclconfig{
+				{
+					path: "/stack",
+					add: Globals(
+						Str("a", "string"),
+					),
+				},
+			},
+			evalDir: "/stack",
+			expr:    `global.a`,
+			want:    `"string"`,
+		},
+		{
+			name:   "extending global in the same scope",
+			layout: []string{"s:stack"},
+			configs: []hclconfig{
+				{
+					path: "/stack",
+					add: Doc(
+						Globals(
+							Labels("obj"),
+							Str("a", "string"),
+						),
+						Globals(
+							Labels("obj"),
+							Str("b", "string"),
+						),
+					),
+				},
+			},
+			evalDir: "/stack",
+			expr:    `global.obj`,
+			want: `{
+				a = "string"
+				b = "string"
+			}`,
+		},
+		{
+			name:   "extended globals outside the target ref range are ignored",
+			layout: []string{"s:stack"},
+			configs: []hclconfig{
+				{
+					path: "/stack",
+					add: Doc(
+						Globals(
+							Labels("obj"),
+							Str("a", "string"),
+						),
+						Globals(
+							Labels("obj"),
+							Expr("fail", "crash()"),
+						),
+					),
+				},
+			},
+			evalDir: "/stack",
+			expr:    `global.obj.a`,
+			want:    `"string"`,
+		},
+		{
+			name:   "not referenced globals are not evaluated",
+			layout: []string{"s:stack"},
+			configs: []hclconfig{
+				{
+					path: "/stack",
+					add: Globals(
+						Str("a", "value"),
+						Expr("fail_if_evaluated", `crash()`),
+					),
+				},
+			},
+			evalDir: "/stack",
+			expr:    `global.a`,
+			want:    `"value"`,
+		},
+		{
+			name:   "single stack with target global depending on same scoped global",
+			layout: []string{"s:stack"},
+			configs: []hclconfig{
+				{
+					path: "/stack",
+					add: Globals(
+						Expr("a", `global.b`),
+						Expr("b", `tm_upper("terramate is fun")`),
+					),
+				},
+			},
+			evalDir: "/stack",
+			expr:    `global.a`,
+			want:    `"TERRAMATE IS FUN"`,
+		},
+		{
+			name:   "extending parent globals",
+			layout: []string{"s:stack"},
+			configs: []hclconfig{
+				{
+					path: "/",
+					add: Globals(
+						Labels("obj"),
+						Expr("a", `"test"`),
+						Expr("b", `tm_upper("test")`),
+					),
+				},
+				{
+					path: "/stack",
+					add: Globals(
+						Labels("obj", "c"),
+						Expr("a", `"c.a"`),
+					),
+				},
+			},
+			evalDir: "/stack",
+			expr:    `global.obj`,
+			want: `{
+				a = "test"
+				b = "TEST"
+				c = {
+					a = "c.a"
+				}
+			}`,
+		},
+		{
+			name:   "extending same key from parent globals",
+			layout: []string{"s:stack"},
+			configs: []hclconfig{
+				{
+					path: "/",
+					add: Globals(
+						Labels("obj"),
+						Expr("a", `"test"`),
+						Expr("b", `tm_upper("test")`),
+					),
+				},
+				{
+					path: "/stack",
+					add: Globals(
+						Labels("obj"),
+						Expr("a", `"stackval"`),
+					),
+				},
+			},
+			evalDir: "/stack",
+			expr:    `global.obj.a`,
+			want:    `"stackval"`,
+		},
+		{
+			name:   "extending same key from parent globals but targeting root object",
+			layout: []string{"s:stack"},
+			configs: []hclconfig{
+				{
+					path: "/",
+					add: Globals(
+						Labels("obj"),
+						Expr("a", `"test"`),
+						Expr("b", `tm_upper("test")`),
+					),
+				},
+				{
+					path: "/stack",
+					add: Globals(
+						Labels("obj"),
+						Expr("a", `"stackval"`),
+					),
+				},
+			},
+			evalDir: "/stack",
+			expr:    `global.obj`,
+			want: `{
+				a = "stackval"
+				b = "TEST"
+			}`,
+		},
+		{
+			name:   "extending parent globals but referencing child defined part -- should not descend into parent",
+			layout: []string{"s:stack"},
+			configs: []hclconfig{
+				{
+					path: "/",
+					add: Globals(
+						Labels("obj"),
+						Expr("a", `crash()`),
+					),
+				},
+				{
+					path: "/stack",
+					add: Globals(
+						Labels("obj", "c"),
+						Expr("a", `"c.a"`),
+					),
+				},
+			},
+			evalDir: "/stack",
+			expr:    `global.obj.c`,
+			want: `{
+				a = "c.a"
+			}`,
+		},
+		{
+			name:   "single stack with target global depending on multiple same scoped globals",
+			layout: []string{"s:stack"},
+			configs: []hclconfig{
+				{
+					path: "/stack",
+					add: Globals(
+						Expr("cfg", `{
+							name = global.name
+							domain = global.domain
+						}`),
+						Expr("name", `tm_upper("terramate")`),
+						Str("domain", `terramate.io`),
+					),
+				},
+			},
+			evalDir: "/stack",
+			expr:    `global.cfg`,
+			want: `{
+				domain = "terramate.io"
+				name = "TERRAMATE"
+			}`,
+		},
+		{
+			name:   "globals with 2 dependency hops",
+			layout: []string{"s:stack"},
+			configs: []hclconfig{
+				{
+					path: "/stack",
+					add: Globals(
+						Expr("cfg", `{
+							name = global.indirect
+						}`),
+						Expr("indirect", `tm_upper(global.name)`),
+						Str("name", `terramate`),
+					),
+				},
+			},
+			evalDir: "/stack",
+			expr:    `global.cfg`,
+			want: `{
+				name = "TERRAMATE"
+			}`,
+		},
+		{
+			name:   "globals with 5 dependency hops",
+			layout: []string{"s:stack"},
+			configs: []hclconfig{
+				{
+					path: "/stack",
+					add: Globals(
+						Expr("obj", `{
+							val = global.a1
+						}`),
+						Expr("a1", `tm_upper(global.a2)`),
+						Expr("a2", `tm_lower(global.a3)`),
+						Expr("a3", `tm_upper(global.a4)`),
+						Expr("a4", `"a4"`),
+					),
+				},
+			},
+			evalDir: "/stack",
+			expr:    `global.obj`,
+			want: `{
+				val = "A4"
+			}`,
+		},
+		{
+			name:   "single stack with global dependency from parent",
+			layout: []string{"s:stack"},
+			configs: []hclconfig{
+				{
+					path: "/",
+					add: Globals(
+						Str("name", "terramate"),
+					),
+				},
+				{
+					path: "/stack",
+					add: Globals(
+						Expr("a", `global.name`),
+					),
+				},
+			},
+			evalDir: "/stack",
+			expr:    `global.a`,
+			want:    `"terramate"`,
+		},
+		{
+			name:   "global dependency from parent with multiple hops",
+			layout: []string{"s:stack"},
+			configs: []hclconfig{
+				{
+					path: "/",
+					add: Globals(
+						Expr("a1", `global.a2`),
+						Expr("a2", `"a2"`),
+					),
+				},
+				{
+					path: "/stack",
+					add: Globals(
+						Expr("a", `global.a1`),
+					),
+				},
+			},
+			evalDir: "/stack",
+			expr:    `global.a`,
+			want:    `"a2"`,
+		},
+		{
+			name:   "global dependency from parent with lazy evaluation",
+			layout: []string{"s:stack"},
+			configs: []hclconfig{
+				{
+					path: "/",
+					add: Globals(
+						Expr("a1", `global.a2`),
+						Expr("a2", `global.stackval`),
+					),
+				},
+				{
+					path: "/stack",
+					add: Globals(
+						Expr("a", `global.a1`),
+						Str("stackval", "value from stack"),
+					),
+				},
+			},
+			evalDir: "/stack",
+			expr:    `global.a`,
+			want:    `"value from stack"`,
+		},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			s := sandbox.New(t)
+			s.BuildTree(tc.layout)
+			for _, globalBlock := range tc.configs {
+				path := filepath.Join(s.RootDir(), globalBlock.path)
+				filename := config.DefaultFilename
+				if globalBlock.filename != "" {
+					filename = globalBlock.filename
+				}
+				test.AppendFile(t, path, filename, globalBlock.add.String())
+			}
+
+			cfg, err := config.LoadRoot(s.RootDir())
+			if err != nil {
+				errtest.Assert(t, err, tc.wantErr)
+				return
+			}
+
+			tree, ok := cfg.Lookup(project.NewPath(tc.evalDir))
+			if !ok {
+				t.Fatalf("evalDir %s not found", tc.evalDir)
+			}
+
+			expr, diags := hclsyntax.ParseExpression([]byte(tc.expr), "test.hcl", hcl.InitialPos)
+			if diags.HasErrors() {
+				t.Fatal(diags.Error())
+			}
+
+			ctx := eval.NewContext(stdlib.Functions(tree.HostDir()))
+			g := globals2.New(ctx, tree)
+			val, err := g.Eval(expr)
+			errtest.Assert(t, err, tc.wantErr)
+
+			if tc.wantErr != nil {
+				return
+			}
+
+			assert.EqualStrings(t, string(hhclwrite.Format([]byte(tc.want))),
+				string(hhclwrite.Format(ast.TokensForValue(val).Bytes())))
+		})
+	}
+}
+
+func init() {
+	zerolog.SetGlobalLevel(zerolog.Disabled)
+}

--- a/globals2/ref.go
+++ b/globals2/ref.go
@@ -41,6 +41,7 @@ type (
 	Refs []Ref
 )
 
+// AsKey returns a ref suitable to be used as a map key.
 func (ref Ref) AsKey() RefStr { return RefStr(ref.String()) }
 
 // String returns a string representation of the Ref.

--- a/globals2/ref.go
+++ b/globals2/ref.go
@@ -1,0 +1,147 @@
+// Copyright 2023 Mineiros GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package globals2
+
+import (
+	"bytes"
+	"strconv"
+
+	hhcl "github.com/hashicorp/hcl/v2"
+	"github.com/mineiros-io/terramate/errors"
+	"github.com/zclconf/go-cty/cty"
+)
+
+type (
+	// Ref is a Terramate variable reference.
+	// It implements the `dot operator` or `member access` syntaxex like:
+	//   global.a.b
+	//   global[a][b]
+	// In the examples above, the `global` is the Object and Path is `["a", "b"]`.
+	Ref struct {
+		Object string
+		Path   []string
+	}
+
+	// RefStr is a string representation of the ref used as map keys.
+	RefStr string
+
+	// Refs is a list of references.
+	Refs []Ref
+)
+
+func (ref Ref) AsKey() RefStr { return RefStr(ref.String()) }
+
+// String returns a string representation of the Ref.
+// Note that it does not represent the syntactic ref found in the source file.
+// This is an internal representation that better fits the implementation design.
+func (ref Ref) String() string {
+	var out bytes.Buffer
+
+	// NOTE: the buffer methods never return errors and always write the full content.
+	// it panics if more memory cannot be allocated.
+	out.WriteString(ref.Object)
+	for _, p := range ref.Path {
+		out.WriteRune('[')
+		out.WriteString(strconv.Quote(p))
+		out.WriteRune(']')
+	}
+	return out.String()
+}
+
+func (ref Ref) has(other Ref) bool {
+	if ref.Object != other.Object {
+		return false
+	}
+	if len(ref.Path) < len(other.Path) {
+		return false
+	}
+	var max int
+	if len(ref.Path) == len(other.Path) {
+		max = len(ref.Path)
+	} else {
+		max = len(other.Path)
+	}
+
+	for i := 0; i < max; i++ {
+		if ref.Path[i] != other.Path[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// equal tells if two refs are the same.
+func (ref Ref) equal(other Ref) bool {
+	if ref.Object != other.Object || len(ref.Path) != len(other.Path) {
+		return false
+	}
+	for i, p := range ref.Path {
+		if other.Path[i] != p {
+			return false
+		}
+	}
+	return true
+}
+
+func (refs Refs) equal(other Refs) bool {
+	if len(refs) != len(other) {
+		return false
+	}
+	for i, ref := range refs {
+		if !ref.equal(other[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+// refsOf returns a distinct set of Refs contained in the expression.
+func refsOf(expr hhcl.Expression) Refs {
+	ret := Refs{}
+	uniqueRefs := map[string]Ref{}
+	for _, trav := range expr.Variables() {
+		// they are all root traversals
+		ref := Ref{
+			Object: trav[0].(hhcl.TraverseRoot).Name,
+		}
+
+		if ref.Object != "global" {
+			continue
+		}
+
+	inner:
+		for _, tt := range trav[1:] {
+			switch t := tt.(type) {
+			case hhcl.TraverseAttr:
+				ref.Path = append(ref.Path, t.Name)
+			case hhcl.TraverseSplat:
+				break inner
+			case hhcl.TraverseIndex:
+				if !t.Key.Type().Equals(cty.String) {
+					break inner
+				}
+				ref.Path = append(ref.Path, t.Key.AsString())
+			default:
+				panic(errors.E(errors.ErrInternal, "unexpected traversal: %v", t))
+			}
+		}
+
+		if _, ok := uniqueRefs[ref.String()]; !ok {
+			uniqueRefs[ref.String()] = ref
+			ret = append(ret, ref)
+		}
+	}
+	return ret
+}

--- a/globals2/ref_test.go
+++ b/globals2/ref_test.go
@@ -276,7 +276,7 @@ func TestStmtsLookupRef(t *testing.T) {
 	} {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			got, found := tc.stmts.filter(tc.ref)
+			got, found := tc.stmts.selectBy(tc.ref)
 			if found != tc.found {
 				t.Fatalf("expected found=%t but got %t", found, tc.found)
 			}

--- a/globals2/ref_test.go
+++ b/globals2/ref_test.go
@@ -1,0 +1,359 @@
+// Copyright 2023 Mineiros GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package globals2
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	hhcl "github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/madlambda/spells/assert"
+	"github.com/mineiros-io/terramate/project"
+)
+
+func TestRefsOf(t *testing.T) {
+	t.Parallel()
+
+	type testcase struct {
+		expr string
+		want []Ref
+	}
+
+	for _, tc := range []testcase{
+		{
+			expr: `global.a`,
+			want: []Ref{
+				{Object: "global", Path: []string{"a"}},
+			},
+		},
+		{
+			expr: `global.a.b.c + global.x.y.z`,
+			want: []Ref{
+				{Object: "global", Path: []string{"a", "b", "c"}},
+				{Object: "global", Path: []string{"x", "y", "z"}},
+			},
+		},
+		{
+			expr: `global.a + global.a * global.a`,
+			want: []Ref{
+				// unique
+				{Object: "global", Path: []string{"a"}},
+			},
+		},
+		{
+			expr: `global["a"]`,
+			want: []Ref{
+				{Object: "global", Path: []string{"a"}},
+			},
+		},
+		{
+			expr: `global["a"]["b"]`,
+			want: []Ref{
+				{Object: "global", Path: []string{"a", "b"}},
+			},
+		},
+		{
+			expr: `global["a"][global.b]`,
+			want: []Ref{
+				{Object: "global", Path: []string{"a"}},
+				{Object: "global", Path: []string{"b"}},
+			},
+		},
+		{
+			expr: `global[global]`,
+			want: []Ref{
+				{Object: "global"},
+			},
+		},
+		{
+			expr: `{
+				a = global.a
+				b = {
+					c = {
+						d = {
+							e = {
+								f = global.b
+							}
+						}
+					}
+				}
+			}`,
+			want: []Ref{
+				{Object: "global", Path: []string{"a"}},
+				{Object: "global", Path: []string{"b"}},
+			},
+		},
+		{
+			expr: `tm_call(global.a)+tm_call(tm_other(tm_bleh(tm_a(hidden.thing))))`,
+			want: []Ref{
+				{Object: "global", Path: []string{"a"}},
+			},
+		},
+	} {
+		tc := tc
+		t.Run(fmt.Sprintf("refsOf(%s)", tc.expr), func(t *testing.T) {
+			expr, diags := hclsyntax.ParseExpression([]byte(tc.expr), "test.hcl", hhcl.InitialPos)
+			if diags.HasErrors() {
+				t.Fatal(diags.Error())
+			}
+			refs := refsOf(expr)
+			if !refs.equal(tc.want) {
+				t.Fatalf(fmt.Sprintf("(%v != %v)", refs, tc.want))
+			}
+		})
+	}
+}
+
+func TestStmtsLookupRef(t *testing.T) {
+	t.Parallel()
+
+	type testcase struct {
+		name  string
+		ref   Ref
+		stmts Stmts
+		want  Stmts
+		found bool
+	}
+
+	for _, tc := range []testcase{
+		{
+			name: "exact match with origin",
+			ref:  Ref{Object: "global", Path: []string{"a", "b"}},
+			stmts: Stmts{
+				Stmt{
+					LHS:    Ref{Object: "global", Path: []string{"a", "b"}},
+					Origin: Ref{Object: "global", Path: []string{"a", "b"}},
+				},
+				Stmt{
+					LHS:    Ref{Object: "global", Path: []string{"c"}},
+					Origin: Ref{Object: "global", Path: []string{"c"}},
+				},
+			},
+			want: Stmts{
+				Stmt{
+					LHS:    Ref{Object: "global", Path: []string{"a", "b"}},
+					Origin: Ref{Object: "global", Path: []string{"a", "b"}},
+				},
+			},
+			found: true,
+		},
+		{
+			name: "exact match with lhs",
+			ref:  Ref{Object: "global", Path: []string{"a", "b"}},
+			stmts: Stmts{
+				Stmt{
+					LHS:    Ref{Object: "global", Path: []string{"a", "b"}},
+					Origin: Ref{Object: "global", Path: []string{"a"}},
+				},
+				Stmt{
+					LHS:    Ref{Object: "global", Path: []string{"c"}},
+					Origin: Ref{Object: "global", Path: []string{"c"}},
+				},
+			},
+			want: Stmts{
+				Stmt{
+					LHS:    Ref{Object: "global", Path: []string{"a", "b"}},
+					Origin: Ref{Object: "global", Path: []string{"a"}},
+				},
+			},
+			found: true,
+		},
+		{
+			name: "partial match",
+			ref:  Ref{Object: "global", Path: []string{"a"}},
+			stmts: Stmts{
+				Stmt{
+					LHS:    Ref{Object: "global", Path: []string{"a", "b"}},
+					Origin: Ref{Object: "global", Path: []string{"a", "b"}},
+				},
+				Stmt{
+					LHS:    Ref{Object: "global", Path: []string{"a", "c"}},
+					Origin: Ref{Object: "global", Path: []string{"a", "c"}},
+				},
+				Stmt{
+					LHS:    Ref{Object: "global", Path: []string{"c"}},
+					Origin: Ref{Object: "global", Path: []string{"c"}},
+				},
+			},
+			want: Stmts{
+				Stmt{
+					LHS:    Ref{Object: "global", Path: []string{"a", "b"}},
+					Origin: Ref{Object: "global", Path: []string{"a", "b"}},
+				},
+				Stmt{
+					LHS:    Ref{Object: "global", Path: []string{"a", "c"}},
+					Origin: Ref{Object: "global", Path: []string{"a", "c"}},
+				},
+			},
+			found: false,
+		},
+		{
+			name: "no match -- in same branch",
+			ref:  Ref{Object: "global", Path: []string{"a", "b", "c"}},
+			stmts: Stmts{
+				Stmt{
+					LHS:    Ref{Object: "global", Path: []string{"a", "b"}},
+					Origin: Ref{Object: "global", Path: []string{"a", "b"}},
+				},
+				Stmt{
+					LHS:    Ref{Object: "global", Path: []string{"a", "c"}},
+					Origin: Ref{Object: "global", Path: []string{"a", "c"}},
+				},
+				Stmt{
+					LHS:    Ref{Object: "global", Path: []string{"c"}},
+					Origin: Ref{Object: "global", Path: []string{"c"}},
+				},
+			},
+			want:  Stmts{},
+			found: false,
+		},
+		{
+			name: "no match -- in different branch",
+			ref:  Ref{Object: "global", Path: []string{"unknown"}},
+			stmts: Stmts{
+				Stmt{
+					LHS:    Ref{Object: "global", Path: []string{"a", "b"}},
+					Origin: Ref{Object: "global", Path: []string{"a", "b"}},
+				},
+				Stmt{
+					LHS:    Ref{Object: "global", Path: []string{"a", "c"}},
+					Origin: Ref{Object: "global", Path: []string{"a", "c"}},
+				},
+				Stmt{
+					LHS:    Ref{Object: "global", Path: []string{"c"}},
+					Origin: Ref{Object: "global", Path: []string{"c"}},
+				},
+			},
+			want:  Stmts{},
+			found: false,
+		},
+		{
+			name: "root match -- should always return all globals",
+			ref:  Ref{Object: "global"},
+			stmts: Stmts{
+				Stmt{
+					LHS: Ref{Object: "global", Path: []string{"a", "b"}},
+				},
+				Stmt{
+					LHS: Ref{Object: "global", Path: []string{"a"}},
+				},
+				Stmt{
+					LHS: Ref{Object: "global", Path: []string{"b"}},
+				},
+				Stmt{
+					LHS: Ref{Object: "global", Path: []string{"c"}},
+				},
+			},
+			want: Stmts{
+				Stmt{
+					LHS: Ref{Object: "global", Path: []string{"a", "b"}},
+				},
+				Stmt{
+					LHS: Ref{Object: "global", Path: []string{"a"}},
+				},
+				Stmt{
+					LHS: Ref{Object: "global", Path: []string{"b"}},
+				},
+				Stmt{
+					LHS: Ref{Object: "global", Path: []string{"c"}},
+				},
+			},
+		},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			got, found := tc.stmts.filter(tc.ref)
+			if found != tc.found {
+				t.Fatalf("expected found=%t but got %t", found, tc.found)
+			}
+			if diff := cmp.Diff(got, tc.want, cmp.AllowUnexported(Stmt{}, project.Path{})); diff != "" {
+				t.Fatal(diff)
+			}
+		})
+	}
+}
+
+func TestRefEquals(t *testing.T) {
+	t.Parallel()
+	type testcase struct {
+		a, b Ref
+		want bool
+	}
+
+	for _, tc := range []testcase{
+		{
+			a:    Ref{Object: "global"},
+			b:    Ref{Object: "terramate"},
+			want: false,
+		},
+		{
+			a:    Ref{Object: "global"},
+			b:    Ref{Object: "global"},
+			want: true,
+		},
+		{
+			a:    Ref{Object: "global", Path: nil},
+			b:    Ref{Object: "global", Path: []string{}},
+			want: true,
+		},
+		{
+			a:    Ref{Object: "global", Path: []string{"a"}},
+			b:    Ref{Object: "global", Path: []string{}},
+			want: false,
+		},
+		{
+			a:    Ref{Object: "global", Path: []string{"a", "b"}},
+			b:    Ref{Object: "global", Path: []string{"a", "b"}},
+			want: true,
+		},
+	} {
+		tc := tc
+		t.Run(fmt.Sprintf("%s == %s", tc.a, tc.b), func(t *testing.T) {
+			if tc.a.equal(tc.b) != tc.want {
+				t.Fatalf(fmt.Sprintf("(%s == %s) != %t", tc.a, tc.b, tc.want))
+			}
+		})
+	}
+}
+
+func TestRefString(t *testing.T) {
+	t.Parallel()
+	type testcase struct {
+		in   Ref
+		want string
+	}
+
+	for _, tc := range []testcase{
+		{
+			in:   Ref{Object: "global"},
+			want: `global`,
+		},
+		{
+			in:   Ref{Object: "global", Path: []string{"a", "b"}},
+			want: `global["a"]["b"]`,
+		},
+		{
+			in:   Ref{Object: "global", Path: []string{"spaces and\nnew lines"}},
+			want: "global[\"spaces and\\nnew lines\"]",
+		},
+	} {
+		tc := tc
+		t.Run(fmt.Sprintf("object:%s, path:%v", tc.in.Object, tc.in.Path), func(t *testing.T) {
+			assert.EqualStrings(t, tc.want, tc.in.String())
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/madlambda/spells v0.4.2
 	github.com/posener/complete v1.2.3
 	github.com/willabides/kongplete v0.2.0
+	github.com/wk8/go-ordered-map/v2 v2.1.7
 	github.com/zclconf/go-cty v1.8.3
 	github.com/zclconf/go-cty-debug v0.0.0-20191215020915-b22d67c1ba0b
 	go.lsp.dev/uri v0.3.0
@@ -33,7 +34,6 @@ require (
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mattn/go-colorable v0.1.12 // indirect
 	github.com/mattn/go-isatty v0.0.14 // indirect
-	github.com/wk8/go-ordered-map/v2 v2.1.7 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -24,12 +24,16 @@ require (
 
 require (
 	github.com/acomagu/bufpipe v1.0.3 // indirect
+	github.com/bahlo/generic-list-go v0.2.0 // indirect
+	github.com/buger/jsonparser v1.1.1 // indirect
 	github.com/go-git/gcfg v1.5.0 // indirect
 	github.com/go-git/go-billy/v5 v5.3.1 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
+	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mattn/go-colorable v0.1.12 // indirect
 	github.com/mattn/go-isatty v0.0.14 // indirect
+	github.com/wk8/go-ordered-map/v2 v2.1.7 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -479,7 +479,6 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/tencentcloud/tencentcloud-sdk-go v3.0.82+incompatible/go.mod h1:0PfYow01SHPMhKY31xa+EFz2RStxIqj6JFAJS+IkCi4=
@@ -848,8 +847,8 @@ gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.7/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/go.sum
+++ b/go.sum
@@ -108,6 +108,8 @@ github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkY
 github.com/aws/aws-sdk-go v1.15.78/go.mod h1:E3/ieXAlvM0XWO57iftYVDLLvQ824smPP3ATZkfNZeM=
 github.com/aws/aws-sdk-go v1.31.9/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/aws/aws-sdk-go v1.37.0/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
+github.com/bahlo/generic-list-go v0.2.0 h1:5sz/EEAK+ls5wF+NeqDpk5+iNdMDXrh3z3nPnH1Wvgk=
+github.com/bahlo/generic-list-go v0.2.0/go.mod h1:2KvAjgMlE5NNynlg/5iLrrCCZ2+5xWbdbCW3pNTGyYg=
 github.com/baiyubin/aliyun-sts-go-sdk v0.0.0-20180326062324-cfa1a18b161f/go.mod h1:AuiFmCCPBSrqvVMvuqFuk0qogytodnVFVSN5CeJB8Gc=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d/go.mod h1:6QX/PXZ00z/TKoufEY6K/a0k6AhaJrQKdFe6OfVXsa4=
@@ -115,6 +117,8 @@ github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kB
 github.com/bmatcuk/doublestar v1.1.5 h1:2bNwBOmhyFEFcoB3tGvTD5xanq+4kyOZlB8wFYbMjkk=
 github.com/bmatcuk/doublestar v1.1.5/go.mod h1:wiQtGV+rzVYxB7WIlirSN++5HPtPlXEo9MEoZQC/PmE=
 github.com/boltdb/bolt v1.3.1/go.mod h1:clJnj/oiGkjum5o1McbSZDSLxVThjynRyGBgiAx27Ps=
+github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMUs=
+github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cheggaaa/pb v1.0.27/go.mod h1:pQciLPpbU0oxA0h+VJYYLxO+XeDQb5pZijXscXHm81s=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
@@ -330,6 +334,7 @@ github.com/jmespath/go-jmespath v0.3.0/go.mod h1:9QtRXoHjLGCJ5IBSaohpXITPlowMeeY
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
+github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/joyent/triton-go v0.0.0-20180313100802-d8f9c0314926/go.mod h1:U+RSyWxWd04xTqnuOQxnai7XGS2PrPY2cfGoDKtMHjA=
 github.com/json-iterator/go v0.0.0-20180612202835-f2b4162afba3/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v0.0.0-20180701071628-ab8a2e0c74be/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
@@ -366,6 +371,8 @@ github.com/lusis/go-artifactory v0.0.0-20160115162124-7e4ce345df82/go.mod h1:y54
 github.com/madlambda/spells v0.4.2 h1:SZnqMRSgp65SoIiW1ky73wPL2ImkSg+sYZlWA+uyrx4=
 github.com/madlambda/spells v0.4.2/go.mod h1:Z8EUYIlBI+GfxQQGHHPkzt9YGu9olhVTbhcnxMGpgYo=
 github.com/mailru/easyjson v0.0.0-20160728113105-d5b7844b561a/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
+github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
+github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/masterzen/simplexml v0.0.0-20160608183007-4572e39b1ab9/go.mod h1:kCEbxUJlNDEBNbdQMkPSp6yaKcRXVI6f4ddk8Riv4bc=
 github.com/masterzen/simplexml v0.0.0-20190410153822-31eea3082786/go.mod h1:kCEbxUJlNDEBNbdQMkPSp6yaKcRXVI6f4ddk8Riv4bc=
 github.com/masterzen/winrm v0.0.0-20200615185753-c42b5136ff88/go.mod h1:a2HXwefeat3evJHxFXSayvRHpYEPJYtErl4uIzfaUqY=
@@ -474,6 +481,7 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/tencentcloud/tencentcloud-sdk-go v3.0.82+incompatible/go.mod h1:0PfYow01SHPMhKY31xa+EFz2RStxIqj6JFAJS+IkCi4=
 github.com/tencentyun/cos-go-sdk-v5 v0.0.0-20190808065407-f07404cefc8c/go.mod h1:wk2XFUg6egk4tSDNZtXeKfe2G6690UVyt163PuUxBZk=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20171017195756-830351dc03c6/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
@@ -485,6 +493,8 @@ github.com/vmihailenco/msgpack/v4 v4.3.12/go.mod h1:gborTTJjAo/GWTqqRjrLCn9pgNN+
 github.com/vmihailenco/tagparser v0.1.1/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=
 github.com/willabides/kongplete v0.2.0 h1:C6wYVn+IPyA8rAGRGLLkuxhhSQTEECX4t8u3gi+fuD0=
 github.com/willabides/kongplete v0.2.0/go.mod h1:kFVw+PkQsqkV7O4tfIBo6iJ9qY94PJC8sPfMgFG5AdM=
+github.com/wk8/go-ordered-map/v2 v2.1.7 h1:aUZ1xBMdbvY8wnNt77qqo4nyT3y0pX4Usat48Vm+hik=
+github.com/wk8/go-ordered-map/v2 v2.1.7/go.mod h1:9Xvgm2mV2kSq2SAm0Y608tBmu8akTzI7c2bz7/G7ZN4=
 github.com/xanzy/ssh-agent v0.2.1/go.mod h1:mLlQY/MoOhWBj+gOGMQkOeiEvkx+8pJSI+0Bx9h2kr4=
 github.com/xanzy/ssh-agent v0.3.0/go.mod h1:3s9xbODqPuuhK9JV1R321M/FlMZSBvE5aY6eAcqrDh0=
 github.com/xiang90/probing v0.0.0-20160813154853-07dd2e8dfe18/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=


### PR DESCRIPTION
# Reason for This Change

Introduces the `globals2` package, which implements a globals evaluator that tracks the expression's dependencies and then only evaluates the globals expression being used.

The current evaluator (the `globals` package) has a naive implementation that skips expressions that fail evaluation and try them again later until no expression successfully evaluates. This has a lot of drawbacks but the most critical is the performance, as several parts of Terramate cannot proceed until all globals are evaluated and it has to evaluate from scratch for each stacks.

The current implementation also leaves room for future optimizations, as for example, all self-contained (or independent) expressions can have their result cached, and others.

## Description of Changes

A new `globals2` package was added and an upcoming PR integrates it with the CLI.
