### PR TITLE
chore: disable symlink tests on Windows

### DIFF
--- a/cmd/terramate/e2etests/exp_trigger_test.go
+++ b/cmd/terramate/e2etests/exp_trigger_test.go
@@ -17,6 +17,7 @@ package e2etest
 import (
 	"fmt"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/madlambda/spells/assert"
@@ -47,6 +48,9 @@ func TestTriggerWorksWithRelativeStackPath(t *testing.T) {
 }
 
 func TestTriggerFailsWithSymlinksInStackPath(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink tests skipped on windows")
+	}
 	t.Parallel()
 	s := sandbox.New(t)
 	s.BuildTree([]string{


### PR DESCRIPTION
# Reason for This Change

Disable symlink test on Windows because creating a symlink is a privileged operation.
