### PR TITLE
feat: terramate experimental cloud login

### DIFF
--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -114,9 +114,6 @@ type cliSpec struct {
 	DisableCheckpoint          bool `optional:"true" default:"false" help:"Disable checkpoint checks for updates"`
 	DisableCheckpointSignature bool `optional:"true" default:"false" help:"Disable checkpoint signature"`
 
-	Login struct {
-	} `cmd:"" help:"Login into Terramate Cloud" hidden:"true"`
-
 	Create struct {
 		Path           string   `arg:"" name:"path" predictor:"file" help:"Path of the new stack relative to the working dir"`
 		ID             string   `help:"ID of the stack, defaults to UUID"`
@@ -208,6 +205,11 @@ type cliSpec struct {
 			AsJSON bool              `help:"Outputs the result as a JSON value"`
 			Vars   []string          `arg:"" help:"variable to be retrieved" name:"var" passthrough:""`
 		} `cmd:"" help:"Get configuration value"`
+
+		Cloud struct {
+			Login struct {
+			} `cmd:"login for cloud.terramate.io"`
+		} `cmd:"" help:"Terramate Cloud commands"`
 	} `cmd:"" help:"Experimental features (may change or be removed in the future)"`
 }
 
@@ -398,13 +400,12 @@ func newCLI(version string, args []string, stdin io.Reader, stdout, stderr io.Wr
 			fatal(err, "installing shell completions")
 		}
 		return &cli{exit: true}
-	case "login":
+	case "experimental cloud login":
 		err := login(output, clicfg)
 		if err != nil {
 			fatal(err, "authentication failed")
 		}
 		output.MsgStdOut("authenticated successfully")
-
 		return &cli{exit: true}
 	}
 

--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -91,7 +91,7 @@ const (
 
 const defaultVendorDir = "/modules"
 
-const terramateHomeConfigDir = ".terramate.d"
+const terramateUserConfigDir = ".terramate.d"
 
 type cliSpec struct {
 	Version        struct{} `cmd:"" help:"Terramate version"`
@@ -340,8 +340,8 @@ func newCLI(version string, args []string, stdin io.Reader, stdout, stderr io.Wr
 		clicfg.DisableCheckpointSignature = parsedArgs.DisableCheckpointSignature
 	}
 
-	if clicfg.HomeTerramateDir == "" {
-		homeTmDir, err := localTerramateDir()
+	if clicfg.UserTerramateDir == "" {
+		homeTmDir, err := userTerramateDir()
 		if err != nil {
 			output.MsgStdErr("Please either export the %s environment variable or "+
 				"set the homeTerramateDir option in the %s configuration file",
@@ -350,7 +350,7 @@ func newCLI(version string, args []string, stdin io.Reader, stdout, stderr io.Wr
 
 			fatal(err)
 		}
-		clicfg.HomeTerramateDir = homeTmDir
+		clicfg.UserTerramateDir = homeTmDir
 	}
 
 	checkpointResults := make(chan *checkpoint.CheckResponse, 1)
@@ -1823,11 +1823,11 @@ func runCheckpoint(version string, clicfg cliconfig.Config, result chan *checkpo
 		Str("action", "runCheckpoint()").
 		Logger()
 
-	cacheFile := filepath.Join(clicfg.HomeTerramateDir, "checkpoint_cache")
+	cacheFile := filepath.Join(clicfg.UserTerramateDir, "checkpoint_cache")
 
 	var signatureFile string
 	if !clicfg.DisableCheckpointSignature {
-		signatureFile = filepath.Join(clicfg.HomeTerramateDir, "checkpoint_signature")
+		signatureFile = filepath.Join(clicfg.UserTerramateDir, "checkpoint_signature")
 	}
 
 	resp, err := checkpoint.CheckAt(defaultTelemetryEndpoint(),

--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -1822,11 +1822,6 @@ func localTerramateDir() (string, error) {
 }
 
 func runCheckpoint(version string, clicfg cliconfig.Config, result chan *checkpoint.CheckResponse) {
-	var (
-		signatureFile string
-		cacheFile     string
-	)
-
 	if clicfg.DisableCheckpoint {
 		result <- nil
 		return
@@ -1836,7 +1831,9 @@ func runCheckpoint(version string, clicfg cliconfig.Config, result chan *checkpo
 		Str("action", "runCheckpoint()").
 		Logger()
 
-	cacheFile = filepath.Join(clicfg.HomeTerramateDir, "checkpoint_cache")
+	cacheFile := filepath.Join(clicfg.HomeTerramateDir, "checkpoint_cache")
+
+	var signatureFile string
 	if !clicfg.DisableCheckpointSignature {
 		signatureFile = filepath.Join(clicfg.HomeTerramateDir, "checkpoint_signature")
 	}

--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -1813,14 +1813,6 @@ func userHomeDir() (string, error) {
 	return homeDir, nil
 }
 
-func localTerramateDir() (string, error) {
-	homeDir, err := userHomeDir()
-	if err != nil {
-		return "", errors.E(err, "failed to discover the location of the local %s directory", terramateHomeConfigDir)
-	}
-	return filepath.Join(homeDir, terramateHomeConfigDir), nil
-}
-
 func runCheckpoint(version string, clicfg cliconfig.Config, result chan *checkpoint.CheckResponse) {
 	if clicfg.DisableCheckpoint {
 		result <- nil

--- a/cmd/terramate/cli/cli.go
+++ b/cmd/terramate/cli/cli.go
@@ -112,6 +112,9 @@ type cliSpec struct {
 	DisableCheckpoint          bool `optional:"true" default:"false" help:"Disable checkpoint checks for updates"`
 	DisableCheckpointSignature bool `optional:"true" default:"false" help:"Disable checkpoint signature"`
 
+	Login struct {
+	} `cmd:"" help:"Login into Terramate Cloud" hidden:"true"`
+
 	Create struct {
 		Path           string   `arg:"" name:"path" predictor:"file" help:"Path of the new stack relative to the working dir"`
 		ID             string   `help:"ID of the stack, defaults to UUID"`
@@ -383,6 +386,14 @@ func newCLI(version string, args []string, stdin io.Reader, stdout, stderr io.Wr
 		if err != nil {
 			fatal(err, "installing shell completions")
 		}
+		return &cli{exit: true}
+	case "login":
+		err := login(output)
+		if err != nil {
+			fatal(err)
+		}
+		output.MsgStdOut("authenticated successfully")
+
 		return &cli{exit: true}
 	}
 

--- a/cmd/terramate/cli/cli_unix.go
+++ b/cmd/terramate/cli/cli_unix.go
@@ -1,0 +1,31 @@
+// Copyright 2023 Mineiros GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build aix || android || darwin || dragonfly || freebsd || hurd || illumos || ios || linux || netbsd || openbsd || solaris
+
+package cli
+
+import (
+	"path/filepath"
+
+	"github.com/mineiros-io/terramate/errors"
+)
+
+func localTerramateDir() (string, error) {
+	homeDir, err := userHomeDir()
+	if err != nil {
+		return "", errors.E(err, "failed to discover the location of the local %s directory", terramateHomeConfigDir)
+	}
+	return filepath.Join(homeDir, terramateHomeConfigDir), nil
+}

--- a/cmd/terramate/cli/cli_unix.go
+++ b/cmd/terramate/cli/cli_unix.go
@@ -22,10 +22,10 @@ import (
 	"github.com/mineiros-io/terramate/errors"
 )
 
-func localTerramateDir() (string, error) {
+func userTerramateDir() (string, error) {
 	homeDir, err := userHomeDir()
 	if err != nil {
-		return "", errors.E(err, "failed to discover the location of the local %s directory", terramateHomeConfigDir)
+		return "", errors.E(err, "failed to discover the location of the local %s directory", terramateUserConfigDir)
 	}
-	return filepath.Join(homeDir, terramateHomeConfigDir), nil
+	return filepath.Join(homeDir, terramateUserConfigDir), nil
 }

--- a/cmd/terramate/cli/cli_windows.go
+++ b/cmd/terramate/cli/cli_windows.go
@@ -1,0 +1,25 @@
+// Copyright 2023 Mineiros GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build windows
+
+package cli
+
+func localTerramateDir() (string, error) {
+	appdata := os.Getenv(cliconfig.DirEnv)
+	if appdata == "" {
+		return "", errors.E("APPDATA not set")
+	}
+	return filepath.Join(appdata, terramateHomeConfigDir), nil
+}

--- a/cmd/terramate/cli/cli_windows.go
+++ b/cmd/terramate/cli/cli_windows.go
@@ -18,6 +18,7 @@ package cli
 
 import (
 	"github.com/mineiros-io/terramate/cmd/terramate/cli/cliconfig"
+	"github.com/mineiros-io/terramate/errors"
 	"os"
 	"path/filepath"
 )

--- a/cmd/terramate/cli/cli_windows.go
+++ b/cmd/terramate/cli/cli_windows.go
@@ -16,6 +16,12 @@
 
 package cli
 
+import (
+	"github.com/mineiros-io/terramate/cmd/terramate/cli/cliconfig"
+	"os"
+	"path/filepath"
+)
+
 func localTerramateDir() (string, error) {
 	appdata := os.Getenv(cliconfig.DirEnv)
 	if appdata == "" {

--- a/cmd/terramate/cli/cli_windows.go
+++ b/cmd/terramate/cli/cli_windows.go
@@ -28,5 +28,5 @@ func userTerramateDir() (string, error) {
 	if appdata == "" {
 		return "", errors.E("APPDATA not set")
 	}
-	return filepath.Join(appdata, terramateHomeConfigDir), nil
+	return filepath.Join(appdata, terramateUserConfigDir), nil
 }

--- a/cmd/terramate/cli/cli_windows.go
+++ b/cmd/terramate/cli/cli_windows.go
@@ -23,7 +23,7 @@ import (
 	"path/filepath"
 )
 
-func localTerramateDir() (string, error) {
+func userTerramateDir() (string, error) {
 	appdata := os.Getenv(cliconfig.DirEnv)
 	if appdata == "" {
 		return "", errors.E("APPDATA not set")

--- a/cmd/terramate/cli/cliconfig/cliconfig.go
+++ b/cmd/terramate/cli/cliconfig/cliconfig.go
@@ -40,7 +40,7 @@ const (
 type Config struct {
 	DisableCheckpoint          bool
 	DisableCheckpointSignature bool
-	HomeTerramateDir           string
+	UserTerramateDir           string
 }
 
 // Load loads (parses and evaluates) all CLI configuration files.
@@ -87,11 +87,11 @@ func LoadFrom(fname string) (Config, error) {
 				return Config{}, err
 			}
 			cfg.DisableCheckpointSignature = val.True()
-		case "homeTerramateDir":
+		case "user_terramate_dir":
 			if err := checkStrType(val, name); err != nil {
 				return Config{}, err
 			}
-			cfg.HomeTerramateDir = val.AsString()
+			cfg.UserTerramateDir = val.AsString()
 		default:
 			return cfg, errors.E(ErrUnrecognizedAttribute, name)
 		}

--- a/cmd/terramate/cli/cliconfig/cliconfig.go
+++ b/cmd/terramate/cli/cliconfig/cliconfig.go
@@ -40,6 +40,7 @@ const (
 type Config struct {
 	DisableCheckpoint          bool
 	DisableCheckpointSignature bool
+	HomeTerramateDir           string
 }
 
 // Load loads (parses and evaluates) all CLI configuration files.
@@ -86,6 +87,11 @@ func LoadFrom(fname string) (Config, error) {
 				return Config{}, err
 			}
 			cfg.DisableCheckpointSignature = val.True()
+		case "homeTerramateDir":
+			if err := checkStrType(val, name); err != nil {
+				return Config{}, err
+			}
+			cfg.HomeTerramateDir = val.AsString()
 		default:
 			return cfg, errors.E(ErrUnrecognizedAttribute, name)
 		}
@@ -99,6 +105,17 @@ func checkBoolType(val cty.Value, name string) error {
 		return errors.E(
 			ErrInvalidAttributeType,
 			`%q attribute expects a boolean value but a value of type %s was given (value %s)`,
+			name, val.Type().FriendlyName(), hclwrite.TokensForValue(val),
+		)
+	}
+	return nil
+}
+
+func checkStrType(val cty.Value, name string) error {
+	if !val.Type().Equals(cty.String) {
+		return errors.E(
+			ErrInvalidAttributeType,
+			`%q attribute expects an string value but a value of type %s was given (value %s)`,
 			name, val.Type().FriendlyName(), hclwrite.TokensForValue(val),
 		)
 	}

--- a/cmd/terramate/cli/cliconfig/cliconfig_test.go
+++ b/cmd/terramate/cli/cliconfig/cliconfig_test.go
@@ -126,6 +126,29 @@ func TestLoad(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "set homeTerramateDir to an invalid value",
+			cfg:  `homeTerramateDir = true`,
+			want: want{
+				err: errors.E(cliconfig.ErrInvalidAttributeType),
+			},
+		},
+		{
+			name: "set homeTerramateDir from funcall -- not supported",
+			cfg:  `homeTerramateDir = tm_upper("/")`,
+			want: want{
+				err: errors.E(eval.ErrEval),
+			},
+		},
+		{
+			name: "set homeTerramateDir -- any string works",
+			cfg:  `homeTerramateDir = "/tmp"`,
+			want: want{
+				cfg: cliconfig.Config{
+					HomeTerramateDir: "/tmp",
+				},
+			},
+		},
 	} {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {

--- a/cmd/terramate/cli/cliconfig/cliconfig_test.go
+++ b/cmd/terramate/cli/cliconfig/cliconfig_test.go
@@ -145,7 +145,7 @@ func TestLoad(t *testing.T) {
 			cfg:  `homeTerramateDir = "/tmp"`,
 			want: want{
 				cfg: cliconfig.Config{
-					HomeTerramateDir: "/tmp",
+					UserTerramateDir: "/tmp",
 				},
 			},
 		},

--- a/cmd/terramate/cli/cliconfig/cliconfig_test.go
+++ b/cmd/terramate/cli/cliconfig/cliconfig_test.go
@@ -127,22 +127,22 @@ func TestLoad(t *testing.T) {
 			},
 		},
 		{
-			name: "set homeTerramateDir to an invalid value",
-			cfg:  `homeTerramateDir = true`,
+			name: "set user_terramate_dir to an invalid value",
+			cfg:  `user_terramate_dir = true`,
 			want: want{
 				err: errors.E(cliconfig.ErrInvalidAttributeType),
 			},
 		},
 		{
-			name: "set homeTerramateDir from funcall -- not supported",
-			cfg:  `homeTerramateDir = tm_upper("/")`,
+			name: "set user_terramate_dir from funcall -- not supported",
+			cfg:  `user_terramate_dir = tm_upper("/")`,
 			want: want{
 				err: errors.E(eval.ErrEval),
 			},
 		},
 		{
-			name: "set homeTerramateDir -- any string works",
-			cfg:  `homeTerramateDir = "/tmp"`,
+			name: "set user_terramate_dir -- any string works",
+			cfg:  `user_terramate_dir = "/tmp"`,
 			want: want{
 				cfg: cliconfig.Config{
 					UserTerramateDir: "/tmp",

--- a/cmd/terramate/cli/login.go
+++ b/cmd/terramate/cli/login.go
@@ -1,0 +1,302 @@
+// Copyright 2023 Mineiros GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"html"
+	"io"
+	"net/http"
+	"sync"
+
+	"github.com/mineiros-io/terramate/cmd/terramate/cli/out"
+	"github.com/mineiros-io/terramate/errors"
+	"github.com/rs/zerolog/log"
+)
+
+const (
+	APIKey = "AIzaSyDeCYIgqEhufsnBGtlNu4fv1alvpcs1Nos"
+
+	serverAddr = "localhost:8080"
+	serverURL  = "http://" + serverAddr + "/auth"
+)
+
+type (
+	createAuthURIResponse struct {
+		Kind       string `json:"kind"`
+		AuthURI    string `json:"authUri"`
+		ProviderID string `json:"providerId"`
+		SessionID  string `json:"sessionId"`
+	}
+
+	credentialInfo struct {
+		ProviderID       string `json:"providerId"`
+		Email            string `json:"email"`
+		DisplayName      string `json:"displayName"`
+		LocalID          string `json:"localId"`
+		IDToken          string `json:"idToken"`
+		Context          string `json:"context"`
+		OauthAccessToken string `json:"oauthAccessToken"`
+		OauthExpireIn    int    `json:"oauthExpireIn"`
+		RefreshToken     string `json:"refreshToken"`
+		ExpiresIn        string `json:"expiresIn"`
+		OauthIDToken     string `json:"oauthIdToken"`
+		RawUserInfo      string `json:"rawUserInfo"`
+	}
+)
+
+func login(output out.O) error {
+	consentData, err := createAuthURI()
+	if err != nil {
+		return err
+	}
+
+	output.MsgStdOut("Please visit the url: %s", consentData.AuthURI)
+
+	h := newHandler(consentData)
+
+	mux := http.NewServeMux()
+	mux.Handle("/auth", h)
+
+	s := http.Server{
+		Addr:    serverAddr,
+		Handler: mux,
+	}
+
+	go func() {
+		err := s.ListenAndServe()
+		if err != nil {
+			h.errChan <- err
+			return
+		}
+	}()
+
+	select {
+	case cred := <-h.credentialChan:
+		output.MsgStdOut("Logged in as: ; %s", cred.DisplayName)
+		return nil
+	case err := <-h.errChan:
+		return err
+	}
+}
+
+func createAuthURI() (createAuthURIResponse, error) {
+	const endpoint = "https://www.googleapis.com/identitytoolkit/v3/relyingparty/createAuthUri"
+
+	type payload struct {
+		ProviderID      string                 `json:"providerId"`
+		ContinueURI     string                 `json:"continueUri"`
+		CustomParameter map[string]interface{} `json:"customParameter"`
+		OauthScope      string                 `json:"oauthScope"`
+	}
+
+	payloadData := payload{
+		ProviderID:      "google.com",
+		ContinueURI:     serverURL,
+		CustomParameter: map[string]interface{}{},
+		OauthScope:      `{"google.com": "profile"}`,
+	}
+
+	postBody, err := json.Marshal(&payloadData)
+	if err != nil {
+		return createAuthURIResponse{}, errors.E(err)
+	}
+	req, err := http.NewRequest("POST", endpoint+"?key="+APIKey, bytes.NewBuffer(postBody))
+	if err != nil {
+		return createAuthURIResponse{}, errors.E(err, "failed to create authentication url")
+	}
+
+	req.Header.Add("content-type", "application/json")
+
+	logger := log.With().
+		Str("action", "createAuthURI()").
+		Logger()
+
+	logger.Debug().
+		Str("url", req.URL.String()).
+		Msg("sending request")
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return createAuthURIResponse{}, errors.E(err, "failed to start authentication process")
+	}
+
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return createAuthURIResponse{}, errors.E(err)
+	}
+
+	logger.Trace().
+		Str("response-body", string(data)).
+		Int("response-status-code", resp.StatusCode).
+		Msg("response")
+
+	if resp.StatusCode != 200 {
+		return createAuthURIResponse{}, errors.E("%s request returned %d", req.URL, resp.StatusCode)
+	}
+
+	var respURL createAuthURIResponse
+	err = json.Unmarshal(data, &respURL)
+	if err != nil {
+		return createAuthURIResponse{}, errors.E(err, "failed to unmarshal response")
+	}
+
+	return respURL, nil
+}
+
+type tokenHandler struct {
+	sync.Mutex
+
+	complete       bool
+	consentData    createAuthURIResponse
+	errChan        chan error
+	credentialChan chan credentialInfo
+}
+
+func newHandler(consent createAuthURIResponse) *tokenHandler {
+	return &tokenHandler{
+		consentData:    consent,
+		credentialChan: make(chan credentialInfo),
+		errChan:        make(chan error),
+	}
+}
+
+func (h *tokenHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	h.Lock()
+	defer func() {
+		h.complete = true
+		h.Unlock()
+	}()
+
+	// handles only 1 request
+
+	if h.complete {
+		return
+	}
+
+	gotURL := "http://" + serverAddr + r.URL.String()
+
+	const signInEndpoint = "https://identitytoolkit.googleapis.com/v1/accounts:signInWithIdp"
+
+	type payload struct {
+		RequestURI          string `json:"requestUri"`
+		SessionId           string `json:"sessionId"`
+		ReturnSecureToken   bool   `json:"returnSecureToken"`
+		ReturnIdpCredential bool   `json:"returnIdpCredential"`
+	}
+
+	postBody := payload{
+		RequestURI:          gotURL,
+		SessionId:           h.consentData.SessionID,
+		ReturnSecureToken:   true,
+		ReturnIdpCredential: true,
+	}
+
+	data, err := json.Marshal(&postBody)
+	if err != nil {
+		h.handleErr(w, errors.E(err))
+		return
+	}
+
+	logger := log.With().
+		Str("action", "tokenHandler.ServeHTTP").
+		Logger()
+
+	logger.Trace().
+		Str("endpoint", signInEndpoint).
+		Str("post-body", string(data)).
+		Msg("prepared request body")
+
+	req, err := http.NewRequest("POST", signInEndpoint+"?key="+APIKey, bytes.NewBuffer(data))
+	if err != nil {
+		h.handleErr(w, errors.E(err, "failed to create authentication url"))
+		return
+	}
+
+	req.Header.Add("content-type", "application/json")
+
+	logger.Debug().
+		Str("url", req.URL.String()).
+		Msg("sending request")
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		h.handleErr(w, errors.E(err, "failed to start authentication process"))
+		return
+	}
+
+	data, err = io.ReadAll(resp.Body)
+	if err != nil {
+		h.errChan <- errors.E(err)
+		return
+	}
+
+	logger.Trace().
+		Str("response-body", string(data)).
+		Int("response-status-code", resp.StatusCode).
+		Msg("response")
+
+	if resp.StatusCode != 200 {
+		h.handleErr(w, errors.E("%s request returned %d", req.URL, resp.StatusCode))
+		return
+	}
+
+	var creds credentialInfo
+	err = json.Unmarshal(data, &creds)
+	if err != nil {
+		h.handleErr(w, errors.E(err))
+		return
+	}
+
+	h.handleOK(w, creds)
+}
+
+func (h *tokenHandler) handleOK(w http.ResponseWriter, cred credentialInfo) {
+	const messageFormat = `
+	<html>
+		<head>
+			<title>Terramate Cloud Login Succeed</title>
+		</head>
+		<body>
+			<h2>Successfully authenticated as %s</h2>
+			<p>You can close this page now.</p>
+		</body>
+	</html>
+	`
+	w.WriteHeader(http.StatusInternalServerError)
+	w.Write([]byte(fmt.Sprintf(messageFormat, html.EscapeString(cred.DisplayName))))
+	h.credentialChan <- cred
+}
+
+func (h *tokenHandler) handleErr(w http.ResponseWriter, err error) {
+	const errMessage = `
+	<html>
+		<head>
+			<title>Terramate Cloud Login Failed</title>
+		</head>
+		<body>
+			<h2>Terramate Cloud Login Failed</h2>
+			<p>Please, go back to Terminal and try again</p>
+		</body>
+	</html>
+	`
+	w.WriteHeader(http.StatusInternalServerError)
+	w.Write([]byte(errMessage))
+	h.errChan <- err
+}

--- a/cmd/terramate/cli/login.go
+++ b/cmd/terramate/cli/login.go
@@ -29,7 +29,7 @@ import (
 )
 
 const (
-	APIKey = "AIzaSyDeCYIgqEhufsnBGtlNu4fv1alvpcs1Nos"
+	apiKey = "AIzaSyDeCYIgqEhufsnBGtlNu4fv1alvpcs1Nos"
 
 	serverAddr = "localhost:8080"
 	serverURL  = "http://" + serverAddr + "/auth"
@@ -115,7 +115,7 @@ func createAuthURI() (createAuthURIResponse, error) {
 	if err != nil {
 		return createAuthURIResponse{}, errors.E(err)
 	}
-	req, err := http.NewRequest("POST", endpoint+"?key="+APIKey, bytes.NewBuffer(postBody))
+	req, err := http.NewRequest("POST", endpoint+"?key="+apiKey, bytes.NewBuffer(postBody))
 	if err != nil {
 		return createAuthURIResponse{}, errors.E(err, "failed to create authentication url")
 	}
@@ -195,14 +195,14 @@ func (h *tokenHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	type payload struct {
 		RequestURI          string `json:"requestUri"`
-		SessionId           string `json:"sessionId"`
+		SessionID           string `json:"sessionId"`
 		ReturnSecureToken   bool   `json:"returnSecureToken"`
 		ReturnIdpCredential bool   `json:"returnIdpCredential"`
 	}
 
 	postBody := payload{
 		RequestURI:          gotURL,
-		SessionId:           h.consentData.SessionID,
+		SessionID:           h.consentData.SessionID,
 		ReturnSecureToken:   true,
 		ReturnIdpCredential: true,
 	}
@@ -222,7 +222,7 @@ func (h *tokenHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		Str("post-body", string(data)).
 		Msg("prepared request body")
 
-	req, err := http.NewRequest("POST", signInEndpoint+"?key="+APIKey, bytes.NewBuffer(data))
+	req, err := http.NewRequest("POST", signInEndpoint+"?key="+apiKey, bytes.NewBuffer(data))
 	if err != nil {
 		h.handleErr(w, errors.E(err, "failed to create authentication url"))
 		return
@@ -280,7 +280,7 @@ func (h *tokenHandler) handleOK(w http.ResponseWriter, cred credentialInfo) {
 	</html>
 	`
 	w.WriteHeader(http.StatusInternalServerError)
-	w.Write([]byte(fmt.Sprintf(messageFormat, html.EscapeString(cred.DisplayName))))
+	_, _ = w.Write([]byte(fmt.Sprintf(messageFormat, html.EscapeString(cred.DisplayName))))
 	h.credentialChan <- cred
 }
 
@@ -297,6 +297,6 @@ func (h *tokenHandler) handleErr(w http.ResponseWriter, err error) {
 	</html>
 	`
 	w.WriteHeader(http.StatusInternalServerError)
-	w.Write([]byte(errMessage))
+	_, _ = w.Write([]byte(errMessage))
 	h.errChan <- err
 }

--- a/cmd/terramate/cli/login.go
+++ b/cmd/terramate/cli/login.go
@@ -377,7 +377,7 @@ func (h *tokenHandler) handleErr(w http.ResponseWriter, err error) {
 
 func cacheToken(output out.O, cred credentialInfo, clicfg cliconfig.Config) error {
 	cachedAt := time.Now()
-	cacheFile := filepath.Join(clicfg.HomeTerramateDir, credfile)
+	cacheFile := filepath.Join(clicfg.UserTerramateDir, credfile)
 
 	expiresIn, err := strconv.Atoi(cred.ExpiresIn)
 	if err != nil {

--- a/cmd/terramate/e2etests/run_test.go
+++ b/cmd/terramate/e2etests/run_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 
 	"github.com/mineiros-io/terramate/cmd/terramate/cli"
+	"github.com/mineiros-io/terramate/cmd/terramate/cli/cliconfig"
 	"github.com/mineiros-io/terramate/config/tag"
 	"github.com/mineiros-io/terramate/run/dag"
 	"github.com/mineiros-io/terramate/test"
@@ -2343,7 +2344,7 @@ func listStacks(stacks ...string) string {
 func testEnviron(t *testing.T) []string {
 	tempHomeDir := t.TempDir()
 	env := []string{
-		"HOME=" + tempHomeDir,
+		fmt.Sprintf("%s="+tempHomeDir, cliconfig.DirEnv),
 		"PATH=" + os.Getenv("PATH"),
 	}
 	if runtime.GOOS == "windows" {

--- a/cmd/terramate/e2etests/run_test.go
+++ b/cmd/terramate/e2etests/run_test.go
@@ -1753,7 +1753,7 @@ func TestRunFailIfGitSafeguardUntracked(t *testing.T) {
 		cli := newCLI(t, s.RootDir())
 		cli.env = append([]string{
 			"TM_DISABLE_CHECK_GIT_UNTRACKED=true",
-		}, testEnviron()...)
+		}, testEnviron(t)...)
 		assertRun(t, cli.run(
 			"run",
 			"--changed",
@@ -1924,7 +1924,7 @@ func TestRunFailIfGeneratedCodeIsOutdated(t *testing.T) {
 		tmcli := newCLI(t, s.RootDir())
 		tmcli.env = append([]string{
 			"TM_DISABLE_CHECK_GEN_CODE=true",
-		}, testEnviron()...)
+		}, testEnviron(t)...)
 
 		assertRunResult(t, tmcli.run("run", "--changed", testHelperBin, "cat", generateFile), runExpected{
 			Stdout: generateFileBody,
@@ -2052,7 +2052,7 @@ func TestRunFailIfGitSafeguardUncommitted(t *testing.T) {
 		cli := newCLI(t, s.RootDir())
 		cli.env = append([]string{
 			"TM_DISABLE_CHECK_GIT_UNCOMMITTED=true",
-		}, testEnviron()...)
+		}, testEnviron(t)...)
 
 		assertRunResult(t, cli.run("run", cat, mainTfFileName), runExpected{
 			Stdout: mainTfAlteredContents,
@@ -2290,7 +2290,7 @@ func TestRunWitCustomizedEnv(t *testing.T) {
 	git.Add(".")
 	git.CommitAll("first commit")
 
-	hostenv := testEnviron()
+	hostenv := testEnviron(t)
 	clienv := append(hostenv,
 		"TERRAMATE_OVERRIDDEN=oldValue",
 		fmt.Sprintf("TERRAMATE_TEST=%s", exportedTerramateTest),
@@ -2340,8 +2340,10 @@ func listStacks(stacks ...string) string {
 	return strings.Join(stacks, "\n") + "\n"
 }
 
-func testEnviron() []string {
+func testEnviron(t *testing.T) []string {
+	tempHomeDir := t.TempDir()
 	env := []string{
+		"HOME=" + tempHomeDir,
 		"PATH=" + os.Getenv("PATH"),
 	}
 	if runtime.GOOS == "windows" {

--- a/cmd/terramate/e2etests/safeguard_test.go
+++ b/cmd/terramate/e2etests/safeguard_test.go
@@ -169,7 +169,7 @@ func TestSafeguardCheckRemoteDisabled(t *testing.T) {
 		tmcli, file, _ := setup(t)
 		tmcli.env = append([]string{
 			"TM_DISABLE_CHECK_GIT_REMOTE=true",
-		}, testEnviron()...)
+		}, testEnviron(t)...)
 
 		assertRunResult(t, tmcli.run("run", cat, file.HostPath()), runExpected{
 			Stdout: fileContents,

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/hectane/go-acl v0.0.0-20190604041725-da78bae5fc95
 	github.com/i4ki/go-checkpoint v0.0.0-20230323112005-d8ee97cebfa8
 	github.com/madlambda/spells v0.4.2
+	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8
 	github.com/posener/complete v1.2.3
 	github.com/willabides/kongplete v0.2.0
 	github.com/zclconf/go-cty v1.8.3

--- a/go.sum
+++ b/go.sum
@@ -425,6 +425,8 @@ github.com/onsi/gomega v1.5.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1Cpa
 github.com/packer-community/winrmcp v0.0.0-20180921211025-c76d91c1e7db/go.mod h1:f6Izs6JvFTdnRbziASagjZ2vmf55NSIkC/weStxCHqk=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pkg/browser v0.0.0-20201207095918-0426ae3fba23/go.mod h1:N6UoU20jOqggOuDwUaBQpluzLNDqif3kq9z2wpdYEfQ=
+github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8 h1:KoWmjvw+nsYOo29YJK9vDA65RGE3NrOnUtO7a+RF9HU=
+github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8/go.mod h1:HKlIX3XHQyzLZPlr7++PzdhaXEj94dEiJgZDTsxEqUI=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
@@ -666,6 +668,7 @@ golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210320140829-1e4c9ba3b0c4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210324051608-47abb6519492/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210502180810-71e4cd670f79/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210616045830-e2b7044e8c71/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.5.0 h1:MUK/U/4lj1t1oPg0HfuXDN/Z1wv31ZJ/YcPiGccS4DU=


### PR DESCRIPTION
Implements the `terramate experimental cloud login`.
Adding `-v` provides detailed output.

- Add `user_terramate_dir` option to `.terramaterc` file (CLI config file)
- Login with Google Provider.
- Open the browser with the OAuth2 consent page.
- RedirectURI to 127.0.0.1:<randon port in range 40000-52023>
- Store token, refresh token and expiration in `$homeTerramateDir/credentials.tmrc.json`

Now it's also possible to customize where the checkpoint cache and signature are stored by setting the `homeTerramateDir`.