### PR TITLE
chore: document that map block can be used with lets

### DIFF
--- a/docs/config-overview.md
+++ b/docs/config-overview.md
@@ -249,7 +249,8 @@ For detailed documentation about this block, see the [HCL Code Generation](https
 ## lets block schema
 
 The `lets` block has no labels, supports [merging](#config-merging) of blocks
-in the same level, accepts **any** attribute and **disallow** child blocks.
+in the same level, accepts **any** attribute and supports any number of 
+[map](#map-block) blocks.
 
 ## generate_hcl.content block schema
 

--- a/docs/map.md
+++ b/docs/map.md
@@ -1,8 +1,9 @@
 # map block
 
 The `map` block can be used to create complex maps/objects inside 
-[Globals](sharing-data.md). It can be used to aggregate lists
-of objects into maps that have duplicated keys and need a defined way of deep merging values of the same key.
+[Globals](sharing-data.md) and [Lets](./codegen/overview.md#lets) blocks. 
+It can be used to aggregate lists of objects into maps that have duplicated keys 
+and need a defined way of deep merging values of the same key.
 
 The following is a very basic example introducing the `map` block inside a `globals` block:
 


### PR DESCRIPTION
# Reason for This Change

The documentation didn't mention that `map` could be used inside `lets` block as well
