### PR TITLE
chore: only run CI benchmarks if Go files changed.

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -14,6 +14,9 @@
 
 name: benchmarks
 on: pull_request
+  branches-ignore: main
+  paths:
+      - '**.go'
 jobs:
   benchmarks:
     runs-on: ubuntu-20.04

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -14,7 +14,6 @@
 
 name: benchmarks
 on: pull_request
-  branches-ignore: main
   paths:
       - '**.go'
 jobs:


### PR DESCRIPTION
avoid running benchmarks in the main branch and if no Go file changed.