### PR TITLE
Change blog url to blog.terramate.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,9 +84,9 @@ The fastest way to get started with Terramate is our [getting started guide](htt
 - [Playground](https://play.terramate.io/)
 - [Getting started guide](https://terramate.io/docs/cli/getting-started/)
 - [About Stacks](https://terramate.io/docs/cli/about-stacks)
-- [Terramate Blog](https://blog.mineiros.io/)
-- [Why we invented Terramate](https://blog.mineiros.io/introducing-terramate-an-orchestrator-and-code-generator-for-terraform-5e538c9ee055?source=friends_link&sk=5272c487ef709c80a34d0b451590f263)
-- [How Terramate compares with Terragrunt](https://blog.mineiros.io/terramate-and-terragrunt-f27f2ec4032f?source=friends_link&sk=8834b3de00d4af4744aac63051ff3b53)
+- [Terramate Blog](https://blog.terramate.io/)
+- [Why we invented Terramate](https://blog.terramate.io/introducing-terramate-an-orchestrator-and-code-generator-for-terraform-5e538c9ee055?source=friends_link&sk=5272c487ef709c80a34d0b451590f263)
+- [How Terramate compares with Terragrunt](https://blog.terramate.io/terramate-and-terragrunt-f27f2ec4032f?source=friends_link&sk=8834b3de00d4af4744aac63051ff3b53)
 - [Terramate VSCode Extension](https://github.com/mineiros-io/vscode-terramate)
 - [Terramate Language Server](https://github.com/mineiros-io/terramate-ls)
 

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -122,7 +122,7 @@ export default defineConfig({
     // https://vitepress.dev/reference/default-theme-config
     nav: [
       { text: 'Docs', link: '/about-stacks' },
-      { text: 'Blog', link: 'https://blog.mineiros.io/' },
+      { text: 'Blog', link: 'https://blog.terramate.io/' },
       { text: 'We are hiring!', link: 'https://jobs.ashbyhq.com/mineiros.io/' },
       {
         text: 'Releases',
@@ -234,23 +234,23 @@ export default defineConfig({
         items: [
           {
             text: 'Introducing Terramate — An Orchestrator and Code Generator for Terraform',
-            link: 'https://blog.mineiros.io/introducing-terramate-an-orchestrator-and-code-generator-for-terraform-5e538c9ee055',
+            link: 'https://blog.terramate.io/introducing-terramate-an-orchestrator-and-code-generator-for-terraform-5e538c9ee055',
           },
           {
             text: 'Understanding the basics of Terramate',
-            link: 'https://blog.mineiros.io/understanding-the-basics-of-terramate-e0d8778f5c53',
+            link: 'https://blog.terramate.io/understanding-the-basics-of-terramate-e0d8778f5c53',
           },
           {
             text: 'Terramate and Terragrunt',
-            link: 'https://blog.mineiros.io/terramate-and-terragrunt-f27f2ec4032f',
+            link: 'https://blog.terramate.io/terramate-and-terragrunt-f27f2ec4032f',
           },
           {
             text: 'How to keep your Terraform code DRY by using Terramate',
-            link: 'https://blog.mineiros.io/how-to-keep-your-terraform-code-dry-by-using-terramate-be5807fef8f6',
+            link: 'https://blog.terramate.io/how-to-keep-your-terraform-code-dry-by-using-terramate-be5807fef8f6',
           },
           {
             text: 'Introducing the Terramate VSCode Extension and Language Server',
-            link: 'https://blog.mineiros.io/introducing-the-terramate-vscode-extension-and-language-server-d77bd392011c',
+            link: 'https://blog.terramate.io/introducing-the-terramate-vscode-extension-and-language-server-d77bd392011c',
           },
         ],
       },

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -13,7 +13,7 @@ next:
 
 # Getting Started
 
-[Terramate](https://github.com/mineiros-io/terramate) is a [code generator and orchestrator for Terraform](https://blog.mineiros.io/product-introduction-github-as-code-af466550a4a9?source=friends_link&sk=ae60be77dcb484724b3b821898e7813d) that adds powerful capabilities such as code generation, stacks, orchestration, change detection, data sharing and more to Terraform.
+[Terramate](https://github.com/mineiros-io/terramate) is a [code generator and orchestrator for Terraform](https://blog.terramate.io/product-introduction-github-as-code-af466550a4a9?source=friends_link&sk=ae60be77dcb484724b3b821898e7813d) that adds powerful capabilities such as code generation, stacks, orchestration, change detection, data sharing and more to Terraform.
 
 This tutorial will demonstrate the basic concepts behind [Terramate](https://github.com/mineiros-io/terramate) and give you some ideas for how a filesystem-oriented code generator can help you to manage your Terraform code at scale more efficiently .
 So that anyone can try Terramate without needing a cloud account, we will use only the `local_file` resource to create a static site demonstrating the basic principles behind Terramate. The only prerequisites are local installations of Terramate, Terraform and Git.


### PR DESCRIPTION
# Reason for This Change

We moved the blog to blog.terramate.io