### PR TITLE
fix: stacks incorrectly selected when having same prefix wd prefix

### DIFF
--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -1718,11 +1718,15 @@ func (c *cli) filterStacks(stacks []stack.Entry) []stack.Entry {
 }
 
 func (c *cli) filterStacksByWorkingDir(stacks []stack.Entry) []stack.Entry {
-	relwd := prj.PrjAbsPath(c.rootdir(), c.wd())
-
+	relwd := prj.PrjAbsPath(c.rootdir(), c.wd()).String()
+	if relwd != "/" {
+		relwd += string(filepath.Separator)
+	}
 	filtered := []stack.Entry{}
 	for _, e := range stacks {
-		if e.Stack.Dir.HasPrefix(relwd.String()) {
+		stackdir := e.Stack.Dir.String() + string(filepath.Separator)
+
+		if strings.HasPrefix(stackdir, relwd) {
 			filtered = append(filtered, e)
 		}
 	}

--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -1720,11 +1720,14 @@ func (c *cli) filterStacks(stacks []stack.Entry) []stack.Entry {
 func (c *cli) filterStacksByWorkingDir(stacks []stack.Entry) []stack.Entry {
 	relwd := prj.PrjAbsPath(c.rootdir(), c.wd()).String()
 	if relwd != "/" {
-		relwd += string(filepath.Separator)
+		relwd += "/"
 	}
 	filtered := []stack.Entry{}
 	for _, e := range stacks {
-		stackdir := e.Stack.Dir.String() + string(filepath.Separator)
+		stackdir := e.Stack.Dir.String()
+		if stackdir != "/" {
+			stackdir += "/"
+		}
 
 		if strings.HasPrefix(stackdir, relwd) {
 			filtered = append(filtered, e)

--- a/cmd/terramate/e2etests/run_test.go
+++ b/cmd/terramate/e2etests/run_test.go
@@ -830,6 +830,32 @@ func TestCLIRunOrder(t *testing.T) {
 				),
 			},
 		},
+		{
+			name: "regression: stacks with same prefix as working dir but outside the fs branch",
+			layout: []string{
+				"s:stacks/test",
+				"s:stacks/test-foo",
+			},
+			workingDir: "/stacks/test",
+			want: runExpected{
+				Stdout: listStacks(
+					"/stacks/test",
+				),
+			},
+		},
+		{
+			name: "regression: stacks with same prefix as working dir but outside the fs branch",
+			layout: []string{
+				"s:test",
+				"s:tests",
+			},
+			workingDir: "/test",
+			want: runExpected{
+				Stdout: listStacks(
+					"/test",
+				),
+			},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			sandboxes := []sandbox.S{


### PR DESCRIPTION
When matching stacks inside the working directory, the implementation checked for stack paths with the working directory prefix. The code was something like:

```go
if strings.HasPrefix(stackdir, wd) {
    // include stack in the list
}
```

it works for most cases but not if *working directory* is also the prefix of disjoint directories, see example stacks below:

```
/test
/tests
```
if *working dir* is `/test`, then both `/test` and `/tests` is a match.

# Changes

Append `/` to the directories so the matches are *workingDir* `/test/` against `/test/` and `/tests/` which only returns `/test/`.

Closes #914 